### PR TITLE
fix: incorrect chainId on page refresh

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by querying `eth_chainId` from the wallet instead of assuming the first permitted chain is selected ([#108](https://github.com/MetaMask/connect-monorepo/pull/108))
 - Update `#attemptSessionRecovery()` to check to state before attempting recovery ([#107](https://github.com/MetaMask/connect-monorepo/pull/107))
 - Bind all public methods in `EIP1193Provider` constructor to ensure stable `this` context when methods are extracted or passed as callbacks ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -800,7 +800,7 @@ export class MetamaskConnectEVM {
       // and correctly set the currently selected account for the dapp
       const permittedAccounts = await this.#core.transport.sendEip1193Message<
         { method: 'eth_accounts'; params: [] },
-        { result: string[]; id: number; jsonrpc: '2.0' }
+        { result: Address[]; id: number; jsonrpc: '2.0' }
       >({ method: 'eth_accounts', params: [] });
 
       const chainId = await this.#getSelectedChainId(permittedChainIds);
@@ -808,7 +808,7 @@ export class MetamaskConnectEVM {
       if (permittedChainIds.length && permittedAccounts.result) {
         this.#onConnect({
           chainId,
-          accounts: permittedAccounts.result as Address[],
+          accounts: permittedAccounts.result,
         });
       }
     } catch (error) {

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -266,9 +266,9 @@ export class MetamaskConnectEVM {
     try {
       const chainIdResponse = await this.#core.transport.sendEip1193Message<
         { method: 'eth_chainId'; params: [] },
-        { result: string; id: number; jsonrpc: '2.0' }
+        { result: Hex; id: number; jsonrpc: '2.0' }
       >({ method: 'eth_chainId', params: [] });
-      const walletChainId = chainIdResponse.result as Hex;
+      const walletChainId = chainIdResponse.result;
       // Validate that the returned chainId is in the permitted chains list
       if (permittedChainIds.includes(walletChainId)) {
         return walletChainId;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When a user switches to a chain other than Ethereum Mainnet and refreshes the page, the selected chainId incorrectly reverts to chainId 1. This occurred because the code assumed the first permitted chain in the session scopes was the selected chain, rather than querying the wallet for the actual selected chain.

## Solution

Query the wallet for the currently selected chain using `eth_chainId` instead of assuming the first permitted chain is selected. This ensures the correct chainId persists across page refreshes.

## Changes

- Added private method `#getSelectedChainId()` that queries `eth_chainId` from the wallet and validates it against permitted chains
- Updated `connect()` and `#attemptSessionRecovery()` to use the new method
- Falls back to the first permitted chain if `eth_chainId` fails or returns an invalid chain

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes [WAPI-924](https://consensyssoftware.atlassian.net/browse/WAPI-924)

## After


https://github.com/user-attachments/assets/4647a551-95a6-43eb-b703-f07121b784a0



## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
