### PR TITLE
fix: clean up dangling event listeners after auditing event listeners

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix duplicate `onNotification` listener ([#81](https://github.com/MetaMask/connect-monorepo/pull/81))
+
 ## [0.1.1]
 
 ### Fixed

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix potential listener leak on `MultichainCore.deeplinkConnect` and duplicate `dappClient.on('message')` on `MWPTransport` ([#81](https://github.com/MetaMask/connect-monorepo/pull/81))
 - Reverted: Fix mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#74](https://github.com/MetaMask/connect-monorepo/pull/74))
 - Fix rejections of the initial permission approval for deeplink connections not correctly updating the connection status to disconnected ([#75](https://github.com/MetaMask/connect-monorepo/pull/75))
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -511,6 +511,7 @@ export class MultichainSDK extends MultichainCore {
           reject(error);
         })
         .finally(() => {
+          this.dappClient.off('message', dappClientMessageHandler);
           if (timeout) {
             clearTimeout(timeout);
           }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -508,10 +508,10 @@ export class MultichainSDK extends MultichainCore {
         .then(resolve)
         .catch((error) => {
           this.storage.removeTransport();
+          this.dappClient.off('message', dappClientMessageHandler);
           reject(error);
         })
         .finally(() => {
-          this.dappClient.off('message', dappClientMessageHandler);
           if (timeout) {
             clearTimeout(timeout);
           }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -428,11 +428,12 @@ export class MWPTransport implements ExtendedTransport {
     });
 
     return connectionPromise
-      .catch(() => {
+      .catch((error) => {
         if (initialConnectionMessageHandler) {
           this.dappClient.off('message', initialConnectionMessageHandler);
           initialConnectionMessageHandler = undefined;
         }
+        throw error;
       })
       .finally(() => {
         if (timeout) {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -418,9 +418,6 @@ export class MWPTransport implements ExtendedTransport {
       }
 
       timeout = setTimeout(() => {
-        if (initialConnectionMessageHandler) {
-          this.dappClient.off('message', initialConnectionMessageHandler);
-        }
         reject(new TransportTimeoutError());
       }, this.options.connectionTimeout);
 
@@ -429,15 +426,15 @@ export class MWPTransport implements ExtendedTransport {
 
     return connectionPromise
       .catch((error) => {
-        if (initialConnectionMessageHandler) {
-          this.dappClient.off('message', initialConnectionMessageHandler);
-          initialConnectionMessageHandler = undefined;
-        }
         throw error;
       })
       .finally(() => {
         if (timeout) {
           clearTimeout(timeout);
+        }
+        if (initialConnectionMessageHandler) {
+          this.dappClient.off('message', initialConnectionMessageHandler);
+          initialConnectionMessageHandler = undefined;
         }
       });
   }


### PR DESCRIPTION
## Explanation

This PR proposes a clean up to a couple dangling event listeners we had across `connect-multichain`, `connect-evm` and mwp transport.

### 1. ✅ connect-evm/src/connect.ts - Fixed duplicate `onNotification` listener
### 2. ✅ MultichainCore deeplinkConnect - Fixed potential listener leak
### 3. ✅ MWPTransport - Fixed duplicate `dappClient.on('message')` listener

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-885

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
