### PR TITLE
fix: Fix initial deeplink connection rejection not updating connection status to disconnected

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reverted: Fix mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#74](https://github.com/MetaMask/connect-monorepo/pull/74))
+- Fix rejections of the initial permission approval for deeplink connections not correctly updating the connection status to disconnected ([#75](https://github.com/MetaMask/connect-monorepo/pull/75))
 
 ## [0.3.2]
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -454,7 +454,7 @@ export class MultichainSDK extends MultichainCore {
     return new Promise<void>(async (resolve, reject) => {
       // Handle the response to the initial wallet_createSession request
       const dappClientMessageHandler = (payload: unknown) => {
-        if (typeof payload !== 'object' || payload === null || !('data' in payload) {
+        if (typeof payload !== 'object' || payload === null || !('data' in payload)) {
           return;
         }
         const data = payload.data as { result?: SessionData , error?: unknown };

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -453,8 +453,11 @@ export class MultichainSDK extends MultichainCore {
   ) {
     return new Promise<void>(async (resolve, reject) => {
       // Handle the response to the initial wallet_createSession request
-      const dappClientMessageHandler = (payload: any) => {
-        const data = payload.data as Record<string, unknown>;
+      const dappClientMessageHandler = (payload: unknown) => {
+        if (typeof payload !== 'object' || payload === null || !('data' in payload) {
+          return;
+        }
+        const data = payload.data as { result?: SessionData , error?: unknown };
         if (typeof data === 'object' && data !== null) {
           // optimistically assume any error is due to the initial wallet_createSession request failure
           if (data.error) {
@@ -462,7 +465,7 @@ export class MultichainSDK extends MultichainCore {
             return reject(data.error);
           }
           // if sessionScopes is set in the result, then this is a response to wallet_createSession
-          if ((data?.result as unknown as SessionData)?.sessionScopes) {
+          if (data?.result?.sessionScopes) {
             this.dappClient.off('message', dappClientMessageHandler);
             return; // unsure if we need to call resolve here like we do above for reject()
           }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -452,25 +452,23 @@ export class MultichainSDK extends MultichainCore {
     caipAccountIds: CaipAccountId[],
   ) {
     return new Promise<void>(async (resolve, reject) => {
-      this.dappClient.on('message', (payload: any) => {
+      // Handle the response to the initial wallet_createSession request
+      const dappClientMessageHandler = (payload: any) => {
         const data = payload.data as Record<string, unknown>;
         if (typeof data === 'object' && data !== null) {
-          if ('method' in data && data.method === 'wallet_createSession') {
-            if (data.error) {
-              this.state = 'loaded';
-              return reject(data.error);
-            }
-            // TODO: is it .params or .result?
-            const session = ((data as any).params ??
-              (data as any).result) as SessionData;
-            if (session) {
-              // Initial request will be what resolves the connection when options is specified
-              this.options.transport?.onNotification?.(payload.data);
-              this.emit('wallet_sessionChanged', session);
-            }
+          // optimistically assume any error is due to the initial wallet_createSession request failure
+          if (data.error) {
+            this.dappClient.off('message', dappClientMessageHandler);
+            return reject(data.error);
+          }
+          // if sessionScopes is set in the result, then this is a response to wallet_createSession
+          if ((data?.result as unknown as SessionData)?.sessionScopes) {
+            this.dappClient.off('message', dappClientMessageHandler);
+            return; // unsure if we need to call resolve here like we do above for reject()
           }
         }
-      });
+      };
+      this.dappClient.on('message', dappClientMessageHandler);
 
       let timeout: NodeJS.Timeout | undefined;
 
@@ -691,7 +689,6 @@ export class MultichainSDK extends MultichainCore {
     await this.__transport?.disconnect();
     await this.storage.removeTransport();
 
-    this.emit('wallet_sessionChanged', undefined);
     this.emit('stateChanged', 'disconnected');
 
     this.listener = undefined;


### PR DESCRIPTION
## Explanation

When making a deeplink connection, the rejection of the initial wallet_createSession request was not causing the dapp to correctly update it's local connection status to be "disconnected". This PR fixes that by updating the logic in the dappClient listener.

To test:
1. In the native browser
2. Connect
3. Accept the deeplink
4. Reject the approval
5. Return to the dapp
6. The dapp should show `status: disconnected` and allow you to attempt to reconnect again

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
