### PR TITLE
setup/configure @metamask/connect root package + repoint playgrounds (ex node playground) to @metamask/connect

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added subpath exports to `@metamask/connect` package: `@metamask/connect/evm` - unified export for EVM functionality
 
 ### Changed

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added subpath exports to `@metamask/connect` package:
-  - `@metamask/connect/evm` - unified export for EVM functionality
+- Added subpath exports to `@metamask/connect` package ([#70](https://github.com/MetaMask/connect-monorepo/pull/70)): 
+  - `@metamask/connect/evm` - unified export for EVM functionality 
   - `@metamask/connect/multichain` - unified export for multichain functionality
-- Updated all playground examples to use the new unified subpath exports
 
 ### Changed
 

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added subpath exports to `@metamask/connect` package ([#70](https://github.com/MetaMask/connect-monorepo/pull/70)): 
-  - `@metamask/connect/evm` - unified export for EVM functionality 
-  - `@metamask/connect/multichain` - unified export for multichain functionality
+- Added subpath exports to `@metamask/connect` package: `@metamask/connect/evm` - unified export for EVM functionality
 
 ### Changed
 

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added subpath exports to `@metamask/connect` package:
+  - `@metamask/connect/evm` - unified export for EVM functionality
+  - `@metamask/connect/multichain` - unified export for multichain functionality
+- Updated all playground examples to use the new unified subpath exports
+
 ### Changed
 
 - Updated `description` in `package.json` ([#18](https://github.com/MetaMask/connect-monorepo/pull/18))

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -36,6 +36,36 @@
       },
       "default": "./dist/multichain/index.js"
     },
+    "./evm": {
+      "import": {
+        "types": "./dist/evm/index.d.ts",
+        "default": "./dist/evm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/evm/index.d.ts",
+        "default": "./dist/evm/index.js"
+      },
+      "default": "./dist/evm/index.js"
+    },
+    "./multichain": {
+      "browser": {
+        "types": "./dist/multichain/index.d.ts",
+        "import": "./dist/multichain/index.mjs"
+      },
+      "react-native": {
+        "types": "./dist/multichain/index.d.ts",
+        "import": "./dist/multichain/index.mjs"
+      },
+      "import": {
+        "types": "./dist/multichain/index.d.ts",
+        "default": "./dist/multichain/index.mjs"
+      },
+      "require": {
+        "types": "./dist/multichain/index.d.ts",
+        "default": "./dist/multichain/index.js"
+      },
+      "default": "./dist/multichain/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
@@ -45,7 +75,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "yarn clean && tsc -b --force tsconfig.build.json && npx tsup src/index.ts src/multichain/index.ts --format esm,cjs --external @metamask/connect-multichain",
+    "build": "yarn clean && tsc -b --force tsconfig.build.json && npx tsup src/index.ts src/multichain/index.ts src/evm/index.ts --format esm,cjs --external @metamask/connect-multichain --external @metamask/connect-evm",
     "build:docs": "typedoc",
     "changelog:format": "../../scripts/format-changelog.sh @metamask/connect",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/connect",
@@ -58,6 +88,7 @@
     "test:verbose": "yarn test"
   },
   "dependencies": {
+    "@metamask/connect-evm": "workspace:^",
     "@metamask/connect-multichain": "workspace:^"
   },
   "devDependencies": {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -47,25 +47,6 @@
       },
       "default": "./dist/evm/index.js"
     },
-    "./multichain": {
-      "browser": {
-        "types": "./dist/multichain/index.d.ts",
-        "import": "./dist/multichain/index.mjs"
-      },
-      "react-native": {
-        "types": "./dist/multichain/index.d.ts",
-        "import": "./dist/multichain/index.mjs"
-      },
-      "import": {
-        "types": "./dist/multichain/index.d.ts",
-        "default": "./dist/multichain/index.mjs"
-      },
-      "require": {
-        "types": "./dist/multichain/index.d.ts",
-        "default": "./dist/multichain/index.js"
-      },
-      "default": "./dist/multichain/index.js"
-    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/connect/src/evm/index.ts
+++ b/packages/connect/src/evm/index.ts
@@ -1,0 +1,2 @@
+export * from '@metamask/connect-evm';
+

--- a/packages/connect/tsconfig.build.json
+++ b/packages/connect/tsconfig.build.json
@@ -7,6 +7,7 @@
   },
   "include": ["./src"],
   "references": [
+    { "path": "../connect-evm/tsconfig.build.json" },
     { "path": "../connect-multichain/tsconfig.build.json" }
   ]
 }

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    { "path": "../connect-evm/tsconfig.build.json" },
+    { "path": "../connect-multichain/tsconfig.build.json" }
+  ],
   "include": ["./src"]
 }

--- a/playground/legacy-evm-react-vite-playground/README.md
+++ b/playground/legacy-evm-react-vite-playground/README.md
@@ -1,8 +1,8 @@
 # Legacy EVM React Vite Playground
 
