### PR TITLE
fix deploy workflow

### DIFF
--- a/.github/workflows/deploy-wagmi-to-gh-pages.yml
+++ b/.github/workflows/deploy-wagmi-to-gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
   deploy-wagmi-to-gh-pages:
     name: Deploy Wagmi Integration to GitHub Pages
     runs-on: ubuntu-latest
-    environment: gh-pages
+    environment: github-pages
     permissions:
       contents: write
 


### PR DESCRIPTION
The correct environment name for the deploy workflow is actually named `github-pages`