### PR TITLE
fix: fix wallet_revokeSession on disconnect using default transport

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix connections made from within the MetaMask Mobile In-App Browser ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
 - Bump `@metamask/multichain-api-client` to prevent JSON RPC request ID conflicts across disconnect/reconnect cycles ([#38](https://github.com/MetaMask/connect-monorepo/pull/38))
+- Fix `wallet_revokeSession` not firing correctly when terminating a session using the default transport (In-App Browser / Extension) ([#41](https://github.com/MetaMask/connect-monorepo/pull/41))
 
 ## [0.1.0]
 

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -262,7 +262,7 @@ export class DefaultTransport implements ExtendedTransport {
   async disconnect(): Promise<void> {
     this.#notificationCallbacks.clear();
 
-    await this.request({ method: 'wallet_revokeSession' });
+    await this.request({ method: 'wallet_revokeSession', params: {} });
 
     // Remove the message listener when disconnecting
     if (this.#handleResponseListener) {


### PR DESCRIPTION
## Explanation

Fixes `wallet_revokeSession` not firing correctly when terminating the session using IAB/Extension


https://github.com/user-attachments/assets/dc918e0c-ce14-4b2b-8909-191304c6a84b



## References

See: https://consensyssoftware.atlassian.net/browse/WAPI-827

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