-> A demo application showcasing `@metamask/connect-evm` integration in a React + Vite application.
+> A demo application showcasing `@metamask/connect/evm` integration in a React + Vite application.
 
-This playground demonstrates how to use `@metamask/connect-evm` in a React application with Vite. It provides working examples of all major features including connection, signing, transactions, and chain switching.
+This playground demonstrates how to use `@metamask/connect/evm` in a React application with Vite. It provides working examples of all major features including connection, signing, transactions, and chain switching.
 
 ## Features Demonstrated
 
@@ -98,7 +98,7 @@ legacy-evm-react-vite-playground/
 - **React 18** - UI framework
 - **Vite** - Build tool and dev server
 - **TypeScript** - Type safety
-- **@metamask/connect-evm** - MetaMask connection SDK
+- **@metamask/connect/evm** - MetaMask connection SDK
 
 ## Troubleshooting
 
@@ -116,7 +116,7 @@ legacy-evm-react-vite-playground/
 
 ## Learn More
 
-- [@metamask/connect-evm Documentation](../../packages/connect-evm/README.md)
+- [@metamask/connect/evm Documentation](../../packages/connect-evm/README.md)
 - [MetaMask Documentation](https://docs.metamask.io)
 - [EIP-1193 Specification](https://eips.ethereum.org/EIPS/eip-1193)
 

--- a/playground/legacy-evm-react-vite-playground/package.json
+++ b/playground/legacy-evm-react-vite-playground/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@metamask/connect-evm": "workspace:^",
+    "@metamask/connect": "workspace:^",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vite-plugin-node-polyfills": "^0.24.0"

--- a/playground/legacy-evm-react-vite-playground/src/App.tsx
+++ b/playground/legacy-evm-react-vite-playground/src/App.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import {
   MetamaskConnectEVM,
   createMetamaskConnectEVM,
-} from '@metamask/connect-evm';
+} from '@metamask/connect/evm';
 import './App.css';
 import { send_eth_signTypedData_v4, send_personal_sign } from './SignHelpers';
-import type { EIP1193Provider } from '@metamask/connect-evm';
+import type { EIP1193Provider } from '@metamask/connect/evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
 
 function useSDK() {

--- a/playground/legacy-evm-react-vite-playground/src/SignHelpers.ts
+++ b/playground/legacy-evm-react-vite-playground/src/SignHelpers.ts
@@ -1,4 +1,4 @@
-import { EIP1193Provider } from '@metamask/connect-evm';
+import { EIP1193Provider } from '@metamask/connect/evm';
 import { Buffer } from 'buffer';
 
 export const send_eth_signTypedData_v4 = async (

--- a/playground/multichain-react-playground/package.json
+++ b/playground/multichain-react-playground/package.json
@@ -51,7 +51,7 @@
     "@metamask/utils": "^11.8.1"
   },
   "dependencies": {
-    "@metamask/connect-multichain": "workspace:^",
+    "@metamask/connect": "workspace:^",
     "@metamask/utils": "^11.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
@@ -108,8 +108,8 @@
       "@solana/web3.js>bigint-buffer": false,
       "@solana/web3.js>rpc-websockets>bufferutil": false,
       "@solana/web3.js>rpc-websockets>utf-8-validate": false,
-      "@metamask/connect-multichain>@metamask/mobile-wallet-protocol-dapp-client>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false,
-      "@metamask/connect-multichain>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false
+      "@metamask/connect>@metamask/mobile-wallet-protocol-dapp-client>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false,
+      "@metamask/connect>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false
     }
   }
 }

--- a/playground/multichain-react-playground/src/App.tsx
+++ b/playground/multichain-react-playground/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Scope, SessionData } from '@metamask/connect-multichain';
+import type { Scope, SessionData } from '@metamask/connect/multichain';
 import type { CaipAccountId } from '@metamask/utils';
 import { useSDK } from './sdk';
 import DynamicInputs, { INPUT_LABEL_TYPE } from './components/DynamicInputs';

--- a/playground/multichain-react-playground/src/App.tsx
+++ b/playground/multichain-react-playground/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Scope, SessionData } from '@metamask/connect/multichain';
+import type { Scope, SessionData } from '@metamask/connect';
 import type { CaipAccountId } from '@metamask/utils';
 import { useSDK } from './sdk';
 import DynamicInputs, { INPUT_LABEL_TYPE } from './components/DynamicInputs';

--- a/playground/multichain-react-playground/src/components/FeaturedNetworks.tsx
+++ b/playground/multichain-react-playground/src/components/FeaturedNetworks.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { Scope } from '@metamask/connect/multichain';
+import type { Scope } from '@metamask/connect';
 // biome-ignore lint/style/useImportType: ok
 import React from 'react';
 

