### PR TITLE
fix: bump multichain api client and add event listener clean up for notifications

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/multichain-api-client` to prevent `RPC request with id already seen.` error on extension when using firefox ([#60](https://github.com/MetaMask/connect-monorepo/pull/60))
+
 ## [0.3.0]
 
 ### Changed

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -69,7 +69,7 @@
     "@metamask/analytics": "workspace:^",
     "@metamask/mobile-wallet-protocol-core": "^0.3.0",
     "@metamask/mobile-wallet-protocol-dapp-client": "^0.2.1",
-    "@metamask/multichain-api-client": "^0.8.1",
+    "@metamask/multichain-api-client": "^0.10.1",
     "@metamask/multichain-ui": "workspace:^",
     "@metamask/onboarding": "^1.0.1",
     "@metamask/utils": "^11.8.1",

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -38,6 +38,7 @@ export class DefaultTransport implements ExtendedTransport {
   readonly #pendingRequests = new Map<string, PendingRequest>();
 
   #handleResponseListener: ((event: MessageEvent) => void) | undefined;
+
   #handleNotificationListener: ((event: MessageEvent) => void) | undefined;
 
   #notifyCallbacks(data: unknown): void {
@@ -131,8 +132,8 @@ export class DefaultTransport implements ExtendedTransport {
 
     // Add the listener
     // eslint-disable-next-line no-restricted-globals
-
     window.addEventListener('message', this.#handleResponseListener);
+    // eslint-disable-next-line no-restricted-globals
     window.addEventListener('message', this.#handleNotificationListener);
   }
 
@@ -268,6 +269,13 @@ export class DefaultTransport implements ExtendedTransport {
       // eslint-disable-next-line no-restricted-globals
       window.removeEventListener('message', this.#handleResponseListener);
       this.#handleResponseListener = undefined;
+    }
+
+    // Remove the notification listener when disconnecting
+    if (this.#handleNotificationListener) {
+      // eslint-disable-next-line no-restricted-globals
+      window.removeEventListener('message', this.#handleNotificationListener);
+      this.#handleNotificationListener = undefined;
     }
 
     // Reject all pending requests

--- a/yarn.lock
+++ b/yarn.lock
@@ -4044,7 +4044,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.3.0"
     "@metamask/mobile-wallet-protocol-dapp-client": "npm:^0.2.1"
-    "@metamask/multichain-api-client": "npm:^0.8.1"
+    "@metamask/multichain-api-client": "npm:^0.10.1"
     "@metamask/multichain-ui": "workspace:^"
     "@metamask/onboarding": "npm:^1.0.1"
     "@metamask/utils": "npm:^11.8.1"
@@ -4453,10 +4453,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-api-client@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "@metamask/multichain-api-client@npm:0.8.1"
-  checksum: 10/a6e079b4acce94d25ffdccbbf7f09ce1b5c650ceec6119e7002f8095cd1eb18c59a26fbfe0ac775c60862e38c657273dad507e27ddbdc166fea404b03f54bdb6
+"@metamask/multichain-api-client@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@metamask/multichain-api-client@npm:0.10.1"
+  checksum: 10/adedb90f433cd619eee54943197dc32eb30e461173e928ea698ec70bf8c6780d9ac0bb9b12a22a17f984170841c071d228aa49e6988d5060e8a30e99c433a8f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

In the Firefox Extension, when a dapp disconnects, the UI updates correctly, but attempting to reconnect does not prompt the wallet pop-up for permission granting.

This happens because [createDupeReqFilterStream middleware](https://github.com/MetaMask/metamask-extension/blob/4f6037d751e3a3b18d3b5019093dc3a9377ca223/app/scripts/lib/createDupeReqFilterStream.ts#L62) is responsible for keeping track of IDs that have been recently seen and not respond to request incoming from these matching IDs.

the proposed fix here is bumping `@metamask/multichain-api-client` to make sure we make use of the fix in [this PR](https://github.com/MetaMask/multichain-api-client/pull/91).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-873

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
