### PR TITLE
chore: factory function renaming

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -30,9 +30,7 @@ import {
   withTimeout,
 } from 'viem';
 
-type CreateEVMClientParameters = Parameters<
-  typeof createEVMClient
->[0];
+type CreateEVMClientParameters = Parameters<typeof createEVMClient>[0];
 
 const DEFAULT_CHAIN_ID = 1;
 

--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -1,5 +1,5 @@
 import {
-  createMetamaskConnectEVM,
+  createEVMClient,
   type EIP1193Provider,
   type MetamaskConnectEVM,
 } from '@metamask/connect-evm';
@@ -30,14 +30,14 @@ import {
   withTimeout,
 } from 'viem';
 
-type CreateMetamaskConnectEVMParameters = Parameters<
-  typeof createMetamaskConnectEVM
+type CreateEVMClientParameters = Parameters<
+  typeof createEVMClient
 >[0];
 
 const DEFAULT_CHAIN_ID = 1;
 
 export type MetaMaskParameters = Partial<
-  Pick<CreateMetamaskConnectEVMParameters, 'dapp' | 'debug'>
+  Pick<CreateEVMClientParameters, 'dapp' | 'debug'>
 > &
   OneOf<
     | {
@@ -74,7 +74,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
             ]),
           );
 
-          metamaskPromise = createMetamaskConnectEVM({
+          metamaskPromise = createEVMClient({
             dapp: parameters.dapp ?? { name: window.location.hostname },
             eventHandlers: {
               accountsChanged: connector.onAccountsChanged.bind(connector),

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention
+
 ### Added
 
 - Add legacy compatibility methods to `EIP1193Provider` for broader ecosystem compatibility ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
-
 ### Added
 
 - Add legacy compatibility methods to `EIP1193Provider` for broader ecosystem compatibility ([#102](https://github.com/MetaMask/connect-monorepo/pull/102))
   - `chainId` getter (alias for `selectedChainId`)
   - `sendAsync()` for callback/promise-based JSON-RPC requests
   - `send()` for callback-based JSON-RPC requests
+
+### Changed
+
+- **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 
 ### Fixed
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention
+- **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 
 ### Added
 

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -24,10 +24,10 @@ npm install @metamask/connect-evm
 ## Quick Start
 
 ```typescript
-import { createMetamaskConnectEVM } from '@metamask/connect-evm';
+import { createEVMClient } from '@metamask/connect-evm';
 
 // Create an SDK instance
-const sdk = await createMetamaskConnectEVM({
+const sdk = await createEVMClient({
   dapp: {
     name: 'My DApp',
     url: 'https://mydapp.com',
@@ -51,9 +51,9 @@ const accounts = await provider.request({
 ### Basic Connection
 
 ```typescript
-import { createMetamaskConnectEVM } from '@metamask/connect-evm';
+import { createEVMClient } from '@metamask/connect-evm';
 
-const sdk = await createMetamaskConnectEVM({
+const sdk = await createEVMClient({
   dapp: {
     name: 'My DApp',
     url: 'https://mydapp.com',

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -7,7 +7,7 @@ import type {
   SessionData,
 } from '@metamask/connect-multichain';
 import {
-  createMetamaskConnect,
+  createMultichainClient,
   getWalletActionAnalyticsProperties,
   isRejectionError,
   TransportType,
@@ -70,7 +70,7 @@ type ConnectOptions = {
  *
  * @example
  * ```typescript
- * const sdk = await createMetamaskConnectEVM({
+ * const sdk = await createEVMClient({
  *   dapp: { name: 'My DApp', url: 'https://mydapp.com' }
  * });
  *
@@ -883,7 +883,7 @@ export class MetamaskConnectEVM {
  * @param options.eventHandlers - The event handlers to use for the Metamask Connect/EVM layer
  * @returns The Metamask Connect/EVM layer instance
  */
-export async function createMetamaskConnectEVM(
+export async function createEVMClient(
   options: Pick<MultichainOptions, 'dapp' | 'api'> & {
     eventHandlers?: Partial<EventHandlers>;
     debug?: boolean;
@@ -906,7 +906,7 @@ export async function createMetamaskConnectEVM(
   validSupportedChainsUrls(options.api.supportedNetworks, 'supportedNetworks');
 
   try {
-    const core = await createMetamaskConnect({
+    const core = await createMultichainClient({
       ...options,
       api: {
         supportedNetworks: options.api.supportedNetworks,

--- a/packages/connect-evm/src/index.ts
+++ b/packages/connect-evm/src/index.ts
@@ -1,5 +1,5 @@
 export { getInfuraRpcUrls } from '@metamask/connect-multichain';
-export { createMetamaskConnectEVM, type MetamaskConnectEVM } from './connect';
+export { createEVMClient, type MetamaskConnectEVM } from './connect';
 export type { EIP1193Provider } from './provider';
 
 export type * from './types';

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** Rename `createMetamaskConnect` to `createMultichainClient` for a cleaner naming convention
+
 ### Fixed
 
 - Fix `wallet_sessionChanged` events subsequent to the initial connection not being persisted ([#100](https://github.com/MetaMask/connect-monorepo/pull/100))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING** Rename `createMetamaskConnect` to `createMultichainClient` for a cleaner naming convention
+- **BREAKING** Rename `createMetamaskConnect` to `createMultichainClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 
 ### Fixed
 

--- a/packages/connect-multichain/src/index.browser.ts
+++ b/packages/connect-multichain/src/index.browser.ts
@@ -5,7 +5,7 @@ import { ModalFactory } from './ui';
 
 export * from './domain';
 
-export const createMetamaskConnect: CreateMultichainFN = async (options) => {
+export const createMultichainClient: CreateMultichainFN = async (options) => {
   const uiModules = await import('./ui/modals/web');
   let storage: StoreClient;
   if (!options.storage) {

--- a/packages/connect-multichain/src/index.native.ts
+++ b/packages/connect-multichain/src/index.native.ts
@@ -5,7 +5,7 @@ import { ModalFactory } from './ui/index.native';
 
 export * from './domain';
 
-export const createMetamaskConnect: CreateMultichainFN = async (options) => {
+export const createMultichainClient: CreateMultichainFN = async (options) => {
   const uiModules = await import('./ui/modals/rn');
   let storage: StoreClient;
   if (!options.storage) {

--- a/packages/connect-multichain/src/index.node.ts
+++ b/packages/connect-multichain/src/index.node.ts
@@ -5,7 +5,7 @@ import { ModalFactory } from './ui';
 
 export * from './domain';
 
-export const createMetamaskConnect: CreateMultichainFN = async (options) => {
+export const createMultichainClient: CreateMultichainFN = async (options) => {
   const uiModules = await import('./ui/modals/node');
   let storage: StoreClient;
   if (!options.storage) {

--- a/packages/connect-multichain/tests/fixtures.test.ts
+++ b/packages/connect-multichain/tests/fixtures.test.ts
@@ -22,9 +22,9 @@ import type { MultichainOptions } from '../src/domain';
 import { MultichainSDK } from '../src/multichain';
 
 // Import createSDK functions for convenience
-import { createMetamaskConnect as createMetamaskSDKWeb } from '../src/index.browser';
-import { createMetamaskConnect as createMetamaskSDKRN } from '../src/index.native';
-import { createMetamaskConnect as createMetamaskSDKNode } from '../src/index.node';
+import { createMultichainClient as createMetamaskSDKWeb } from '../src/index.browser';
+import { createMultichainClient as createMetamaskSDKRN } from '../src/index.native';
+import { createMultichainClient as createMetamaskSDKNode } from '../src/index.node';
 import type {
   NativeStorageStub,
   MockedData,

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update to use renamed API functions: `createMetamaskConnect` → `createMultichainClient` and `createMetamaskConnectEVM` → `createEVMClient` ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 - Remove `enable` flag from `analytics` config object for `createMetamaskConnect` constructor ([#92](https://github.com/MetaMask/connect-monorepo/pull/92))
 - Bump `@types/jest` from ^28.1.6 to ^29.5.14 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `@types/node` from ^18.18 to ^22.9.0 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -1,7 +1,4 @@
-import {
-  MetamaskConnectEVM,
-  createEVMClient,
-} from '@metamask/connect/evm';
+import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect/evm';
 import type { EIP1193Provider } from '@metamask/connect/evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
 import type React from 'react';
@@ -143,7 +140,9 @@ export const LegacyEVMSDKProvider = ({
 export const useLegacyEVMSDK = () => {
   const context = useContext(LegacyEVMSDKContext);
   if (context === undefined) {
-    throw new Error('useLegacyEVMSDK must be used within a LegacyEVMSDKProvider');
+    throw new Error(
+      'useLegacyEVMSDK must be used within a LegacyEVMSDKProvider',
+    );
   }
   return context;
 };

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -1,6 +1,6 @@
 import {
   MetamaskConnectEVM,
-  createMetamaskConnectEVM,
+  createEVMClient,
 } from '@metamask/connect/evm';
 import type { EIP1193Provider } from '@metamask/connect/evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
@@ -53,7 +53,7 @@ export const LegacyEVMSDKProvider = ({
               'eip155:137': 'https://polygon-rpc.com',
             };
 
-        const clientSDK = await createMetamaskConnectEVM({
+        const clientSDK = await createEVMClient({
           dapp: {
             name: 'playground',
             url: 'https://playground.metamask.io',

--- a/playground/browser-playground/src/sdk/SDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/SDKProvider.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 import {
-  createMetamaskConnect,
+  createMultichainClient,
   getInfuraRpcUrls,
   type InvokeMethodOptions,
   type MultichainCore,
@@ -46,7 +46,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     if (!sdkRef.current) {
-      sdkRef.current = createMetamaskConnect({
+      sdkRef.current = createMultichainClient({
         dapp: {
           name: 'playground',
           url: 'https://playground.metamask.io',

--- a/playground/browser-playground/src/wagmi/metamask-connector.ts
+++ b/playground/browser-playground/src/wagmi/metamask-connector.ts
@@ -10,7 +10,7 @@
 
 // @ts-nocheck
 import {
-  createMetamaskConnectEVM,
+  createEVMClient,
   type EIP1193Provider,
   type MetamaskConnectEVM,
 } from '@metamask/connect-evm';
@@ -41,14 +41,12 @@ import {
   withTimeout,
 } from 'viem';
 
-type CreateMetamaskConnectEVMParameters = Parameters<
-  typeof createMetamaskConnectEVM
->[0];
+type CreateEVMClientParameters = Parameters<typeof createEVMClient>[0];
 
 const DEFAULT_CHAIN_ID = 1;
 
 export type MetaMaskParameters = Partial<
-  Pick<CreateMetamaskConnectEVMParameters, 'dapp' | 'debug'>
+  Pick<CreateEVMClientParameters, 'dapp' | 'debug'>
 > &
   OneOf<
     | {
@@ -85,7 +83,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
             ]),
           );
 
-          metamaskPromise = createMetamaskConnectEVM({
+          metamaskPromise = createEVMClient({
             dapp: parameters.dapp ?? { name: window.location.hostname },
             eventHandlers: {
               accountsChanged: connector.onAccountsChanged.bind(connector),

--- a/playground/node-playground/src/index.ts
+++ b/playground/node-playground/src/index.ts
@@ -1,10 +1,10 @@
 import {
-  createMetamaskConnect,
+  createMultichainClient,
   getInfuraRpcUrls,
   type SessionData,
 } from '@metamask/connect-multichain';
 import {
-  createMetamaskConnectEVM,
+  createEVMClient,
   type MetamaskConnectEVM,
 } from '@metamask/connect-evm';
 import { hexToNumber } from '@metamask/utils';
@@ -30,7 +30,7 @@ const AVAILABLE_CHAINS = [
 const state: {
   app: AppState;
   connectorType: ConnectorType | null;
-  multichainSdk: Awaited<ReturnType<typeof createMetamaskConnect>> | null;
+  multichainSdk: Awaited<ReturnType<typeof createMultichainClient>> | null;
   evmSdk: MetamaskConnectEVM | null;
   accounts: { [chainId: string]: string[] }; // Group accounts by chain
   spinner: Ora | null;
@@ -367,7 +367,7 @@ const main = async (): Promise<void> => {
   const supportedNetworks = getInfuraRpcUrls(infuraApiKey);
 
   // Initialize Multichain SDK
-  state.multichainSdk = await createMetamaskConnect({
+  state.multichainSdk = await createMultichainClient({
     dapp: {
       name: 'Node.js Playground',
       url: 'https://playground.metamask.io',
@@ -378,7 +378,7 @@ const main = async (): Promise<void> => {
   });
 
   // Initialize EVM SDK
-  state.evmSdk = await createMetamaskConnectEVM({
+  state.evmSdk = await createEVMClient({
     dapp: {
       name: 'Node.js Playground',
       url: 'https://playground.metamask.io',

--- a/playground/react-native-playground/src/sdk/SDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/SDKProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { createMetamaskConnect, type SDKState, type InvokeMethodOptions, type Scope, type SessionData, type MultichainCore, getInfuraRpcUrls } from '@metamask/connect-multichain';
+import { createMultichainClient, type SDKState, type InvokeMethodOptions, type Scope, type SessionData, type MultichainCore, getInfuraRpcUrls } from '@metamask/connect-multichain';
 import type { CaipAccountId } from '@metamask/utils';
 import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
@@ -28,7 +28,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
 
 	useEffect(() => {
 		if (!sdkRef.current) {
-			sdkRef.current = createMetamaskConnect({
+			sdkRef.current = createMultichainClient({
 				dapp: {
 					name: 'playground',
 					url: 'https://playground.metamask.io',


### PR DESCRIPTION
## Explanation

Renames two factory functions for clearer naming:

- `createMetamaskConnectEVM` → `createEVMClient`
- `createMetamaskConnect` → `createMultichainClient`

Also updates relevant documentation such as `README`'s.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:


* Fixes #12345
* Related to #67890
-->

Fixes [WAPI-932](https://consensyssoftware.atlassian.net/browse/WAPI-932)


## After

https://github.com/user-attachments/assets/6e519f13-90b2-4037-98ef-66baff7f355b



## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
