### PR TITLE
Revert "Release/2.0.0 (#49)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-connect-monorepo",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -7,22 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1]
-
-### Added
-
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
-
-### Changed
-
-- align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
-
 ## [0.1.0]
 
 ### Added
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.1.1...HEAD
-[0.1.1]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.1.0...@metamask/analytics@0.1.1
+[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/analytics@0.1.0

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/analytics",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Analytics package for MetaMask Connect",
   "keywords": [
     "MetaMask",

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,26 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
-
 ### Added
 
 - Add `removeListener`, `once` and `listenerCount` function to internal `EventEmitter` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
-- Add support for read only RPC calls ([#33](https://github.com/MetaMask/metamask-connect-monorepo/pull/33))
 
 ### Changed
 
-- Align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
 - Rename `preferDesktop` flag to `showInstallModal` ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 - `MetaMaskConnect.provider` will be defined if there is a previous session that can be restored. Previously `connect()` had to be called explicitly first. ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
-- **BREAKING** Rename `readonlyRpcMap` to `supportedNetworks` ([#37](https://github.com/MetaMask/metamask-connect-monorepo/pull/37))
-- **BREAKING** Remove api.infuraAPIKey SDK param. Export getInfuraRpcUrls. Add env to playgrounds ([#19](https://github.com/MetaMask/metamask-connect-monorepo/pull/19))
 
 ### Fixed
 
-- Fix switch to Bowser’s default export to fix Vite build ([#26](https://github.com/MetaMask/metamask-connect-monorepo/pull/26))
-- Fix reconnect `dappClient` on resumed session ([#43](https://github.com/MetaMask/metamask-connect-monorepo/pull/43))
 - Fix install modal not rendering when called from Vite application ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 - Fix requests not being sent to the mobile wallet with proper wrapping metadata ([#28](https://github.com/MetaMask/connect-monorepo/pull/28))
 - Fix connections made from within the MetaMask Mobile In-App Browser ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
@@ -39,6 +30,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.1.0...@metamask/connect-multichain@0.2.0
+[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/connect-multichain@0.1.0

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-multichain",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Multichain package for MetaMask Connect",
   "keywords": [
     "MetaMask",

--- a/packages/multichain-ui/CHANGELOG.md
+++ b/packages/multichain-ui/CHANGELOG.md
@@ -7,15 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
-
-### Added
-
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
-
 ### Changed
 
-- Align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
 - Rename `preferDesktop` flag to `showInstallModal` ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 
 ## [0.1.0]
@@ -24,6 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/multichain-ui@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/multichain-ui@0.1.0...@metamask/multichain-ui@0.2.0
+[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/multichain-ui@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/multichain-ui@0.1.0

--- a/packages/multichain-ui/package.json
+++ b/packages/multichain-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/multichain-ui",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "MetaMask Connect Install Modal for Web",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
This reverts commit 6a6f458cea3c102b523109b9eefc959fa08688dd pertaining to release/2.0.0.

This is needed because we aren't releasing `connect-evm` and having a version above `0.0.0` borks the release GH action.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
