### PR TITLE
fix: stop caching error responses 

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed incorrect caching of error responses for some requests/events ([#59](https://github.com/MetaMask/connect-monorepo/pull/59))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed incorrect caching of error responses for some requests/events ([#59](https://github.com/MetaMask/connect-monorepo/pull/59))
+
 ## [0.3.0]
 
 ### Changed

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -522,6 +522,9 @@ export class MWPTransport implements ExtendedTransport {
     request: TransportRequest,
     response: TransportResponse,
   ): Promise<void> {
+    if(response.error) {
+      return;
+    }
     if (CACHED_METHOD_LIST.includes(request.method)) {
       await this.kvstore.set(SESSION_STORE_KEY, JSON.stringify(response));
     } else if (request.method === 'eth_accounts') {


### PR DESCRIPTION
## Explanation

Our response caching strategy in the `MwpTransport` is caching all responses, including errors. We only want to cache successful responses. This PR adds a check to ensure that the response being cached is successful.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
