### PR TITLE
Remove dangling branching logic where old sdk deeplink routes can be generated

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -18,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typedoc generation ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
 - Permissioning accounts through `wallet_requestPermissions` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
 - Enable conditional logging through options in `createMetamaskConnectEVM` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
+- Fixed mobile deeplink bug when attempting to connect when already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
 
 [Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -18,6 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typedoc generation ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
 - Permissioning accounts through `wallet_requestPermissions` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
 - Enable conditional logging through options in `createMetamaskConnectEVM` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
-- Fixed mobile deeplink bug when attempting to connect when already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
+- Fixed mobile deeplink bug that occurred when `MetamaskConnectEVM.connect()` was called and the transport was already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
 
 [Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mobile deeplink bug when attempting to connect when already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
+
 ## [0.2.1]
 
 ### Added

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed mobile deeplink bug when attempting to connect when already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
+- Fixed mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#57](https://github.com/MetaMask/connect-monorepo/pull/57))
 
 ## [0.2.1]
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -496,16 +496,6 @@ export class MultichainSDK extends MultichainCore {
             }
           },
         );
-      } else {
-        timeout = setTimeout(() => {
-          const deeplink = this.options.ui.factory.createDeeplink();
-          const universalLink = this.options.ui.factory.createUniversalLink();
-          if (this.options.mobile?.preferredOpenLink) {
-            this.options.mobile.preferredOpenLink(deeplink, '_self');
-          } else {
-            openDeeplink(this.options, deeplink, universalLink);
-          }
-        }, 250);
       }
 
       this.transport

--- a/packages/connect-multichain/src/ui/index.ts
+++ b/packages/connect-multichain/src/ui/index.ts
@@ -147,7 +147,7 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
 
   createDeeplink(connectionRequest?: ConnectionRequest) {
     if (!connectionRequest) {
-      return `${METAMASK_DEEPLINK_BASE}`;
+      throw new Error('createDeeplink can only be called with a connection request');
     }
     const json = JSON.stringify(connectionRequest);
     const compressed = compressString(json);


### PR DESCRIPTION
Per our sync this morning, we don't believe there are any cases where old deeplink format should be generated