### PR TITLE
chore: specify minimum node version `20.19.0` in root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "packageManager": "yarn@4.9.2",
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
## Explanation

Currently we have a root `.nvmrc` file specifying the minimum required / recommended version of node that’s compatible with the packages in our `connect-monorepo`.

However, we don’t want to rely just on `.nvmrc`, so we need to set the engine requirements in the root `package.json` in the following PR.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-816

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
