### PR TITLE
fix: lowercase `metamask_accountsChanged` address casing to match `eth_accounts`

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix connections made from within the MetaMask Mobile In-App Browser ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
 - Bump `@metamask/multichain-api-client` to prevent JSON RPC request ID conflicts across disconnect/reconnect cycles ([#38](https://github.com/MetaMask/connect-monorepo/pull/38))
+- Lowercase cached account address values from `metamask_accountsChanged` to align with `eth_accounts` ([#40](https://github.com/MetaMask/connect-monorepo/pull/40))
 
 ## [0.1.0]
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -190,10 +190,14 @@ export class MWPTransport implements ExtendedTransport {
             (message.data as { method: string }).method ===
             'metamask_accountsChanged'
           ) {
+            // Account addressed are being lowercased here to align with the eth_accounts returned casing
+            // and with how they are returned/emitted in the injected EIP-1193 provider.
+            const messageData = message.data as { params: string[] };
+            messageData.params = messageData.params.map(account => account.toLowerCase());
             this.kvstore.set(
               ACCOUNTS_STORE_KEY,
               JSON.stringify(
-                (message.data as { params: { accounts: string[] } }).params,
+                messageData.params,
               ),
             );
           }


### PR DESCRIPTION
## Explanation

BackgroundBridge returns checksummed addresses in the `metamask_accountsChanged` event but lowercase in the `eth_accounts` responses. This PR "fixes" that by lowercasing the incoming `metamask_accoutnsChanged` addresses. This also aligns with how addresses are presented to the dapp in the injected EIP-1193 provider

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-834

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
