### PR TITLE
fix: inconsistent sessionChanged events

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fix `wallet_sessionChanged` events subsequent to the initial connection not being persisted ([#100](https://github.com/MetaMask/connect-monorepo/pull/100))
+
 ## [0.4.0]
 
 ### Changed

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 
 - Fix `wallet_sessionChanged` events subsequent to the initial connection not being persisted ([#100](https://github.com/MetaMask/connect-monorepo/pull/100))
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -197,6 +197,24 @@ export class MWPTransport implements ExtendedTransport {
               ),
             );
           }
+
+          // Ensure session changes are always persisted to the store
+          if (
+            (message.data as { method: string }).method ===
+            'wallet_sessionChanged'
+          ) {
+            const notification = message.data as {
+              method: string;
+              params: SessionData;
+            };
+
+            const response = {
+              result: notification.params,
+            };
+
+            this.kvstore.set(SESSION_STORE_KEY, JSON.stringify(response));
+          }
+
           this.notifyCallbacks(message.data);
         }
       }


### PR DESCRIPTION
## Explanation

Fixes a bug where `wallet_sessionChanged` events subsequent to the initial connection weren't being persisted, leading to inconsistencies such as those described in [WAPI-900](https://consensyssoftware.atlassian.net/browse/WAPI-900). This PR ensures these events are always persisted.

## References

Fixes [WAPI-900](https://consensyssoftware.atlassian.net/browse/WAPI-900)

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## After

https://github.com/user-attachments/assets/53f83220-3f8e-4d9c-ad0f-94bf3371f290

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
