### PR TITLE
chore: Add deploy-legacy-evm-to-gh-pages github action

### DIFF
--- a/.github/workflows/deploy-legacy-evm-to-gh-pages.yml
+++ b/.github/workflows/deploy-legacy-evm-to-gh-pages.yml
@@ -1,0 +1,68 @@
+name: Deploy Legacy EVM Playground to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        required: true
+        type: string
+    secrets:
+      PUBLISH_DOCS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      destination_dir:
+        description: 'Destination directory on GitHub Pages (e.g., "latest", "5.0.0", "wagmi")'
+        required: true
+        type: string
+
+jobs:
+  deploy-legacy-evm-to-gh-pages:
+    name: Deploy Legacy EVM Playground to GitHub Pages
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+
+    steps:
+      - name: Ensure `destination_dir` is not empty
+        if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install Yarn
+        run: corepack enable
+
+      - name: Restore Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies via Yarn
+        run: yarn --immutable
+
+      - name: Build workspace dependencies
+        run: |
+          # Build all packages (workspace dependencies) in topological order
+          # This ensures @metamask/connect-evm and other dependencies are built first
+          yarn workspaces foreach --all --topological-dev --verbose --no-private run build
+
+      - name: Build wagmi integration
+        working-directory: playground/legacy-evm-react-vite-playground
+        run: yarn build
+
+      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+        with:
+          # This `PUBLISH_DOCS_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `github-pages` environment.
+          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+          publish_dir: ./playground/legacy-evm-react-vite-playground/build
+          destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
## Explanation

Adds a `deploy-legacy-evm-to-gh-pages` equivalent of `deploy-wagmi-to-gh-pages` github action. Note this is temporary and we should move to a more scalable solution as part of the playground consolidation refactor

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
