### PR TITLE
fix: wrap multichain requests in multichain substream

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Fix requests not being sent to the mobile wallet with proper wrapping metadata ([#28](https://github.com/MetaMask/connect-monorepo/pull/28))
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Fix requests not being sent to the mobile wallet with proper wrapping metadata ([#28](https://github.com/MetaMask/connect-monorepo/pull/28))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/transports/constants.ts
+++ b/packages/connect-multichain/src/multichain/transports/constants.ts
@@ -1,0 +1,2 @@
+export const EIP_1193_PROVIDER_STREAM_NAME = 'metamask-provider';
+export const MULTICHAIN_PROVIDER_STREAM_NAME = 'metamask-multichain-provider';

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -317,7 +317,13 @@ export class MWPTransport implements ExtendedTransport {
             });
 
             dappClient
-              .connect({ mode: 'trusted', initialPayload: request })
+              .connect({
+                mode: 'trusted',
+                initialPayload: {
+                  name: 'metamask-multichain-provider',
+                  data: request
+                }
+              })
               .catch(rejectConnection);
           },
         );

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -40,6 +40,7 @@ import {
   getValidAccounts,
   isSameScopesAndAccounts,
 } from '../../utils';
+import { MULTICHAIN_PROVIDER_STREAM_NAME } from '../constants';
 
 const DEFAULT_REQUEST_TIMEOUT = 60 * 1000;
 const CONNECTION_GRACE_PERIOD = 60 * 1000;
@@ -320,7 +321,7 @@ export class MWPTransport implements ExtendedTransport {
               .connect({
                 mode: 'trusted',
                 initialPayload: {
-                  name: 'metamask-multichain-provider',
+                  name: MULTICHAIN_PROVIDER_STREAM_NAME,
                   data: request
                 }
               })
@@ -434,7 +435,7 @@ export class MWPTransport implements ExtendedTransport {
       });
 
       this.dappClient.sendRequest({
-        name: 'metamask-multichain-provider',
+        name: MULTICHAIN_PROVIDER_STREAM_NAME,
         data: request
       }).catch(reject);
     });

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -427,7 +427,10 @@ export class MWPTransport implements ExtendedTransport {
         timeout,
       });
 
-      this.dappClient.sendRequest(request).catch(reject);
+      this.dappClient.sendRequest({
+        name: 'metamask-multichain-provider',
+        data: request
+      }).catch(reject);
     });
   }
 

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -20,6 +20,7 @@ import { Store } from './store';
 import type { TestSuiteOptions, MockedData } from '../tests/types';
 import { mockSessionData, mockSessionRequestData } from '../tests/data';
 import { SessionStore } from '@metamask/mobile-wallet-protocol-core';
