### PR TITLE
fix: make sure session recovery is only called when connected or connecting

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update `#attemptSessionRecovery()` to check to state before attempting recovery ([#107](https://github.com/MetaMask/connect-monorepo/pull/107))
 - Bind all public methods in `EIP1193Provider` constructor to ensure stable `this` context when methods are extracted or passed as callbacks ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
 
 ## [0.1.2]

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -745,6 +745,12 @@ export class MetamaskConnectEVM {
    * and trigger an accountsChanged event if the results are valid accounts.
    */
   async #attemptSessionRecovery(): Promise<void> {
+    // Skip session recovery if transport is not initialized yet.
+    // Transport is only initialized when there's a stored session or after connect() is called.
+    // Only attempt recovery if we're in a state where transport should be available.
+    if (this.#core.state !== 'connected' && this.#core.state !== 'connecting') {
+      return;
+    }
     try {
       const response = await this.#core.transport.request<
         { method: 'wallet_getSession' },


### PR DESCRIPTION
## Explanation

`#attemptSessionRecovery()` runs in the constructor before transport is initialized. The SDK starts in 'pending' and may become 'loaded' without transport, so recovery should only run when transport is available.

<img width="1004" height="557" alt="Screenshot 2026-01-14 at 11 04 54" src="https://github.com/user-attachments/assets/7c1cc21f-2a84-4ef7-a769-2d45f3b0a8b8" />

Which results in this error consistently throwing whenever we start up node playground (this may even by manifesting itself in regular connection flow, we just are not seeing it)

This PR proposes a check to the SDK state before attempting recovery.
This will fix the [following PR proposing a CI workflow for checking Node Playground](https://github.com/MetaMask/connect-monorepo/pull/105).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
