### PR TITLE
fix: Fix `MultichainSDK.create()` getting blocked by connection resumption

### DIFF
--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -264,7 +264,6 @@ export class MultichainSDK extends MultichainCore {
         logger('MetaMaskSDK: init already initialized');
       } else {
         await this.#setupAnalytics();
-        await this.#setupTransport();
         if (this.options.analytics?.enabled) {
           try {
             const baseProps = await getBaseAnalyticsProperties(
@@ -280,12 +279,15 @@ export class MultichainSDK extends MultichainCore {
           // @ts-expect-error mmsdk should be accessible
           window.mmsdk = this;
         }
+        this.#setupTransport().catch(async () => {
+          await this.storage.removeTransport();
+          this.state = 'pending';
+        });
       }
     } catch (error) {
-      await this.storage.removeTransport();
-      this.state = 'pending';
       logger('MetaMaskSDK error during initialization', error);
     }
+
   }
 
   async #createDappClient(): Promise<DappClient> {


### PR DESCRIPTION
## Explanation

Fixes an issue with `MultichainSDK.create()` not returning until any pre-existing connection have been re-established. This is an issue for MWP (specifically on android simulator on chrome, we're not sure why) where the `#setupTransport()` method called via `#init()` from `create()` takes a long time before failing. We don't see the same problem on physical android devices, on ios simulator safari, nor on ios physical device chrome. It seems exclusive to android simulator.

Another potential way to tackle this bug would be to figure out why the MwpTransport.connect() takes so long to resolve on Android simulator but not other environments, but that still leaves the question why we are blocking the `create()` method on reconnection. 


**Repro steps:**
1. On Android Simulator Chrome, open the wagmi integration test dapp
2. Connect, open the deeplink, but do not accept or reject it in the wallet
3. Return to the dapp
4. Refresh the page
5. Afterwards, disconnect/connect buttons will seem unresponsive until the initial connection resumption attempt resolves


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
