### PR TITLE
Release/7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/metamask-connect-monorepo",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -7,12 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- setup/configure @metamask/connect root package + repoint playgrounds (ex node playground) to @metamask/connect ([#70](https://github.com/MetaMask/metamask-connect-monorepo/pull/70))
-- align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
-- feat: wagmi connector ([#31](https://github.com/MetaMask/metamask-connect-monorepo/pull/31))
-- add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
+## [0.2.0]
 
 ### Added
 
@@ -28,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect@0.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect@0.1.0...@metamask/connect@0.2.0
 [0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/connect@0.1.0

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- setup/configure @metamask/connect root package + repoint playgrounds (ex node playground) to @metamask/connect ([#70](https://github.com/MetaMask/metamask-connect-monorepo/pull/70))
+- align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
+- feat: wagmi connector ([#31](https://github.com/MetaMask/metamask-connect-monorepo/pull/31))
+- add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
+
 ### Added
 
 - Added subpath exports to `@metamask/connect` package: `@metamask/connect/evm` - unified export for EVM functionality

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Easily connect to MetaMask and its ecosystem from any application and platform",
   "keywords": [
     "MetaMask",

--- a/playground/multichain-react-playground/CHANGELOG.md
+++ b/playground/multichain-react-playground/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- setup/configure @metamask/connect root package + repoint playgrounds (ex node playground) to @metamask/connect ([#70](https://github.com/MetaMask/metamask-connect-monorepo/pull/70))
-
 ### Changed
 
 - Bump `@types/jest` from ^28.1.6 to ^29.5.14 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))

--- a/playground/multichain-react-playground/CHANGELOG.md
+++ b/playground/multichain-react-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- setup/configure @metamask/connect root package + repoint playgrounds (ex node playground) to @metamask/connect ([#70](https://github.com/MetaMask/metamask-connect-monorepo/pull/70))
+
 ### Changed
 
 - Bump `@types/jest` from ^28.1.6 to ^29.5.14 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))


### PR DESCRIPTION
# @metamask/connect

## [0.2.0]

### Added

- Added subpath exports to `@metamask/connect` package: `@metamask/connect/evm` - unified export for EVM functionality
