### PR TITLE
fix: make MultichainCore's dapp name and url properties mandatory

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING** Make the `dapp.name` and `dapp.url` properties required in `createMetamaskConnectEVM()` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
-  - The `dapp.url` property is now always overwritten with the value of the page's url when MetaMask Connect is running in a browser context ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
-
 ### Added
 
 - Added `connectWith()` method which makes a request for the method to be paired together with a connection request ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
@@ -24,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** Make the `dapp.name` and `dapp.url` properties required in `createMetamaskConnectEVM()` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+  - The `dapp.url` property is now always overwritten with the value of the page's url when MetaMask Connect is running in a browser context ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
 - `connect()` now always returns `chainId`, previously it could undefined ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))
 
 ### Fixed

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** Make the `dapp.name` and `dapp.url` properties required in `createMetamaskConnectEVM()` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+  - The `dapp.url` property is now always overwritten with the value of the page's url when MetaMask Connect is running in a browser context ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+
 ### Added
 
 - Added `connectWith()` method which makes a request for the method to be paired together with a connection request ([#53](https://github.com/MetaMask/connect-monorepo/pull/53))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
-
 ### Changed
 
 - **BREAKING** Make the `dapp.name` and `dapp.url` properties required in `createMetamaskConnect()` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
   - The `dapp.url` property is now always overwritten with the value of the page's url when MetaMask Connect is running in a browser context ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+
+### Fixed
+
+- Fixed mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
 
 ## [0.2.1]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
 
+### Changed
+
+- **BREAKING** Make `dapp.url` and `dapp.name` properties mandatory in `MultichainCore` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+
 ## [0.2.1]
 
 ### Added

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING** Make `dapp.url` and `dapp.name` properties mandatory in `MultichainCore` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+- **BREAKING** Make the `dapp.name` and `dapp.url` properties required in `createMetamaskConnect()` ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
+  - The `dapp.url` property is now always overwritten with the value of the page's url when MetaMask Connect is running in a browser context ([#56](https://github.com/MetaMask/connect-monorepo/pull/56))
 
 ## [0.2.1]
 

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -22,8 +22,8 @@ export type { SessionData } from '@metamask/multichain-api-client';
  * - Using a base64-encoded icon
  */
 export type DappSettings = {
-  name?: string;
-  url?: string;
+  name: string;
+  url: string;
 } & ({ iconUrl?: string } | { base64Icon?: string });
 
 export type ConnectionRequest = {

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -23,7 +23,7 @@ export type { SessionData } from '@metamask/multichain-api-client';
  */
 export type DappSettings = {
   name: string;
-  url: string;
+  url?: string;
 } & ({ iconUrl?: string } | { base64Icon?: string });
 
 export type ConnectionRequest = {

--- a/packages/connect-multichain/src/multichain/utils/index.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.test.ts
@@ -31,41 +31,21 @@ t.describe('Utils', () => {
 	});
 
 	t.describe('getDappId', () => {
-		const mockHostname = 'mockdapp.com';
 		const mockDappName = 'Mock DApp Name';
 		const mockDappUrl = 'http://mockdapp.com';
-		const originalWindow = global.window;
 
-		t.afterEach(() => {
-			global.window = originalWindow;
-		});
-
-		t.it('should return window.location.hostname if window and window.location are defined', () => {
-			global.window = {
-				location: {
-					hostname: mockHostname,
-				},
-			} as any;
-			t.expect(utils.getDappId()).toBe(mockHostname);
-		});
-
-		t.it('should return dappMetadata.name if window is undefined and name is available', () => {
+		t.it('should return dappMetadata.name if defined and url is not', () => {
 			global.window = undefined as any;
-			const dappSettings = { name: mockDappName, url: mockDappUrl };
+			const dappSettings = { name: mockDappName };
 			t.expect(utils.getDappId(dappSettings)).toBe(mockDappName);
 		});
 
-		t.it('should return dappMetadata.url if window is undefined and name is not available but url is', () => {
+		t.it('should return dappMetadata.url if defined', () => {
 			global.window = undefined as any;
-			const dappSettings = { url: mockDappUrl };
+			const dappSettings = { url: mockDappUrl, name: mockDappName };
 			t.expect(utils.getDappId(dappSettings)).toBe(mockDappUrl);
 		});
 
-		t.it('should return "N/A" if window is undefined and neither name nor url is available', () => {
-			global.window = undefined as any;
-			const dappSettings = {};
-			t.expect(utils.getDappId(dappSettings)).toBe('N/A');
-		});
 	});
 
 	t.describe('getSDKVersion', () => {

--- a/packages/connect-multichain/src/multichain/utils/index.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.test.ts
@@ -141,7 +141,7 @@ t.describe('Utils', () => {
 			t.expect(consoleWarnSpy).toHaveBeenCalledWith('Invalid dappMetadata.iconUrl: URL must start with http:// or https://');
 		});
 
-		t.it('should set url to undenied if it does not start with http:// or https:// and favicon is undefined', async () => {
+		t.it('should set url to undefined if it does not start with http:// or https:// and favicon is undefined', async () => {
 			options.dapp.url = 'wrong';
 			const consoleWarnSpy = t.vi.spyOn(console, 'warn');
 
@@ -151,12 +151,17 @@ t.describe('Utils', () => {
 			t.expect(consoleWarnSpy).toHaveBeenCalledWith('Invalid dappMetadata.url: URL must start with http:// or https://');
 		});
 
-		t.it('should prove that dapp is mandatory is platform is not browser', async () => {
-			(options.dapp as any) = undefined;
+		t.it('throw if platform is not browser and dapp url is missing', async () => {
+			(options.dapp as any) = { name: 'test' };
 			await t.expect(() => utils.setupDappMetadata(options)).toThrow('You must provide dapp url');
 		});
 
-		t.it('should prove that dapp is optional is platform is browser', async () => {
+		t.it('throw if platform dapp name is missing', async () => {
+			(options.dapp as any) = { url: 'https://example.com' };
+			await t.expect(() => utils.setupDappMetadata(options)).toThrow('You must provide dapp name');
+		});
+
+		t.it('should set the dapp url if not provided and platform is browser', async () => {
 			const mockGetPlatformType = t.vi.mocked(getPlatformType);
 			mockGetPlatformType.mockReturnValue(PlatformType.DesktopWeb);
 			t.vi.stubGlobal('window', {
@@ -165,7 +170,9 @@ t.describe('Utils', () => {
 					host: 'example.com',
 				},
 			});
-			(options.dapp as any) = undefined;
+			(options.dapp as any) = {
+				name: 'test',
+			};
 			utils.setupDappMetadata(options);
 			t.expect(options.dapp.url).toBe('https://example.com');
 		});
@@ -175,6 +182,7 @@ t.describe('Utils', () => {
 			const consoleWarnSpy = t.vi.spyOn(console, 'warn');
 
 			options.dapp = {
+				name: 'test',
 				iconUrl: 'https://example.com/favicon.ico',
 				url: 'https://example.com',
 				base64Icon: longString,
@@ -188,6 +196,7 @@ t.describe('Utils', () => {
 
 		t.it('should set iconUrl to the extracted favicon if iconUrl and base64Icon are not provided', async () => {
 			options.dapp = {
+				name: 'test',
 				url: 'https://example.com',
 			};
 

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -43,8 +43,8 @@ export function compressString(str: string): string {
   return base64Encode(binaryString);
 }
 
-export function getDappId(dapp?: DappSettings) {
-  return dapp?.url ?? dapp?.name;
+export function getDappId(dapp: DappSettings) {
+  return dapp.url ?? dapp.name;
 }
 
 export function openDeeplink(

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -44,11 +44,7 @@ export function compressString(str: string): string {
 }
 
 export function getDappId(dapp?: DappSettings) {
-  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
-    return dapp?.name ?? dapp?.url ?? 'N/A';
-  }
-
-  return window.location.hostname;
+  return dapp?.url ?? dapp?.name;
 }
 
 export function openDeeplink(

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -122,16 +122,14 @@ export function setupDappMetadata(
     platform === PlatformType.MobileWeb ||
     platform === PlatformType.MetaMaskMobileWebview;
 
+  if (isBrowser) {
+    options.dapp = {
+      ...options.dapp,
+      url: `${window.location.protocol}//${window.location.host}`,
+    };
+  }
   if (!options.dapp?.url) {
-    // Automatically set dappMetadata on web env if not defined
-    if (isBrowser) {
-      options.dapp = {
-        ...options.dapp,
-        url: `${window.location.protocol}//${window.location.host}`,
-      };
-    } else {
-      throw new Error('You must provide dapp url');
-    }
+    throw new Error('You must provide dapp url');
   }
   const BASE_64_ICON_MAX_LENGTH = 163400;
   // Check if iconUrl and url are valid

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -122,6 +122,9 @@ export function setupDappMetadata(
     platform === PlatformType.MobileWeb ||
     platform === PlatformType.MetaMaskMobileWebview;
 
+  if (!options.dapp?.name) {
+    throw new Error('You must provide dapp name');
+  }
   if (isBrowser) {
     options.dapp = {
       ...options.dapp,


### PR DESCRIPTION
## Explanation

In order for a `connect` request to succeed on Metamask Mobile via `MultichainCore`, it needs to have a `dapp.name` and `dapp.url` properties configured as they're enforced in [this mobile validation function](https://github.com/MetaMask/metamask-mobile/blob/e3d9ff6c12bf70ec064d74d9cdb181bdae4da18e/app/core/SDKConnectV2/types/connection-request.ts#L68).  This PR marks them as mandatory.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
