### PR TITLE
build: add ci workflow for node playground check

### DIFF
--- a/.github/workflows/node-playground.yml
+++ b/.github/workflows/node-playground.yml
@@ -32,14 +32,19 @@ jobs:
         run: |
           # Start the playground and capture any immediate errors
           # We'll timeout after 10 seconds to ensure we catch compilation errors
-          # Exit code 124 means timeout (expected for interactive app), any other non-zero exit code is an error
+          # Exit code 124 = timeout command's exit code (expected for interactive app)
+          # Exit code 129 = SIGTERM (128 + 1), process terminated by timeout (also success)
+          # Exit code 0 = process completed normally (unexpected but acceptable)
+          # Any other non-zero exit code indicates a failure (e.g., compilation error)
+          set +e
           timeout 10 yarn start connect
           exit_code=$?
-          if [ $exit_code -eq 124 ]; then
-            echo "Node playground started successfully (timeout expected for interactive app)"
-          elif [ $exit_code -ne 0 ]; then
+          set -e
+          if [ $exit_code -eq 124 ] || [ $exit_code -eq 129 ]; then
+            echo "Node playground started successfully (terminated by timeout as expected)"
+          elif [ $exit_code -eq 0 ]; then
+            echo "Node playground started and completed successfully"
+          else
             echo "Node playground failed to start with exit code: $exit_code"
             exit $exit_code
-          else
-            echo "Node playground started successfully"
           fi

--- a/.github/workflows/node-playground.yml
+++ b/.github/workflows/node-playground.yml
@@ -1,0 +1,45 @@
+name: Node Playground Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-node-playground:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build project
+        run: yarn build
+
+      - name: Verify node playground starts
+        working-directory: playground/node-playground
+        run: |
+          # Start the playground and capture any immediate errors
+          # We'll timeout after 10 seconds to ensure we catch compilation errors
+          # Exit code 124 means timeout (expected for interactive app), any other non-zero exit code is an error
+          timeout 10 yarn start connect
+          exit_code=$?
+          if [ $exit_code -eq 124 ]; then
+            echo "Node playground started successfully (timeout expected for interactive app)"
+          elif [ $exit_code -ne 0 ]; then
+            echo "Node playground failed to start with exit code: $exit_code"
+            exit $exit_code
+          else
+            echo "Node playground started successfully"
+          fi


### PR DESCRIPTION
## Explanation

While working on [updating Node playground to support legacy EVM connector](https://github.com/MetaMask/connect-monorepo/pull/104/), it was discovered that running the app was actually broken for some time, with the following error message.

```bash
TSError: ⨯ Unable to compile TypeScript: ../../packages/connect-multichain/src/ui/index.ts:16:7 - error TS2307: Cannot find module '@metamask/multichain-ui/loader' or its corresponding type declarations. 16 '@metamask/multichain-ui/loader'
```
Even though the app was building properly.
So this PR adds a github CI workflow that simply runs the `yarn start connect` command after build, to make sure the node playground is not broken.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-919

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