--- a/playground/multichain-react-playground/src/components/FeaturedNetworks.tsx
+++ b/playground/multichain-react-playground/src/components/FeaturedNetworks.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { Scope } from '@metamask/connect-multichain';
+import type { Scope } from '@metamask/connect/multichain';
 // biome-ignore lint/style/useImportType: ok
 import React from 'react';
 

--- a/playground/multichain-react-playground/src/components/ScopeCard.tsx
+++ b/playground/multichain-react-playground/src/components/ScopeCard.tsx
@@ -1,5 +1,5 @@
 import MetaMaskOpenRPCDocument from '@metamask/api-specs';
-import type { Scope, SessionData } from '@metamask/connect-multichain';
+import type { Scope, SessionData } from '@metamask/connect/multichain';
 import {
   type CaipAccountAddress,
   type CaipAccountId,

--- a/playground/multichain-react-playground/src/components/ScopeCard.tsx
+++ b/playground/multichain-react-playground/src/components/ScopeCard.tsx
@@ -1,5 +1,5 @@
 import MetaMaskOpenRPCDocument from '@metamask/api-specs';
-import type { Scope, SessionData } from '@metamask/connect/multichain';
+import type { Scope, SessionData } from '@metamask/connect';
 import {
   type CaipAccountAddress,
   type CaipAccountId,

--- a/playground/multichain-react-playground/src/sdk/SDKProvider.tsx
+++ b/playground/multichain-react-playground/src/sdk/SDKProvider.tsx
@@ -8,7 +8,7 @@ import {
   type Scope,
   type SDKState,
   type SessionData,
-} from '@metamask/connect-multichain';
+} from '@metamask/connect/multichain';
 import type { CaipAccountId } from '@metamask/utils';
 import type React from 'react';
 import {

--- a/playground/multichain-react-playground/src/sdk/SDKProvider.tsx
+++ b/playground/multichain-react-playground/src/sdk/SDKProvider.tsx
@@ -8,7 +8,7 @@ import {
   type Scope,
   type SDKState,
   type SessionData,
-} from '@metamask/connect/multichain';
+} from '@metamask/connect';
 import type { CaipAccountId } from '@metamask/utils';
 import type React from 'react';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,7 +4466,7 @@ __metadata:
   resolution: "@metamask/multichain-node-playground@workspace:playground/multichain-node-playground"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/connect": "workspace:^"
+    "@metamask/connect-multichain": "workspace:^"
     "@types/inquirer": "npm:^8.2.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,11 +4077,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/connect@workspace:packages/connect":
+"@metamask/connect@workspace:^, @metamask/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@metamask/connect@workspace:packages/connect"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/connect-evm": "workspace:^"
     "@metamask/connect-multichain": "workspace:^"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"
@@ -4465,7 +4466,7 @@ __metadata:
   resolution: "@metamask/multichain-node-playground@workspace:playground/multichain-node-playground"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/connect-multichain": "workspace:^"
+    "@metamask/connect": "workspace:^"
     "@types/inquirer": "npm:^8.2.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.9.0"
@@ -4546,7 +4547,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.0.0"
     "@metamask/api-specs": "npm:^0.14.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/connect-multichain": "workspace:^"
+    "@metamask/connect": "workspace:^"
     "@metamask/utils": "npm:^11.8.1"
     "@open-rpc/meta-schema": "npm:^1.14.9"
     "@open-rpc/schema-utils-js": "npm:^2.0.5"
@@ -20099,7 +20100,7 @@ __metadata:
   resolution: "legacy-evm-react-vite@workspace:playground/legacy-evm-react-vite-playground"
   dependencies:
     "@eslint/js": "npm:^9.13.0"
-    "@metamask/connect-evm": "workspace:^"
+    "@metamask/connect": "workspace:^"
     "@types/react": "npm:^18.3.1"
     "@types/react-dom": "npm:^18.3.1"
     "@vitejs/plugin-react": "npm:^4.3.3"


### PR DESCRIPTION
## Unified Connect Package API with Subpath Exports

Consolidates the Connect API by adding subpath exports to `@metamask/connect`, allowing imports from a single package instead of separate packages.

### Changes

- Added subpath exports to `@metamask/connect`:
  - `@metamask/connect/evm` - re-exports from `@metamask/connect-evm`
- Updated all playground examples to use the new subpath exports:
  - `legacy-evm-react-vite-playground` - now uses `@metamask/connect/evm`
  - `multichain-react-playground` - now uses `@metamask/connect/multichain`
  - ~`multichain-node-playground` - now uses `@metamask/connect/multichain`~ (couldn't get this one to work nicely)
- Updated build configuration to include the new entry points and externalize dependencies

### Benefits

- Single package entry point (`@metamask/connect`) for all Connect functionality
- Backward compatible - direct package imports still work
- Cleaner import paths: `@metamask/connect/evm` instead of `@metamask/connect-evm`

### Migration

No breaking changes. Existing code using direct package imports continues to work. New code can use the unified subpath exports.