### PR TITLE
Add legacy compatibility methods and ensure stable method binding for EIP1193Provider

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add legacy compatibility methods to `EIP1193Provider` for broader ecosystem compatibility ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
+  - `chainId` getter (alias for `selectedChainId`)
+  - `sendAsync()` for callback/promise-based JSON-RPC requests
+  - `send()` for callback-based JSON-RPC requests
+
+### Fixed
+
+- Bind all public methods in `EIP1193Provider` constructor to ensure stable `this` context when methods are extracted or passed as callbacks ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
+
 ## [0.1.2]
 
 ### Added

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -113,3 +113,27 @@ export type ProviderRequest =
 export type ProviderRequestInterceptor = (
   req: ProviderRequest,
 ) => Promise<unknown>;
+
+// JSON-RPC types for legacy compatibility (sendAsync/send)
+export type JsonRpcRequest<T = unknown> = {
+  id?: number | string;
+  jsonrpc?: '2.0';
+  method: string;
+  params?: T;
+};
+
+export type JsonRpcResponse<T = unknown> = {
+  id: number | string;
+  jsonrpc: '2.0';
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+};
+
+export type JsonRpcCallback<T = unknown> = (
+  error: Error | null,
+  response: JsonRpcResponse<T> | null,
+) => void;

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -277,6 +277,11 @@ export class MultichainSDK extends MultichainCore {
       this.state = 'pending';
       logger('MetaMaskSDK error during initialization', error);
     }
+
+    this.#setupTransport().catch(async () => {
+      await this.storage.removeTransport();
+      this.state = 'pending';
+    });
   }
 
   async #createDappClient(): Promise<DappClient> {

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -277,11 +277,6 @@ export class MultichainSDK extends MultichainCore {
       this.state = 'pending';
       logger('MetaMaskSDK error during initialization', error);
     }
-
-    this.#setupTransport().catch(async () => {
-      await this.storage.removeTransport();
-      this.state = 'pending';
-    });
   }
 
   async #createDappClient(): Promise<DappClient> {


### PR DESCRIPTION
This PR enhances `EIP1193Provider` with legacy JSON-RPC compatibility methods and ensures all public methods maintain their `this` binding when extracted or passed as callbacks.

**Changes**

1. **Legacy compatibility methods** (`types.ts`, `provider.ts`)
   - Added `chainId` getter (alias for `selectedChainId`)
   - Added `sendAsync()` for callback/promise-based JSON-RPC requests
   - Added `send()` for callback-based JSON-RPC requests
   - Added corresponding `JsonRpcRequest`, `JsonRpcResponse`, and `JsonRpcCallback` types

2. **Method binding in constructor** (`provider.ts`)
   - Bound all public methods (`request`, `sendAsync`, `send`) and inherited EventEmitter methods (`on`, `off`, `emit`, `once`, `removeListener`, `listenerCount`) to `this` in the constructor

**Why this is necessary**

Many dApps and wallet integration libraries pass provider instances through adapters, store them in state, or destructure methods:

```javascript
const { request } = provider;
request({ method: 'eth_accounts' }); // Without binding, `this` is undefined
```

Because `EIP1193Provider` uses private fields (`#core`, `#accounts`), losing the `this` binding causes runtime errors like `Cannot read from private field`. Binding methods in the constructor makes the provider "extraction-safe" and eliminates the need for consumers to wrap the provider in a Proxy.
