### PR TITLE
fix: cache last selected chainId

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by querying `eth_chainId` from the wallet instead of assuming the first permitted chain is selected ([#108](https://github.com/MetaMask/connect-monorepo/pull/108))
+- Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by caching the selected chainId and retrieving it from storage instead of assuming the first permitted chain is selected ()
 - Update `#attemptSessionRecovery()` to check to state before attempting recovery ([#107](https://github.com/MetaMask/connect-monorepo/pull/107))
 - Bind all public methods in `EIP1193Provider` constructor to ensure stable `this` context when methods are extracted or passed as callbacks ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by caching the selected chainId and retrieving it from storage instead of assuming the first permitted chain is selected ()
+- Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by caching the selected chainId and retrieving it from storage instead of assuming the first permitted chain is selected ([#113](https://github.com/MetaMask/connect-monorepo/pull/113))
 - Update `#attemptSessionRecovery()` to check to state before attempting recovery ([#107](https://github.com/MetaMask/connect-monorepo/pull/107))
 - Bind all public methods in `EIP1193Provider` constructor to ensure stable `this` context when methods are extracted or passed as callbacks ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -267,16 +267,8 @@ export class MetamaskConnectEVM {
       const cachedChainId =
         await this.#core.storage.adapter.get(CHAIN_STORE_KEY);
       if (cachedChainId) {
-        // The cached value might be stored as a number (from metamask_chainChanged) or hex string (from eth_chainId)
-        let chainId: Hex;
-        try {
-          const parsed = JSON.parse(cachedChainId);
-          chainId =
-            typeof parsed === 'number' ? numberToHex(parsed) : (parsed as Hex);
-        } catch {
-          // If parsing fails, try treating it as a direct hex string
-          chainId = cachedChainId as Hex;
-        }
+        const chainId: Hex = JSON.parse(cachedChainId);
+
         // Validate that the cached chainId is in the permitted chains list
         if (permittedChainIds.includes(chainId)) {
           return chainId;


### PR DESCRIPTION
## Explanation

When a user switches to a chain other than Ethereum Mainnet and refreshes the page, the selected chainId incorrectly reverts to chainId 1. This occurred because the code assumed the first permitted chain in the session scopes was the selected chain, rather than persisting the user's actual selection.

### Solution

Cache the selected chainId in storage whenever it changes, and retrieve it from cache during session recovery and connection. This ensures the correct chainId persists across page refreshes.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
