### PR TITLE
fix: changelog repo url

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -113,10 +113,10 @@ If you're developing your project locally and want to test changes to a package,
 
       > **Example:**
       >
-      > - If your project uses Yarn, `@metamask/wallet-utils` is listed in dependencies at `^1.1.4`, and your clone of this repo (`metamask-connect-monorepo`) is at the same level as your project, add the following to `resolutions`:
+      > - If your project uses Yarn, `@metamask/wallet-utils` is listed in dependencies at `^1.1.4`, and your clone of this repo (`connect-monorepo`) is at the same level as your project, add the following to `resolutions`:
       >
       >   ```
-      >   "@metamask/wallet-utils@^1.1.4": "file:../metamask-connect-monorepo/packages/controller-utils"
+      >   "@metamask/wallet-utils@^1.1.4": "file:../connect-monorepo/packages/controller-utils"
       >   ```
 
    4. Run `yarn install`.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@metamask/metamask-connect-monorepo",
+  "name": "@metamask/connect-monorepo",
   "version": "7.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "files": [],
   "workspaces": [

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
+- Add changelog formatting script ([#44](https://github.com/MetaMask/connect-monorepo/pull/44))
 
 ### Changed
 
-- Align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
+- Align package versions ([#48](https://github.com/MetaMask/connect-monorepo/pull/48))
 
 ## [0.1.0]
 
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.1.1...@metamask/analytics@0.2.0
-[0.1.1]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/analytics@0.1.0...@metamask/analytics@0.1.1
-[0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/analytics@0.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/analytics@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/analytics@0.1.1...@metamask/analytics@0.2.0
+[0.1.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/analytics@0.1.0...@metamask/analytics@0.1.1
+[0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/analytics@0.1.0

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -12,4 +12,4 @@ or
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/analytics#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/analytics#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -21,6 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#58](https://github.com/MetaMask/connect-monorepo/pull/58))
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-evm@0.1.1...HEAD
-[0.1.1]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-evm@0.1.0...@metamask/connect-evm@0.1.1
-[0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/connect-evm@0.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@0.1.1...HEAD
+[0.1.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@0.1.0...@metamask/connect-evm@0.1.1
+[0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/connect-evm@0.1.0

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -127,7 +127,7 @@ yarn workspace @metamask/connect-evm run test
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).
 
 ## License
 

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/connect-evm#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/connect-evm#readme",
   "bugs": {
     "url": ""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add connection id to simple deeplinks ([#63](https://github.com/MetaMask/metamask-connect-monorepo/pull/63))
+- Add connection id to simple deeplinks ([#63](https://github.com/MetaMask/connect-monorepo/pull/63))
 
 ## [0.3.1]
 
@@ -49,21 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `removeListener`, `once` and `listenerCount` function to internal `EventEmitter` ([#31](https://github.com/MetaMask/connect-monorepo/pull/31))
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
-- Add support for read only RPC calls ([#33](https://github.com/MetaMask/metamask-connect-monorepo/pull/33))
+- Add changelog formatting script ([#44](https://github.com/MetaMask/connect-monorepo/pull/44))
+- Add support for read only RPC calls ([#33](https://github.com/MetaMask/connect-monorepo/pull/33))
 
 ### Changed
 
-- Align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
+- Align package versions ([#48](https://github.com/MetaMask/connect-monorepo/pull/48))
 - Rename `preferDesktop` flag to `showInstallModal` ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 - `MetaMaskConnect.provider` will be defined if there is a previous session that can be restored. Previously `connect()` had to be called explicitly first. ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
-- **BREAKING** Rename `readonlyRpcMap` to `supportedNetworks` ([#37](https://github.com/MetaMask/metamask-connect-monorepo/pull/37))
-- **BREAKING** Remove api.infuraAPIKey SDK param. Export getInfuraRpcUrls. Add env to playgrounds ([#19](https://github.com/MetaMask/metamask-connect-monorepo/pull/19))
+- **BREAKING** Rename `readonlyRpcMap` to `supportedNetworks` ([#37](https://github.com/MetaMask/connect-monorepo/pull/37))
+- **BREAKING** Remove api.infuraAPIKey SDK param. Export getInfuraRpcUrls. Add env to playgrounds ([#19](https://github.com/MetaMask/connect-monorepo/pull/19))
 
 ### Fixed
 
-- Fix switch to Bowser’s default export to fix Vite build ([#26](https://github.com/MetaMask/metamask-connect-monorepo/pull/26))
-- Fix reconnect `dappClient` on resumed session ([#43](https://github.com/MetaMask/metamask-connect-monorepo/pull/43))
+- Fix switch to Bowser’s default export to fix Vite build ([#26](https://github.com/MetaMask/connect-monorepo/pull/26))
+- Fix reconnect `dappClient` on resumed session ([#43](https://github.com/MetaMask/connect-monorepo/pull/43))
 - Fix install modal not rendering when called from Vite application ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 - Fix requests not being sent to the mobile wallet with proper wrapping metadata ([#28](https://github.com/MetaMask/connect-monorepo/pull/28))
 - Fix connections made from within the MetaMask Mobile In-App Browser ([#21](https://github.com/MetaMask/connect-monorepo/pull/21))
@@ -76,10 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.3.2...HEAD
-[0.3.2]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.3.1...@metamask/connect-multichain@0.3.2
-[0.3.1]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.3.0...@metamask/connect-multichain@0.3.1
-[0.3.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.2.1...@metamask/connect-multichain@0.3.0
-[0.2.1]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.2.0...@metamask/connect-multichain@0.2.1
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect-multichain@0.1.0...@metamask/connect-multichain@0.2.0
-[0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/connect-multichain@0.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.3.2...HEAD
+[0.3.2]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.3.1...@metamask/connect-multichain@0.3.2
+[0.3.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.3.0...@metamask/connect-multichain@0.3.1
+[0.3.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.2.1...@metamask/connect-multichain@0.3.0
+[0.2.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.2.0...@metamask/connect-multichain@0.2.1
+[0.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.1.0...@metamask/connect-multichain@0.2.0
+[0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/connect-multichain@0.1.0

--- a/packages/connect-multichain/README.md
+++ b/packages/connect-multichain/README.md
@@ -12,4 +12,4 @@ or
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/multichain#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -23,6 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/connect@0.1.0...@metamask/connect@0.2.0
-[0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/connect@0.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect@0.1.0...@metamask/connect@0.2.0
+[0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/connect@0.1.0

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -12,4 +12,4 @@ or
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/connect#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/connect#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/multichain-ui/CHANGELOG.md
+++ b/packages/multichain-ui/CHANGELOG.md
@@ -9,17 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING** Change stencil loader export path to `./loader` for previous paths `./dist/loader/index.js` and `./dist/loader/index.cjs.js` ([#73](https://github.com/MetaMask/metamask-connect-monorepo/pull/73))
+- **BREAKING** Change stencil loader export path to `./loader` for previous paths `./dist/loader/index.js` and `./dist/loader/index.cjs.js` ([#73](https://github.com/MetaMask/connect-monorepo/pull/73))
 
 ## [0.2.0]
 
 ### Added
 
-- Add changelog formatting script ([#44](https://github.com/MetaMask/metamask-connect-monorepo/pull/44))
+- Add changelog formatting script ([#44](https://github.com/MetaMask/connect-monorepo/pull/44))
 
 ### Changed
 
-- Align package versions ([#48](https://github.com/MetaMask/metamask-connect-monorepo/pull/48))
+- Align package versions ([#48](https://github.com/MetaMask/connect-monorepo/pull/48))
 - **BREAKING** Rename `preferDesktop` flag to `showInstallModal` ([#42](https://github.com/MetaMask/connect-monorepo/pull/42))
 
 ## [0.1.0]
@@ -28,6 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/multichain-ui@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/metamask-connect-monorepo/compare/@metamask/multichain-ui@0.1.0...@metamask/multichain-ui@0.2.0
-[0.1.0]: https://github.com/MetaMask/metamask-connect-monorepo/releases/tag/@metamask/multichain-ui@0.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/multichain-ui@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/multichain-ui@0.1.0...@metamask/multichain-ui@0.2.0
+[0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/multichain-ui@0.1.0

--- a/packages/multichain-ui/package.json
+++ b/packages/multichain-ui/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/multichain-ui#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain-ui#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/playground/multichain-node-playground/CHANGELOG.md
+++ b/playground/multichain-node-playground/CHANGELOG.md
@@ -15,4 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `tsup` from ^8.0.1 to ^8.4.0 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `typescript` from ~5.2.2 to ~5.9.2 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/playground/multichain-node-playground/package.json
+++ b/playground/multichain-node-playground/package.json
@@ -7,13 +7,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/multichain-node-playground#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain-node-playground#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/playground/multichain-react-native-playground/CHANGELOG.md
+++ b/playground/multichain-react-native-playground/CHANGELOG.md
@@ -14,4 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `react` from 19.1.0 to ^18.3.1 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `react-dom` from 19.1.0 to ^18.3.1 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/playground/multichain-react-native-playground/package.json
+++ b/playground/multichain-react-native-playground/package.json
@@ -7,13 +7,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/multichain-react-native-playground#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain-react-native-playground#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "main": "expo-router/entry",

--- a/playground/multichain-react-playground/CHANGELOG.md
+++ b/playground/multichain-react-playground/CHANGELOG.md
@@ -24,4 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make sure TailwindCSS configs look at package's local config instead of a parent monorepo config ([#25](https://github.com/MetaMask/connect-monorepo/pull/25))
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/playground/multichain-react-playground/package.json
+++ b/playground/multichain-react-playground/package.json
@@ -8,11 +8,11 @@
   ],
   "homepage": ".",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "exports": {

--- a/scripts/create-package/package-template/CHANGELOG.md
+++ b/scripts/create-package/package-template/CHANGELOG.md
@@ -13,4 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@types/jest` from ^27.4.1 to ^29.5.14 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `typescript` from ~5.2.2 to ~5.9.2 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 
-[Unreleased]: https://github.com/MetaMask/metamask-connect-monorepo/
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/scripts/create-package/package-template/README.md
+++ b/scripts/create-package/package-template/README.md
@@ -12,4 +12,4 @@ or
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/metamask-connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).

--- a/scripts/create-package/package-template/package.json
+++ b/scripts/create-package/package-template/package.json
@@ -6,13 +6,13 @@
     "MetaMask",
     "Ethereum"
   ],
-  "homepage": "https://github.com/MetaMask/metamask-connect-monorepo/tree/main/packages/PACKAGE_DIRECTORY_NAME#readme",
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/packages/PACKAGE_DIRECTORY_NAME#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo/issues"
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-connect-monorepo.git"
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/scripts/generate-preview-build-message.ts
+++ b/scripts/generate-preview-build-message.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
   }
 
   const previewBuildMessage = `
-Preview builds have been published. [See these instructions](https://github.com/MetaMask/metamask-connect-monorepo/blob/main/docs/contributing.md#using-packages-in-other-projects-during-developmenttesting) for more information about preview builds.
+Preview builds have been published. [See these instructions](https://github.com/MetaMask/connect-monorepo/blob/main/docs/contributing.md#using-packages-in-other-projects-during-developmenttesting) for more information about preview builds.
 
 <details>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,6 +4036,58 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/connect-monorepo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/connect-monorepo@workspace:."
+  dependencies:
+    "@babel/core": "npm:^7.28.4"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
+    "@babel/preset-typescript": "npm:^7.23.3"
+    "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@metamask/create-release-branch": "npm:^4.1.3"
+    "@metamask/eslint-config": "npm:^14.0.0"
+    "@metamask/eslint-config-jest": "npm:^14.0.0"
+    "@metamask/eslint-config-nodejs": "npm:^14.0.0"
+    "@metamask/eslint-config-typescript": "npm:^14.0.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@ts-bridge/cli": "npm:^0.5.1"
+    "@types/jest": "npm:^29.5.14"
+    "@types/lodash": "npm:^4.14.191"
+    "@types/node": "npm:^22.9.0"
+    "@types/semver": "npm:^7"
+    "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
+    "@typescript-eslint/parser": "npm:^5.62.0"
+    "@yarnpkg/types": "npm:^4.0.0"
+    babel-jest: "npm:^27.5.1"
+    depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.25.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-import-resolver-typescript: "npm:^3.6.3"
+    eslint-interactive: "npm:^10.8.0"
+    eslint-plugin-import: "npm:2.26.0"
+    eslint-plugin-import-x: "npm:^4.3.0"
+    eslint-plugin-jest: "npm:^28.11.0"
+    eslint-plugin-jsdoc: "npm:^50.2.4"
+    eslint-plugin-n: "npm:^17.10.3"
+    eslint-plugin-prettier: "npm:^5.2.1"
+    eslint-plugin-promise: "npm:^7.1.0"
+    execa: "npm:^5.0.0"
+    jest: "npm:^29.6.4"
+    jest-silent-reporter: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+    prettier: "npm:^3.3.3"
+    prettier-2: "npm:prettier@^2.8.8"
+    prettier-plugin-packagejson: "npm:^2.4.5"
+    rimraf: "npm:^5.0.5"
+    semver: "npm:^7.6.3"
+    simple-git-hooks: "npm:^2.8.0"
+    tsx: "npm:^4.19.3"
+    typescript: "npm:~5.9.2"
+    typescript-eslint: "npm:^8.10.0"
+    yargs: "npm:^17.7.2"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/connect-multichain@workspace:^, @metamask/connect-multichain@workspace:packages/connect-multichain":
   version: 0.0.0-use.local
   resolution: "@metamask/connect-multichain@workspace:packages/connect-multichain"
@@ -4357,58 +4409,6 @@ __metadata:
   checksum: 10/84e9f4193646d749c7260a4958b13974b3c8738cc2e414116279ed31734e1edba687ff56ddbfdb75033bce30aaa9eeb7c391bccb87a66dbc99a902882271f673
   languageName: node
   linkType: hard
-
-"@metamask/metamask-connect-monorepo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@metamask/metamask-connect-monorepo@workspace:."
-  dependencies:
-    "@babel/core": "npm:^7.28.4"
-    "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
-    "@babel/preset-typescript": "npm:^7.23.3"
-    "@lavamoat/allow-scripts": "npm:^3.0.4"
-    "@metamask/create-release-branch": "npm:^4.1.3"
-    "@metamask/eslint-config": "npm:^14.0.0"
-    "@metamask/eslint-config-jest": "npm:^14.0.0"
-    "@metamask/eslint-config-nodejs": "npm:^14.0.0"
-    "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.5.1"
-    "@types/jest": "npm:^29.5.14"
-    "@types/lodash": "npm:^4.14.191"
-    "@types/node": "npm:^22.9.0"
-    "@types/semver": "npm:^7"
-    "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
-    "@typescript-eslint/parser": "npm:^5.62.0"
-    "@yarnpkg/types": "npm:^4.0.0"
-    babel-jest: "npm:^27.5.1"
-    depcheck: "npm:^1.4.7"
-    eslint: "npm:^9.25.0"
-    eslint-config-prettier: "npm:^9.1.0"
-    eslint-import-resolver-typescript: "npm:^3.6.3"
-    eslint-interactive: "npm:^10.8.0"
-    eslint-plugin-import: "npm:2.26.0"
-    eslint-plugin-import-x: "npm:^4.3.0"
-    eslint-plugin-jest: "npm:^28.11.0"
-    eslint-plugin-jsdoc: "npm:^50.2.4"
-    eslint-plugin-n: "npm:^17.10.3"
-    eslint-plugin-prettier: "npm:^5.2.1"
-    eslint-plugin-promise: "npm:^7.1.0"
-    execa: "npm:^5.0.0"
-    jest: "npm:^29.6.4"
-    jest-silent-reporter: "npm:^0.5.0"
-    lodash: "npm:^4.17.21"
-    prettier: "npm:^3.3.3"
-    prettier-2: "npm:prettier@^2.8.8"
-    prettier-plugin-packagejson: "npm:^2.4.5"
-    rimraf: "npm:^5.0.5"
-    semver: "npm:^7.6.3"
-    simple-git-hooks: "npm:^2.8.0"
-    tsx: "npm:^4.19.3"
-    typescript: "npm:~5.9.2"
-    typescript-eslint: "npm:^8.10.0"
-    yargs: "npm:^17.7.2"
-  languageName: unknown
-  linkType: soft
 
 "@metamask/mobile-wallet-protocol-core@npm:^0.2.0":
   version: 0.2.0


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fixes some changelogs being incorrectly pointed at `(github)/metamask-connect-monorepo`, where actual URL is `(github)/connect-monorepo` 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
