### PR TITLE
fix: Fix stuck connection by attempting to clear any old state before new connection attempt

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reverted: Fix mobile deeplink bug that occurred when `MultichainSDK.connect()` was called and the transport was already connected ([#74](https://github.com/MetaMask/connect-monorepo/pull/74))
 - Fix rejections of the initial permission approval for deeplink connections not correctly updating the connection status to disconnected ([#75](https://github.com/MetaMask/connect-monorepo/pull/75))
+- Fix `connect()` not working for mobile deeplink and QR connections when a previous connection attempt gets stuck ([#85](https://github.com/MetaMask/connect-monorepo/pull/85))
 
 ## [0.3.2]
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -590,6 +590,9 @@ export class MultichainSDK extends MultichainCore {
     caipAccountIds: CaipAccountId[],
     forceRequest?: boolean,
   ): Promise<void> {
+    if (this.state !== 'connected') {
+      await this.disconnect();
+    }
     const { ui } = this.options;
     const platformType = getPlatformType();
     const isWeb =


### PR DESCRIPTION
## Explanation

Fixes stuck MWP connections that cannot be resolved using the disconnect and connect buttons in the wagmi react demo. This is partly because wagmi does not actually call `disconnect()` on the MM Connect instance if it has not self reported to be connected. This leaves the user soft locked if their MWP connection fails to establish as pressing connect with try to reuse the existing broken connection.

This PR fixes that by calling `disconnect()` internally if the connection status is anything but `connected` thus theoretically getting into a clean state before establishing a whole new connection.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
