### PR TITLE
feat: add connection id to simple deeplinks 

### DIFF
--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -1,4 +1,4 @@
-import type { SessionRequest } from '@metamask/mobile-wallet-protocol-core';
+import type { Session, SessionRequest } from '@metamask/mobile-wallet-protocol-core';
 import type {
   Transport,
   TransportRequest,
@@ -109,4 +109,6 @@ export type ExtendedTransport = Omit<Transport, 'connect'> & {
       timeout?: number;
     },
   ) => Promise<TResponse>;
+
+  getActiveSession: () => Promise<Session | undefined>;
 };

--- a/packages/connect-multichain/src/invoke.test.ts
+++ b/packages/connect-multichain/src/invoke.test.ts
@@ -124,6 +124,9 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 			t.expect(sdk.state).toBe('connected');
 			t.expect(sdk.storage).toBeDefined();
 			t.expect(sdk.transport).toBeDefined();
+			if (platform === 'web-mobile') {
+				sdk.transport.getActiveSession = t.vi.fn().mockResolvedValue({id: 'mock-session-id'});
+			}
 
 			const providerInvokeMethodSpy = t.vi.spyOn(RequestRouter.prototype, 'invokeMethod');
 			const options = {
@@ -154,6 +157,10 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 				sdk = await createSDK(testOptions);
 				await sdk.connect(scopes, caipAccountIds);
 				t.expect(sdk.state).toBe('connected');
+
+				if (platform === 'web-mobile') {
+					sdk.transport.getActiveSession = t.vi.fn().mockResolvedValue({id: 'mock-session-id'});
+				}
 
 				const options = {
 					scope: 'eip155:1',
@@ -228,6 +235,10 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 			} as InvokeMethodOptions;
 			t.expect(sdk.state).toBe('connected');
 			t.expect(sdk.provider).toBeDefined();;
+
+			if (platform === 'web-mobile') {
+				sdk.transport.getActiveSession = t.vi.fn().mockResolvedValue({id: 'mock-session-id'});
+			}
 
 			await t.expect(sdk.invokeMethod(options)).rejects.toThrow('RPCErr53: RPC Client invoke method reason (Failed to invoke method)');
 		});

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -486,9 +486,9 @@ export class MultichainSDK extends MultichainCore {
               },
             };
             const deeplink =
-              this.options.ui.factory.createDeeplink(connectionRequest);
+              this.options.ui.factory.createConnectionDeeplink(connectionRequest);
             const universalLink =
