### PR TITLE
fix: make sure node playground legacy evm connection is working properly

### DIFF
--- a/playground/node-playground/src/index.ts
+++ b/playground/node-playground/src/index.ts
@@ -311,10 +311,12 @@ const main = async (): Promise<void> => {
           console.log('------------------------------------');
         }
 
-        if (state.spinner && state.app === 'CONNECTING') {
+        if (state.spinner) {
           state.spinner.stop();
           state.spinner = null;
         }
+
+        state.connectorType = 'evm';
 
         // Group accounts by chain ID for EVM connector
         // chainId is a hex string, convert to number for CAIP format


### PR DESCRIPTION
## Explanation

After this [commit](https://github.com/MetaMask/connect-monorepo/pull/88), legacy EVM connection on node playground seem to be in a limbo state which did not allow for any interactions to be made after connecting.

This PR proposes a fix to node playground state to make sure we are able to do normal interactions after connection.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
