### PR TITLE
chore: fix package consistency across monorepo

### DIFF
--- a/integrations/wagmi/package.json
+++ b/integrations/wagmi/package.json
@@ -15,14 +15,14 @@
     "@tanstack/react-query-persist-client": "5.0.5",
     "@wagmi/core": "^2.22.1",
     "idb-keyval": "^6.2.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "viem": "2.*",
     "wagmi": "^2.19.2"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "5.0.5",
-    "@types/react": "^18.3.1",
+    "@types/react": "19.1.0",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "@wagmi/cli": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "semver": "^7.6.3",
     "simple-git-hooks": "^2.8.0",
     "tsx": "^4.19.3",
-    "typescript": "~5.9.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.10.0",
     "yargs": "^17.7.2"
   },

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -59,11 +59,11 @@
     "tsup": "^8.4.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.1.2"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -68,11 +68,11 @@
     "tsup": "^8.4.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.1.2"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -98,14 +98,14 @@
     "tsup": "^8.4.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.23"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -80,10 +80,10 @@
     "tsup": "^8.4.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/multichain-ui/package.json
+++ b/packages/multichain-ui/package.json
@@ -88,10 +88,10 @@
     "size-limit": "^11.1.6",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "lavamoat": {
     "allowScripts": {

--- a/playground/legacy-evm-react-vite-playground/package.json
+++ b/playground/legacy-evm-react-vite-playground/package.json
@@ -13,20 +13,20 @@
   },
   "dependencies": {
     "@metamask/connect": "workspace:^",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "vite-plugin-node-polyfills": "^0.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
-    "@types/react": "^18.3.1",
+    "@types/react": "19.1.0",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.13",
     "globals": "^15.11.0",
-    "typescript": "~5.9.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.10.0",
     "vite": "^5.4.20"
   }

--- a/playground/multichain-node-playground/package.json
+++ b/playground/multichain-node-playground/package.json
@@ -49,10 +49,10 @@
     "tsup": "^8.4.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public",

--- a/playground/multichain-react-native-playground/README.md
+++ b/playground/multichain-react-native-playground/README.md
@@ -14,7 +14,7 @@ This React Native application is a complete port of the multichain-react web tes
 
 ## Prerequisites
 
-- Node.js (^18.18 || >=20)
+- Node.js (>=20.19.0)
 - Yarn (v4.1.1+)
 - Expo CLI
 - iOS Simulator (for iOS development) or Android Studio (for Android development)

--- a/playground/multichain-react-native-playground/package.json
+++ b/playground/multichain-react-native-playground/package.json
@@ -82,10 +82,10 @@
     "cross-env": "^10.1.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
-    "typescript": "~5.9.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "restricted",

--- a/playground/multichain-react-playground/package.json
+++ b/playground/multichain-react-playground/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "@metamask/connect": "workspace:^",
     "@metamask/utils": "^11.8.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "@craco/craco": "^7.1.0",
@@ -71,7 +71,7 @@
     "@types/chrome": "^0.0.279",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.9.0",
-    "@types/react": "^18.3.1",
+    "@types/react": "19.1.0",
     "@yarnpkg/types": "^4.0.0",
     "autoprefixer": "^10.4.21",
     "buffer": "^6.0.3",
@@ -90,11 +90,11 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "~5.9.2"
+    "typescript": "^5.9.3"
   },
   "packageManager": "yarn@4.1.1",
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "restricted",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -23,6 +23,7 @@ const { inspect } = require('util');
  * This should trend towards empty.
  */
 const ALLOWED_INCONSISTENT_DEPENDENCIES = {
+  '@metamask/connect-evm': 'workspace:^',
   '@metamask/connect-multichain': 'workspace:^',
   '@metamask/multichain-ui': 'workspace:^',
   '@metamask/analytics': 'workspace:^',
@@ -195,8 +196,8 @@ module.exports = defineConfig({
         expectWorkspaceField(workspace, 'packageManager', 'yarn@4.9.2');
       }
 
-      // All packages must specify a minimum Node.js version of 18.18.
-      expectWorkspaceField(workspace, 'engines.node', '^18.18 || >=20');
+      // All packages must specify a minimum Node.js version of 20.19.0.
+      expectWorkspaceField(workspace, 'engines.node', '>=20.19.0');
 
       // All non-root public packages should be published to the NPM registry;
       // all non-root private packages should not.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,7 +3946,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
     vitest: "npm:^3.1.2"
   languageName: unknown
   linkType: soft
@@ -4031,7 +4031,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
     vitest: "npm:^3.1.2"
   languageName: unknown
   linkType: soft
@@ -4082,7 +4082,7 @@ __metadata:
     semver: "npm:^7.6.3"
     simple-git-hooks: "npm:^2.8.0"
     tsx: "npm:^4.19.3"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.10.0"
     yargs: "npm:^17.7.2"
   languageName: unknown
@@ -4120,7 +4120,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
     uuid: "npm:^11.1.0"
     vitest: "npm:^3.1.2"
     ws: "npm:^8.18.3"
@@ -4142,7 +4142,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -4481,7 +4481,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -4534,7 +4534,7 @@ __metadata:
     react-native-screens: "npm:~4.16.0"
     react-native-web: "npm:^0.21.0"
     react-native-worklets: "npm:^0.5.0"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -4558,7 +4558,7 @@ __metadata:
     "@types/chrome": "npm:^0.0.279"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.9.0"
-    "@types/react": "npm:^18.3.1"
+    "@types/react": "npm:19.1.0"
     "@yarnpkg/types": "npm:^4.0.0"
     autoprefixer: "npm:^10.4.21"
     buffer: "npm:^6.0.3"
@@ -4570,8 +4570,8 @@ __metadata:
     prettier: "npm:^3.3.3"
     prettier-plugin-packagejson: "npm:^2.4.5"
     process: "npm:^0.11.10"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
+    react: "npm:19.1.0"
+    react-dom: "npm:19.1.0"
     react-scripts: "npm:5.0.1"
     serve: "npm:^14.2.5"
     tailwindcss: "npm:^4.1.11"
@@ -4579,7 +4579,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -4604,7 +4604,7 @@ __metadata:
     size-limit: "npm:^11.1.6"
     typedoc: "npm:^0.28.14"
     typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -8391,13 +8391,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.15
-  resolution: "@types/prop-types@npm:15.7.15"
-  checksum: 10/31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
-  languageName: node
-  linkType: hard
-
 "@types/q@npm:^1.5.1":
   version: 1.5.8
   resolution: "@types/q@npm:1.5.8"
@@ -8441,16 +8434,6 @@ __metadata:
   dependencies:
     csstype: "npm:^3.0.2"
   checksum: 10/bfa3bb7e2efe929bdf41bf36461f2598611a29647852b8b7ecde510e83f797caf7f290388d13e2b71055df10587b3c41fc4345c1d9cbc38b4e897b03ad11c02f
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.3.1":
-  version: 18.3.27
-  resolution: "@types/react@npm:18.3.27"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.2.2"
-  checksum: 10/90155820a2af315cad1ff47df695f3f2f568c12ad641a7805746a6a9a9aa6c40b1374e819e50d39afe0e375a6b9160a73176cbdb4e09807262bc6fcdc06e67db
   languageName: node
   linkType: hard
 
@@ -13215,7 +13198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.2.2":
+"csstype@npm:^3.0.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10/ad41baf7e2ffac65ab544d79107bf7cd1a4bb9bab9ac3302f59ab4ba655d5e30942a8ae46e10ba160c6f4ecea464cc95b975ca2fefbdeeacd6ac63f12f99fe1f
@@ -20110,16 +20093,16 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.13.0"
     "@metamask/connect": "workspace:^"
-    "@types/react": "npm:^18.3.1"
+    "@types/react": "npm:19.1.0"
     "@types/react-dom": "npm:^18.3.1"
     "@vitejs/plugin-react": "npm:^4.3.3"
     eslint: "npm:^9.25.0"
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.13"
     globals: "npm:^15.11.0"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
-    typescript: "npm:~5.9.2"
+    react: "npm:19.1.0"
+    react-dom: "npm:19.1.0"
+    typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.10.0"
     vite: "npm:^5.4.20"
     vite-plugin-node-polyfills: "npm:^0.24.0"
@@ -20622,7 +20605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -24841,18 +24824,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
-  peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
-  languageName: node
-  linkType: hard
-
 "react-error-overlay@npm:^6.0.11":
   version: 6.1.0
   resolution: "react-error-overlay@npm:6.1.0"
@@ -25213,15 +25184,6 @@ __metadata:
   version: 19.1.0
   resolution: "react@npm:19.1.0"
   checksum: 10/d0180689826fd9de87e839c365f6f361c561daea397d61d724687cae88f432a307d1c0f53a0ee95ddbe3352c10dac41d7ff1ad85530fb24951b27a39e5398db4
-  languageName: node
-  linkType: hard
-
-"react@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
   languageName: node
   linkType: hard
 
@@ -26105,15 +26067,6 @@ __metadata:
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
   checksum: 10/1ecf2e5d7de1a7a132796834afe14a2d589ba7e437615bd8c06f3e0786a3ac3434655e67aac8755d9b14e05754c177e49c064261de2673aaa3c926bc98caa002
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
   languageName: node
   linkType: hard
 
@@ -28425,7 +28378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3, typescript@npm:~5.9.2":
+"typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -28435,7 +28388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -29379,15 +29332,15 @@ __metadata:
     "@tanstack/react-query": "npm:>=5.45.1"
     "@tanstack/react-query-devtools": "npm:5.0.5"
     "@tanstack/react-query-persist-client": "npm:5.0.5"
-    "@types/react": "npm:^18.3.1"
+    "@types/react": "npm:19.1.0"
     "@types/react-dom": "npm:^18.3.1"
     "@vitejs/plugin-react": "npm:^4.3.3"
     "@wagmi/cli": "npm:^2.3.2"
     "@wagmi/core": "npm:^2.22.1"
     buffer: "npm:^6.0.3"
     idb-keyval: "npm:^6.2.1"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
+    react: "npm:19.1.0"
+    react-dom: "npm:19.1.0"
     typescript: "npm:^5.9.3"
     viem: "npm:2.*"
     vite: "npm:^5.4.20"


### PR DESCRIPTION
## Explanation

This PR makes a bump to the following dependency versions across packages in monorepo.

```
   ├─  typescript (in devDependencies) '^5.9.3'
   ├─  react (in dependencies) '19.1.0'
   ├─ react-dom (in dependencies) '19.1.0'
   └─  @types/react (in devDependencies) '19.1.0'
```

It also ensures node engine specification across `package.json` files are consistent, as well as adding `connect-evm` to `yarn.config.cjs` `ALLOWED_INCONSISTENT_DEPENDENCIES` to make sure it can be referenced via `workspace:^`.

This ensures `yarn constraints` runs smoothly in order to facilitate releasing packages for the future.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