-              this.options.ui.factory.createUniversalLink(connectionRequest);
+              this.options.ui.factory.createConnectionUniversalLink(connectionRequest);
             if (this.options.mobile?.preferredOpenLink) {
               this.options.mobile.preferredOpenLink(deeplink, '_self');
             } else {
@@ -715,13 +715,19 @@ export class MultichainSDK extends MultichainCore {
     const shouldOpenDeeplink = secure && !showInstallModal;
 
     if (shouldOpenDeeplink) {
-      setTimeout(() => {
+      setTimeout(async () => {
+        const session = await this.transport.getActiveSession();
+        if (!session) {
+          throw new Error('No active session found');
+        }
+
+        const url = `${METAMASK_DEEPLINK_BASE}/mwp?id=${encodeURIComponent(session.id)}`;
         if (mobile?.preferredOpenLink) {
-          mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
+          mobile.preferredOpenLink(url, '_self'); // here
         } else {
           openDeeplink(
             this.options,
-            METAMASK_DEEPLINK_BASE,
+            url,
             METAMASK_CONNECT_BASE_URL,
           );
         }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -723,7 +723,7 @@ export class MultichainSDK extends MultichainCore {
 
         const url = `${METAMASK_DEEPLINK_BASE}/mwp?id=${encodeURIComponent(session.id)}`;
         if (mobile?.preferredOpenLink) {
-          mobile.preferredOpenLink(url, '_self'); // here
+          mobile.preferredOpenLink(url, '_self');
         } else {
           openDeeplink(
             this.options,

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -61,7 +61,7 @@ export class RequestRouter {
 
 					const url = `${METAMASK_DEEPLINK_BASE}/mwp?id=${encodeURIComponent(session.id)}`;
 					if (mobile?.preferredOpenLink) {
-						mobile.preferredOpenLink(url, '_self'); // here
+						mobile.preferredOpenLink(url, '_self');
 					} else {
 						openDeeplink(this.config, url, METAMASK_CONNECT_BASE_URL);
 					}

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -53,11 +53,17 @@ export class RequestRouter {
 			const shouldOpenDeeplink = secure && !showInstallModal;
 
 			if (shouldOpenDeeplink) {
-				setTimeout(() => {
+				setTimeout(async () => {
+					const session = await this.transport.getActiveSession();
+					if (!session) {
+						throw new Error('No active session found');
+					}
+
+					const url = `${METAMASK_DEEPLINK_BASE}/mwp?s=${encodeURIComponent(session.id)}`;
 					if (mobile?.preferredOpenLink) {
-						mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
+						mobile.preferredOpenLink(url, '_self'); // here
 					} else {
-						openDeeplink(this.config, METAMASK_DEEPLINK_BASE, METAMASK_CONNECT_BASE_URL);
+						openDeeplink(this.config, url, METAMASK_CONNECT_BASE_URL);
 					}
 				}, 10); // small delay to ensure the message encryption and dispatch completes
 			}
@@ -166,4 +172,3 @@ export class RequestRouter {
 		return this.handleWithWallet(options);
 	}
 }
-

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -59,7 +59,7 @@ export class RequestRouter {
 						throw new Error('No active session found');
 					}
 
-					const url = `${METAMASK_DEEPLINK_BASE}/mwp?s=${encodeURIComponent(session.id)}`;
+					const url = `${METAMASK_DEEPLINK_BASE}/mwp?id=${encodeURIComponent(session.id)}`;
 					if (mobile?.preferredOpenLink) {
 						mobile.preferredOpenLink(url, '_self'); // here
 					} else {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -14,6 +14,7 @@ import {
   getValidAccounts,
   isSameScopesAndAccounts,
 } from '../../utils';
+import { Session } from '@metamask/mobile-wallet-protocol-core';
 
 const DEFAULT_REQUEST_TIMEOUT = 60 * 1000;
 
@@ -300,5 +301,9 @@ export class DefaultTransport implements ExtendedTransport {
     return () => {
       this.#notificationCallbacks.delete(callback);
     };
+  }
+
+  getActiveSession(): Promise<Session | undefined> {
+    throw new Error('getActiveSession is purposely not implemented for the DefaultTransport');
   }
 }

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -312,6 +312,9 @@ export class DefaultTransport implements ExtendedTransport {
   }
 
   getActiveSession(): Promise<Session | undefined> {
+    // This code path should never be triggered when the DefaultTransport is being used
+    // It's only purpose is for exposing the session ID used for deeplinking to the mobile app
+    // and so it is only implemented for the MWPTransport.
     throw new Error('getActiveSession is purposely not implemented for the DefaultTransport');
   }
 }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -593,8 +593,10 @@ export class MWPTransport implements ExtendedTransport {
     try {
       const [activeSession] = await sessionStore.list();
       return activeSession;
-    } catch {
-      /* empty */
+    } catch (error){
+      // TODO: verify if this try catch is necessary
+      logger('error getting active session', error);
+      return undefined;
     }
   }
 }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -319,18 +319,11 @@ export class MWPTransport implements ExtendedTransport {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
   }): Promise<void> {
-    const { dappClient, kvstore } = this;
-    const sessionStore = new SessionStore(kvstore);
+    const { dappClient } = this;
 
-    let session: Session | undefined;
-    try {
-      const [activeSession] = await sessionStore.list();
-      if (activeSession) {
-        logger('active session found', activeSession);
-        session = activeSession;
-      }
-    } catch {
-      /* empty */
+    const session = await this.getActiveSession();
+    if (session) {
+      logger('active session found', session);
     }
 
     let timeout: NodeJS.Timeout;
@@ -588,5 +581,17 @@ export class MWPTransport implements ExtendedTransport {
     return () => {
       this.notificationCallbacks.delete(callback);
     };
+  }
+
+  async getActiveSession(): Promise<Session | undefined> {
+    const { kvstore } = this;
+    const sessionStore = new SessionStore(kvstore);
+
+    try {
+      const [activeSession] = await sessionStore.list();
+      return activeSession;
+    } catch {
+      /* empty */
+    }
   }
 }

--- a/packages/connect-multichain/src/ui/index.ts
+++ b/packages/connect-multichain/src/ui/index.ts
@@ -145,9 +145,9 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
     return container;
   }
 
-  createDeeplink(connectionRequest?: ConnectionRequest) {
+  createConnectionDeeplink(connectionRequest?: ConnectionRequest) {
     if (!connectionRequest) {
-      throw new Error('createDeeplink can only be called with a connection request');
+      throw new Error('createConnectionDeeplink can only be called with a connection request');
     }
     const json = JSON.stringify(connectionRequest);
     const compressed = compressString(json);
@@ -155,7 +155,7 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
     return `${METAMASK_DEEPLINK_BASE}/mwp?p=${urlEncoded}&c=1`;
   }
 
-  createUniversalLink(connectionRequest?: ConnectionRequest) {
+  createConnectionUniversalLink(connectionRequest?: ConnectionRequest) {
     if (!connectionRequest) {
       return `${METAMASK_CONNECT_BASE_URL}`;
     }
@@ -186,7 +186,7 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
 
     const parentElement = this.getMountedContainer();
     const connectionRequest = await createConnectionRequest();
-    const qrCodeLink = this.createDeeplink(connectionRequest);
+    const qrCodeLink = this.createConnectionDeeplink(connectionRequest);
 
     const modal: Modal<any> = new this.options.InstallModal({
       expiresIn:
@@ -197,7 +197,7 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
       link: qrCodeLink,
       sdkVersion: getVersion(),
       generateQRCode: async (request: ConnectionRequest) =>
-        this.createDeeplink(request),
+        this.createConnectionDeeplink(request),
       onClose: this.onCloseModal.bind(this),
       startDesktopOnboarding: this.onStartDesktopOnboarding.bind(this),
       createConnectionRequest,


### PR DESCRIPTION
## Explanation

When deeplinking the user into the wallet for non-initial connection cases, the wallet has no idea which connection/session the user is opening the wallet from. In the case that the connection the dapp is using no longer exists on the wallet side, the user will sit in the wallet indefinitely waiting for a request that will never arrive.

This PR fixes that by including the connection id to the previously plain `metamask://connect/mwp` deeplink. It is now `metamask://connect/mwp?id=CONN_ID_HERE`. This will allow the wallet to prompt the user with an error toast if that connection no longer exists on the wallet side.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
See: https://github.com/MetaMask/metamask-mobile/pull/23700

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
