### PR TITLE
fix: reconnect `dappClient` on resumed session

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix validation of `MWPTransport` connection state after resuming a session ([#43](https://github.com/MetaMask/connect-monorepo/pull/43))
 - Fix install modal not rendering when called from Vite application ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 - Fix requests not being sent to the mobile wallet with proper wrapping metadata ([#28](https://github.com/MetaMask/connect-monorepo/pull/28))
 - Fix connections made from within the MetaMask Mobile In-App Browser ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -448,7 +448,14 @@ export class MWPTransport implements ExtendedTransport {
     return (this.dappClient as any).state === 'CONNECTED';
   }
 
-  private async attemptResumeSession() {
+  /**
+   * Attempts to re-establish a connection via DappClient
+   *
+   * @returns Nothing
+   */
+  // TODO: We should re-evaluate adding this to the WebSocketTransport layer from `@metamask/mobile-wallet-protocol-core`
+  // ticket: https://consensyssoftware.atlassian.net/browse/WAPI-862
+  private async attemptResumeSession(): Promise<void> {
     try {
       await this.dappClient.reconnect();
       // Wait for connection to be established


### PR DESCRIPTION
## Explanation

Currently, when using `MWPTransport`, the connection state of `dappClient` isn't validated before sending requests when we resume a session.
The `MWPTransport.request()` method sends requests without checking if the `dappClient` is connected.
This PR proposes adding a connection validation and calling `this.dappClient.reconnect()` in `MWPTransport.request()` in case it's not connected.

## Screenshots/Recordings

### After

https://github.com/user-attachments/assets/af3e7344-f636-48e1-a83c-3f748b7404aa

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-859

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
