### PR TITLE
Remove Buffer Polyfill Requirement for Browser Environments

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove Buffer polyfill requirement for browser environments by using native `TextEncoder`/`TextDecoder` and `btoa`/`atob` APIs with Buffer fallback for Node.js and React Native ([#106](https://github.com/MetaMask/connect-monorepo/pull/106))
 - Fix `wallet_sessionChanged` events subsequent to the initial connection not being persisted ([#100](https://github.com/MetaMask/connect-monorepo/pull/100))
 - Fix hanging when attempting to resume a previous connection initialization in which the wallet does not send any response at all ([#103](https://github.com/MetaMask/connect-monorepo/pull/103))
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
@@ -4,6 +4,107 @@ import type {
 } from '@metamask/mobile-wallet-protocol-core';
 import { decrypt, encrypt, PrivateKey } from 'eciesjs';
 
+/**
+ * Encodes a string to a Uint8Array using UTF-8 encoding.
+ * Works in browser, Node.js, and React Native environments.
+ *
+ * @param str - The string to encode
+ * @returns The UTF-8 encoded Uint8Array
+ */
+function stringToUtf8Bytes(str: string): Uint8Array {
+  // Browser and modern Node.js (v12+)
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(str);
+  }
+
+  // Node.js and React Native with Buffer polyfill
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(str, 'utf8'));
+  }
+
+  throw new Error(
+    'No UTF-8 encoding method available. Install a Buffer polyfill for React Native.',
+  );
+}
+
+/**
+ * Decodes a Uint8Array to a string using UTF-8 decoding.
+ * Works in browser, Node.js, and React Native environments.
+ *
+ * @param bytes - The Uint8Array to decode
+ * @returns The decoded string
+ */
+function utf8BytesToString(bytes: Uint8Array): string {
+  // Browser and modern Node.js (v12+)
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder('utf-8').decode(bytes);
+  }
+
+  // Node.js and React Native with Buffer polyfill
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('utf8');
+  }
+
+  throw new Error(
+    'No UTF-8 decoding method available. Install a Buffer polyfill for React Native.',
+  );
+}
+
+/**
+ * Encodes a Uint8Array to a base64 string.
+ * Works in browser, Node.js, and React Native environments.
+ *
+ * @param bytes - The Uint8Array to encode
+ * @returns The base64 encoded string
+ */
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  // Browser and React Native with btoa polyfill
+  if (typeof btoa !== 'undefined') {
+    // Convert Uint8Array to binary string
+    const binaryString = Array.from(bytes, (byte) =>
+      String.fromCharCode(byte),
+    ).join('');
+    return btoa(binaryString);
+  }
+
+  // Node.js and React Native with Buffer polyfill
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+
+  throw new Error(
+    'No base64 encoding method available. Install a Buffer polyfill for React Native.',
+  );
+}
+
+/**
+ * Decodes a base64 string to a Uint8Array.
+ * Works in browser, Node.js, and React Native environments.
+ *
+ * @param base64 - The base64 string to decode
+ * @returns The decoded Uint8Array
+ */
+function base64ToUint8Array(base64: string): Uint8Array {
+  // Browser and React Native with atob polyfill
+  if (typeof atob !== 'undefined') {
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  // Node.js and React Native with Buffer polyfill
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(base64, 'base64'));
+  }
+
+  throw new Error(
+    'No base64 decoding method available. Install a Buffer polyfill for React Native.',
+  );
+}
+
 class KeyManager implements IKeyManager {
   generateKeyPair(): KeyPair {
     const privateKey = new PrivateKey();
@@ -17,18 +118,18 @@ class KeyManager implements IKeyManager {
     plaintext: string,
     theirPublicKey: Uint8Array,
   ): Promise<string> {
-    const plaintextBuffer = Buffer.from(plaintext, 'utf8');
-    const encryptedBuffer = encrypt(theirPublicKey, plaintextBuffer);
-    return encryptedBuffer.toString('base64');
+    const plaintextBytes = stringToUtf8Bytes(plaintext);
+    const encryptedBytes = encrypt(theirPublicKey, plaintextBytes);
+    return uint8ArrayToBase64(encryptedBytes);
   }
 
   async decrypt(
     encryptedB64: string,
     myPrivateKey: Uint8Array,
   ): Promise<string> {
-    const encryptedBuffer = Buffer.from(encryptedB64, 'base64');
-    const decryptedBuffer = await decrypt(myPrivateKey, encryptedBuffer);
-    return Buffer.from(decryptedBuffer).toString('utf8');
+    const encryptedBytes = base64ToUint8Array(encryptedB64);
+    const decryptedBytes = await decrypt(myPrivateKey, encryptedBytes);
+    return utf8BytesToString(decryptedBytes);
   }
 }
 

--- a/playground/legacy-evm-react-vite-playground/package.json
+++ b/playground/legacy-evm-react-vite-playground/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@metamask/connect": "workspace:^",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/playground/legacy-evm-react-vite-playground/vite.config.ts
+++ b/playground/legacy-evm-react-vite-playground/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -14,6 +13,6 @@ export default defineConfig({
     outDir: './build',
     emptyOutDir: true, // also necessary
   },
-  plugins: [react(), nodePolyfills({ include: ['buffer'] })],
+  plugins: [react()],
   base: './',
 });


### PR DESCRIPTION
Replaces Node.js Buffer API with browser-native APIs in KeyManager.ts to eliminate the need for a Buffer polyfill in browser environments.

| Before | After |
|--------|-------|
| `Buffer.from(str, 'utf8')` | `TextEncoder.encode()` → `Buffer` fallback |
| `Buffer.from(bytes).toString('utf8')` | `TextDecoder.decode()` → `Buffer` fallback |
| `Buffer.from(bytes).toString('base64')` | `btoa()` → `Buffer` fallback |
| `Buffer.from(str, 'base64')` | `atob()` → `Buffer` fallback |

### Impact
| Environment | Before | After |
|-------------|--------|-------|
| Browser | ❌ Requires Buffer polyfill | ✅ No polyfill needed |
| Node.js | ✅ Works | ✅ Works |
| React Native | ⚠️ Requires Buffer polyfill | ⚠️ Requires Buffer polyfill (unchanged) |

### Testing Checklist
- [ ] Browser: Verify encryption/decryption works without Buffer polyfill
- [ ] Node.js: Run existing tests
- [ ] React Native: Verify with Buffer polyfill still works