+import { MULTICHAIN_PROVIDER_STREAM_NAME } from './multichain/transports/constants';
 
 function testSuite<T extends MultichainOptions>({
   platform,
@@ -161,7 +162,7 @@ function testSuite<T extends MultichainOptions>({
           mockedData.mockDappClient.sendRequest,
         ).not.toHaveBeenCalledWith(
           t.expect.objectContaining({
-            name: 'metamask-multichain-provider',
+            name: MULTICHAIN_PROVIDER_STREAM_NAME,
             data: t.expect.objectContaining({
               method: 'wallet_getSession',
             }),
@@ -169,7 +170,7 @@ function testSuite<T extends MultichainOptions>({
         );
         t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(
           t.expect.objectContaining({
-            name: 'metamask-multichain-provider',
+            name: MULTICHAIN_PROVIDER_STREAM_NAME,
             data: t.expect.objectContaining({
               method: 'wallet_createSession',
               params: {
@@ -238,7 +239,7 @@ function testSuite<T extends MultichainOptions>({
         } else {
           t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(
             t.expect.objectContaining({
-              name: 'metamask-multichain-provider',
+              name: MULTICHAIN_PROVIDER_STREAM_NAME,
               data: t.expect.objectContaining({
                 method: 'wallet_createSession',
                 params: {

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -161,15 +161,21 @@ function testSuite<T extends MultichainOptions>({
           mockedData.mockDappClient.sendRequest,
         ).not.toHaveBeenCalledWith(
           t.expect.objectContaining({
-            method: 'wallet_getSession',
+            name: 'metamask-multichain-provider',
+            data: t.expect.objectContaining({
+              method: 'wallet_getSession',
+            }),
           }),
         );
         t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(
           t.expect.objectContaining({
-            method: 'wallet_createSession',
-            params: {
-              optionalScopes: mockedSessionUpgradeData.sessionScopes,
-            },
+            name: 'metamask-multichain-provider',
+            data: t.expect.objectContaining({
+              method: 'wallet_createSession',
+              params: {
+                optionalScopes: mockedSessionUpgradeData.sessionScopes,
+              },
+            }),
           }),
         );
       }
@@ -232,10 +238,13 @@ function testSuite<T extends MultichainOptions>({
         } else {
           t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(
             t.expect.objectContaining({
-              method: 'wallet_createSession',
-              params: {
-                optionalScopes: {},
-              },
+              name: 'metamask-multichain-provider',
+              data: t.expect.objectContaining({
+                method: 'wallet_createSession',
+                params: {
+                  optionalScopes: {},
+                },
+              }),
             }),
           );
         }

--- a/packages/connect-multichain/tests/fixtures.test.ts
+++ b/packages/connect-multichain/tests/fixtures.test.ts
@@ -289,10 +289,13 @@ export const createTest: CreateTestFN = ({
           mockDappClient.emit('connected');
           mockDappClient.state = 'CONNECTED' as any;
           await mockDappClient.sendRequest({
-            id: `${this.__reqId++}`,
-            jsonrpc: '2.0',
-            method: 'wallet_getSession',
-            params: [],
+            name: 'metamask-multichain-provider',
+            data: {
+              id: `${this.__reqId++}`,
+              jsonrpc: '2.0',
+              method: 'wallet_getSession',
+              params: [],
+            },
           });
           return Promise.resolve();
         }),
@@ -314,8 +317,13 @@ export const createTest: CreateTestFN = ({
           mockDappClient.state = 'DISCONNECTED' as any;
           return Promise.resolve();
         }),
-        sendRequest: t.vi.fn(async (request: any) => {
+        sendRequest: t.vi.fn(async (message: any) => {
           try {
+            // Handle new nested structure: { name: 'metamask-multichain-provider', data: request }
+            const { name, data: request } = message;
+            if (name !== 'metamask-multichain-provider') {
+              return Promise.reject('only metamask-multichain-provider is supported in the mock');
+            }
             const id = `${request.id ?? requestId++}`;
             if (request.method === 'wallet_getSession') {
               return new Promise<void>((resolve, reject) => {

--- a/packages/connect-multichain/tests/fixtures.test.ts
+++ b/packages/connect-multichain/tests/fixtures.test.ts
@@ -37,6 +37,7 @@ import {
   TransportResponse,
 } from '@metamask/multichain-api-client';
 import { DappClient } from '@metamask/mobile-wallet-protocol-dapp-client';
+import { MULTICHAIN_PROVIDER_STREAM_NAME } from '../src/multichain/transports/constants';
 
 import {
   setupNodeMocks,
@@ -289,7 +290,7 @@ export const createTest: CreateTestFN = ({
           mockDappClient.emit('connected');
           mockDappClient.state = 'CONNECTED' as any;
           await mockDappClient.sendRequest({
-            name: 'metamask-multichain-provider',
+            name: MULTICHAIN_PROVIDER_STREAM_NAME,
             data: {
               id: `${this.__reqId++}`,
               jsonrpc: '2.0',
@@ -319,10 +320,10 @@ export const createTest: CreateTestFN = ({
         }),
         sendRequest: t.vi.fn(async (message: any) => {
           try {
-            // Handle new nested structure: { name: 'metamask-multichain-provider', data: request }
+            // Handle new nested structure: { name: MULTICHAIN_PROVIDER_STREAM_NAME, data: request }
             const { name, data: request } = message;
-            if (name !== 'metamask-multichain-provider') {
-              return Promise.reject('only metamask-multichain-provider is supported in the mock');
+            if (name !== MULTICHAIN_PROVIDER_STREAM_NAME) {
+              return Promise.reject('only MULTICHAIN_PROVIDER_STREAM_NAME is supported in the mock');
             }
             const id = `${request.id ?? requestId++}`;
             if (request.method === 'wallet_getSession') {


### PR DESCRIPTION
## Explanation

Wraps the multichain requests sent over the MWP in a substream in order to better support targeting EIP-1193 and Multichain APIs on the wallet side

## References

See: https://github.com/MetaMask/metamask-mobile/pull/22027

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
