### PR TITLE
feat: connectWith method and playground updates

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -141,21 +141,6 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           currentChainId = chain?.id ?? currentChainId;
         }
 
-        // Emit events for connectAndSign and connectWith
-        const provider = await this.getProvider();
-        if (signResponse)
-          provider.emit('connectAndSign', {
-            accounts: checksummedAccounts as Address[],
-            chainId: currentChainId,
-            signResponse,
-          });
-        else if (connectWithResponse)
-          provider.emit('connectWith', {
-            accounts: checksummedAccounts as Address[],
-            chainId: currentChainId,
-            connectWithResponse,
-          });
-
         return {
           accounts: (withCapabilities
             ? checksummedAccounts.map((account) => ({

--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -1,6 +1,7 @@
 import {
   type AddEthereumChainParameter,
   createMetamaskConnectEVM,
+  type EIP1193Provider,
   type MetamaskConnectEVM,
 } from '@metamask/connect-evm';
 
@@ -13,7 +14,7 @@ import {
 import type { OneOf } from '@wagmi/core/internal';
 
 import {
-  type EIP1193Provider,
+  type Address,
   getAddress,
   type ProviderConnectInfo,
   ResourceUnavailableRpcError,
@@ -80,30 +81,83 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       });
     },
 
-    async connect<withCapabilities extends boolean = false>(parameters?: {
+    async connect<withCapabilities extends boolean = false>(connectParams?: {
       chainId?: number | undefined;
       isReconnecting?: boolean | undefined;
       withCapabilities?: withCapabilities | boolean | undefined;
     }) {
-      const chainId = parameters?.chainId ?? DEFAULT_CHAIN_ID;
-      const withCapabilities = parameters?.withCapabilities;
+      const chainId = connectParams?.chainId ?? DEFAULT_CHAIN_ID;
+      const withCapabilities = connectParams?.withCapabilities;
 
-      // TODO: Add connectAndSign and connectWith support, including events
+      let accounts: readonly string[] = [];
+      if (connectParams?.isReconnecting) {
+        accounts = (await this.getAccounts().catch(() => [])).map((account) =>
+          getAddress(account),
+        );
+      }
 
       try {
-        const result = await metamask.connect({
-          chainId,
-          account: undefined,
-        });
+        let signResponse: string | undefined;
+        let connectWithResponse: unknown | undefined;
+
+        if (!accounts?.length) {
+          if (parameters.connectAndSign || parameters.connectWith) {
+            if (parameters.connectAndSign) {
+              signResponse = await (metamask as any).connectAndSign({
+                msg: parameters.connectAndSign,
+              });
+            } else if (parameters.connectWith) {
+              connectWithResponse = await (metamask as any).connectWith({
+                method: parameters.connectWith.method,
+                params: parameters.connectWith.params,
+              });
+            }
+
+            accounts = (await this.getAccounts()).map((account) =>
+              getAddress(account),
+            );
+          } else {
+            const result = await metamask.connect({
+              chainId,
+              account: undefined,
+            });
+            accounts = result.accounts.map((account) => getAddress(account));
+          }
+        }
+
+        // Switch to chain if provided
+        let currentChainId = (await this.getChainId()) as number;
+        if (chainId && currentChainId !== chainId) {
+          const chain = await this.switchChain!({ chainId }).catch((error) => {
+            if (error.code === UserRejectedRequestError.code) throw error;
+            return { id: currentChainId };
+          });
+          currentChainId = chain?.id ?? currentChainId;
+        }
+
+        // Emit events for connectAndSign and connectWith
+        const provider = await this.getProvider();
+        if (signResponse)
+          provider.emit('connectAndSign', {
+            accounts: accounts as Address[],
+            chainId: currentChainId,
+            signResponse,
+          });
+        else if (connectWithResponse)
+          provider.emit('connectWith', {
+            accounts: accounts as Address[],
+            chainId: currentChainId,
+            connectWithResponse,
+          });
 
         return {
           accounts: (withCapabilities
-            ? result.accounts.map((account) => ({
+            ? accounts.map((account) => ({
                 address: account,
                 capabilities: {},
               }))
-            : result.accounts) as never,
-          chainId: result.chainId ?? chainId,
+            : accounts) as never,
+          chainId: currentChainId,
         };
       } catch (err) {
         const error = err as RpcError;
@@ -199,15 +253,6 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
     },
 
     async onAccountsChanged(accounts) {
-      // TODO: verify if this is needed or if we can just rely on the
-      // existing disconnect event instead
-      // Disconnect if there are no accounts
-      if (accounts.length === 0) {
-        this.onDisconnect();
-        return;
-      }
-      // Regular change event
-
       config.emitter.emit('change', {
         accounts: accounts.map((account) => getAddress(account)),
       });
@@ -231,7 +276,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
       // https://github.com/MetaMask/providers/pull/120
       if (error && (error as unknown as RpcError<1013>).code === 1013) {
         const provider = await this.getProvider();
-        if (provider && (await this.getAccounts()).length > 0) return;
+        if (provider && !!(await this.getAccounts()).length) return;
       }
 
       config.emitter.emit('disconnect');

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `connect()` now always returns `chainId`, previously it could undefined ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
-
 ### Added
 
 - Added `connectWith()` method which makes a request for the method to be paired together with a connection request ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
@@ -20,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `eventHandlers.connectWith` handler which is called on successful `connectWith` request with an object including the `accounts`, `chainId`, and `connectWithResponse` ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
 - Added analytics tracking of request handling ([#46](https://github.com/MetaMask/connect-monorepo/pull/46))
 - Initial release ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
+
+### Changed
+
+- `connect()` now always returns `chainId`, previously it could undefined ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
 
 ### Fixed
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `connect()` now always returns `chainId`, previously it could undefined ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
+
 ### Added
 
+- Added `connectWith()` method which makes a request for the method to be paired together with a connection request ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
+  - This method expects param options `method`, `params`, `chainId`, and `account`
+  - `params` can be a function or a plain value. When it is a function, it will be called with the selected account as the first param and must return a value that will be used as the actual params for the request.
+- Added `eventHandlers.connectAndSign` handler which is called on successful `connectAndSign` request with an object including the `accounts`, `chainId`, and `signResponse` ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
+- Added `eventHandlers.connectWith` handler which is called on successful `connectWith` request with an object including the `accounts`, `chainId`, and `connectWithResponse` ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
 - Added analytics tracking of request handling ([#46](https://github.com/MetaMask/connect-monorepo/pull/46))
 - Initial release ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -279,22 +279,14 @@ export class MetamaskConnectEVM {
       forceRequest,
     });
 
-    // If account is already available, proceed immediately
-    if (this.#provider.selectedAccount) {
-      const resolvedParams =
-        typeof params === 'function'
-          ? params(this.#provider.selectedAccount)
-          : params;
-      return await this.#provider.request({
-        method,
-        params: resolvedParams,
-      });
-    }
-
-    // Otherwise, wait for the accountsChanged event to be triggered
     // This is only needed for methods that require an account
     const timeout = 5000;
     const accountPromise = new Promise<Address>((resolve, reject) => {
+      // If account is already available, proceed immediately
+      if (this.#provider.selectedAccount) {
+        return this.#provider.selectedAccount;
+      }
+      // Otherwise, wait for the accountsChanged event to be triggered
       // eslint-disable-next-line prefer-const
       let timeoutId: ReturnType<typeof setTimeout>;
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -77,7 +77,7 @@ export class MetamaskConnectEVM {
   #sessionScopes: SessionData['sessionScopes'] = {};
 
   /** Optional event handlers for the EIP-1193 provider events. */
-  readonly #eventHandlers?: EventHandlers | undefined;
+  readonly #eventHandlers?: Partial<EventHandlers> | undefined;
 
   /** The handler for the wallet_sessionChanged event */
   readonly #sessionChangedHandler: (session?: SessionData) => void;
@@ -697,7 +697,7 @@ export class MetamaskConnectEVM {
  */
 export async function createMetamaskConnectEVM(
   options: Pick<MultichainOptions, 'dapp' | 'api'> & {
-    eventHandlers?: EventHandlers;
+    eventHandlers?: Partial<EventHandlers>;
     debug?: boolean;
   },
 ): Promise<MetamaskConnectEVM> {

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -249,6 +249,82 @@ export class MetamaskConnectEVM {
   }
 
   /**
+   * Connects to the wallet and invokes a method with specified parameters.
+   *
+   * @param options - The options for connecting and invoking the method
+   * @param options.method - The method name to invoke
+   * @param options.params - The parameters to pass to the method
+   * @param options.chainId - Optional chain ID to connect to (defaults to mainnet)
+   * @param options.account - Optional specific account to connect to
+   * @param options.forceRequest - Whether to force a request regardless of an existing session
+   * @returns A promise that resolves with the result of the method invocation
+   * @throws Error if the selected account is not available after timeout (for methods that require an account)
+   */
+  async connectWith({
+    method,
+    params,
+    chainId,
+    account,
+    forceRequest,
+  }: {
+    method: string;
+    params: unknown[];
+    chainId?: number;
+    account?: string | undefined;
+    forceRequest?: boolean;
+  }): Promise<unknown> {
+    await this.connect({
+      chainId: chainId ?? DEFAULT_CHAIN_ID,
+      account,
+      forceRequest,
+    });
+
+    // If account is already available, proceed immediately
+    if (this.#provider.selectedAccount) {
+      return await this.#provider.request({
+        method,
+        params,
+      });
+    }
+
+    // Otherwise, wait for the accountsChanged event to be triggered
+    // This is only needed for methods that require an account
+    const timeout = 5000;
+    const accountPromise = new Promise<Address>((resolve, reject) => {
+      // eslint-disable-next-line prefer-const
+      let timeoutId: ReturnType<typeof setTimeout>;
+
+      const handler = (accounts: Address[]): void => {
+        if (accounts.length > 0) {
+          clearTimeout(timeoutId);
+          this.#provider.off('accountsChanged', handler);
+          resolve(accounts[0]);
+        }
+      };
+
+      this.#provider.on('accountsChanged', handler);
+
+      timeoutId = setTimeout(() => {
+        this.#provider.off('accountsChanged', handler);
+        reject(new Error('Selected account not available after timeout'));
+      }, timeout);
+
+      if (this.#provider.selectedAccount) {
+        clearTimeout(timeoutId);
+        this.#provider.off('accountsChanged', handler);
+        resolve(this.#provider.selectedAccount);
+      }
+    });
+
+    await accountPromise;
+
+    return await this.#provider.request({
+      method,
+      params,
+    });
+  }
+
+  /**
    * Disconnects from the wallet by revoking the session and cleaning up event listeners.
    *
    * @returns A promise that resolves when disconnection is complete

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -25,7 +25,7 @@ export type EIP1193ProviderEvents = {
 };
 
 export type EventHandlers = {
-  connect: (result: { chainId: string }) => void;
+  connect: (result: { chainId: string, accounts: Address[] }) => void;
   disconnect: () => void;
   accountsChanged: (accounts: Address[]) => void;
   chainChanged: (chainId: Hex) => void;

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -12,6 +12,16 @@ export type EIP1193ProviderEvents = {
   accountsChanged: [Address[]];
   chainChanged: [Hex];
   message: [{ type: string; data: unknown }];
+  connectAndSign: [
+    { accounts: readonly Address[]; chainId: number; signResponse: string },
+  ];
+  connectWith: [
+    {
+      accounts: readonly Address[];
+      chainId: number;
+      connectWithResponse: unknown;
+    },
+  ];
 };
 
 export type EventHandlers = {
@@ -19,11 +29,21 @@ export type EventHandlers = {
   disconnect: () => void;
   accountsChanged: (accounts: Address[]) => void;
   chainChanged: (chainId: Hex) => void;
+  connectAndSign: (result: {
+    accounts: readonly Address[];
+    chainId: number;
+    signResponse: string;
+  }) => void;
+  connectWith: (result: {
+    accounts: readonly Address[];
+    chainId: number;
+    connectWithResponse: unknown;
+  }) => void;
 };
 
 export type MetamaskConnectEVMOptions = {
   core: MultichainCore;
-  eventHandlers?: EventHandlers;
+  eventHandlers?: Partial<EventHandlers>;
   notificationQueue?: unknown[];
   supportedNetworks?: Record<CaipChainId, string>;
 };

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -25,7 +25,7 @@ export type EIP1193ProviderEvents = {
 };
 
 export type EventHandlers = {
-  connect: (result: { chainId?: Hex }) => void;
+  connect: (result: { chainId: string }) => void;
   disconnect: () => void;
   accountsChanged: (accounts: Address[]) => void;
   chainChanged: (chainId: Hex) => void;

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -93,7 +93,7 @@ type GenericProviderRequest = {
     | 'wallet_switchEthereumChain'
     | 'wallet_addEthereumChain'
   >;
-  params: unknown;
+  params?: unknown;
 };
 
 // Discriminated union for provider requests

--- a/playground/legacy-evm-react-vite-playground/src/App.tsx
+++ b/playground/legacy-evm-react-vite-playground/src/App.tsx
@@ -71,8 +71,7 @@ function useSDK() {
 
 export const App = () => {
   const [response, setResponse] = useState<unknown>('');
-  const { sdk, connected, provider, chainId, accounts } =
-    useSDK();
+  const { sdk, connected, provider, chainId, accounts } = useSDK();
 
   // TODO: Do we need language support?
   // const languages = sdk?.availableLanguages ?? ['en'];
@@ -102,6 +101,25 @@ export const App = () => {
       setResponse(signResult);
     } catch (err) {
       console.warn(`failed to connect...`, err);
+    }
+  };
+
+  const connectWith = async () => {
+    try {
+      const result = await sdk?.connectWith({
+        method: 'eth_sendTransaction',
+        params: (account) => [
+          {
+            to: account,
+            from: account,
+            value: '0x0',
+          },
+        ],
+      });
+      setResponse(result);
+    } catch (err) {
+      console.warn(`failed to connect with...`, err);
+      setResponse(err instanceof Error ? err.message : 'Unknown error');
     }
   };
 
@@ -187,19 +205,18 @@ export const App = () => {
       throw new Error(`invalid ethereum provider`);
     }
 
-    provider
-      .request({
-        method: 'wallet_addEthereumChain',
-        params: [
-          {
-            chainId: '0x89',
-            chainName: 'Polygon',
-            blockExplorerUrls: ['https://polygonscan.com'],
-            nativeCurrency: { symbol: 'MATIC', decimals: 18 },
-            rpcUrls: ['https://polygon-rpc.com/'],
-          },
-        ],
-      })
+    provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: '0x89',
+          chainName: 'Polygon',
+          blockExplorerUrls: ['https://polygonscan.com'],
+          nativeCurrency: { symbol: 'MATIC', decimals: 18 },
+          rpcUrls: ['https://polygon-rpc.com/'],
+        },
+      ],
+    });
   };
 
   const sendTransaction = async () => {
@@ -268,10 +285,10 @@ export const App = () => {
     <div className="App">
       <h1>Vite React MMSDK Example</h1>
       <div className={'Info-Status'}>
-        <p id='connected-chain'>{`Connected chain: ${chainId}`}</p>
-        <p id='connected-accounts'>{`Connected accounts: ${accounts}`}</p>
-        <p id='request-response'>{`Last request response: ${response}`}</p>
-        <p id='connected-status'>{`Connected: ${connected}`}</p>
+        <p id="connected-chain">{`Connected chain: ${chainId}`}</p>
+        <p id="connected-accounts">{`Connected accounts: ${accounts}`}</p>
+        <p id="request-response">{`Last request response: ${response}`}</p>
+        <p id="connected-status">{`Connected: ${connected}`}</p>
       </div>
 
       {/* <div className="language-dropdown">
@@ -294,8 +311,8 @@ export const App = () => {
           <button
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
-            onClick={requestPermissions}
-            id='request-accounts-button'
+            onClick={connect}
+            id="request-accounts-button"
           >
             wallet_requestPermissions
           </button>
@@ -312,7 +329,7 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={eth_personal_sign}
-            id='personal-sign-button'
+            id="personal-sign-button"
           >
             personal_sign
           </button>
@@ -321,7 +338,7 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={sendTransaction}
-            id='send-transaction-button'
+            id="send-transaction-button"
           >
             Send transaction
           </button>
@@ -331,7 +348,7 @@ export const App = () => {
               className={'Button-Normal'}
               style={{ padding: 10, margin: 10 }}
               onClick={() => changeNetwork('0x5')}
-              id='switch-to-goerli-button'
+              id="switch-to-goerli-button"
             >
               Switch to Goerli
             </button>
@@ -340,7 +357,7 @@ export const App = () => {
               className={'Button-Normal'}
               style={{ padding: 10, margin: 10 }}
               onClick={() => changeNetwork('0x1')}
-              id='switch-to-mainnet-button'
+              id="switch-to-mainnet-button"
             >
               Switch to Mainnet
             </button>
@@ -350,7 +367,7 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={() => changeNetwork('0x89')}
-            id='switch-to-polygon-button'
+            id="switch-to-polygon-button"
           >
             Switch to Polygon
           </button>
@@ -359,18 +376,24 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={addEthereumChain}
-            id='add-polygon-chain-button'
+            id="add-polygon-chain-button"
           >
             Add Polygon Chain
           </button>
 
-          <div style={{ marginTop: 20, borderTop: '1px solid #ccc', paddingTop: 10 }}>
+          <div
+            style={{
+              marginTop: 20,
+              borderTop: '1px solid #ccc',
+              paddingTop: 10,
+            }}
+          >
             <h3>Read-Only RPC Calls</h3>
             <button
               className={'Button-Normal'}
               style={{ padding: 10, margin: 10 }}
               onClick={eth_getBalance}
-              id='eth-get-balance-button'
+              id="eth-get-balance-button"
             >
               eth_getBalance
             </button>
@@ -378,7 +401,7 @@ export const App = () => {
               className={'Button-Normal'}
               style={{ padding: 10, margin: 10 }}
               onClick={eth_blockNumber}
-              id='eth-block-number-button'
+              id="eth-block-number-button"
             >
               eth_blockNumber
             </button>
@@ -386,7 +409,7 @@ export const App = () => {
               className={'Button-Normal'}
               style={{ padding: 10, margin: 10 }}
               onClick={eth_gasPrice}
-              id='eth-gas-price-button'
+              id="eth-gas-price-button"
             >
               eth_gasPrice
             </button>
@@ -398,7 +421,7 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={connect}
-            id='connect-button'
+            id="connect-button"
           >
             Connect
           </button>
@@ -406,9 +429,17 @@ export const App = () => {
             className={'Button-Normal'}
             style={{ padding: 10, margin: 10 }}
             onClick={connectAndSign}
-            id='connect-and-sign-button'
+            id="connect-and-sign-button"
           >
             Connect w/ Sign
+          </button>
+          <button
+            className={'Button-Normal'}
+            style={{ padding: 10, margin: 10 }}
+            onClick={connectWith}
+            id="connect-with-button"
+          >
+            Connect w/ Method
           </button>
         </div>
       )}
@@ -417,7 +448,7 @@ export const App = () => {
         className={'Button-Danger'}
         style={{ padding: 10, margin: 10 }}
         onClick={terminate}
-        id='terminate-button'
+        id="terminate-button"
       >
         Terminate
       </button>


### PR DESCRIPTION
## Explanation

Adds `connectWith` to enable connecting with a method invocation as it existed in the legacy SDK.
Also updates the `legacy-evm-react-playground` to support this method.

### Testing:

1. `yarn && yarn build`
2. `yarn workspace legacy-evm-react-vite dev`
3. click `connectWith`; it should connect and prompt a self send tx w/ 0 amount


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
