### PR TITLE
revert: clear state when establishing a new connection but an existing session exists for `ConnectEvm` 

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING** Rename `createMetamaskConnectEVM` to `createEVMClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 
+### Removed
+
+- Revert: Fix local state not correctly being reset when establishing a new connection when there is an existing active session ([#119](https://github.com/MetaMask/connect-monorepo/pull/119))
+
 ### Fixed
 
 - Fix selected chainId incorrectly reverting to Ethereum Mainnet after page refresh by caching the selected chainId and retrieving it from storage instead of assuming the first permitted chain is selected ([#113](https://github.com/MetaMask/connect-monorepo/pull/113))
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix duplicate `onNotification` listener ([#81](https://github.com/MetaMask/connect-monorepo/pull/81))
 - Fixed `addEthereumChain` not being prompted on mobile native browsers after a switch chain failure ([#79](https://github.com/MetaMask/connect-monorepo/pull/79))
+- Fix local state not correctly being reset when establishing a new connection when there is an existing active session ([#88](https://github.com/MetaMask/connect-monorepo/pull/88))
 
 ## [0.1.1]
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -41,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix duplicate `onNotification` listener ([#81](https://github.com/MetaMask/connect-monorepo/pull/81))
 - Fixed `addEthereumChain` not being prompted on mobile native browsers after a switch chain failure ([#79](https://github.com/MetaMask/connect-monorepo/pull/79))
-- Fix local state not correctly being reset when establishing a new connection when there is an existing active session ([#88](https://github.com/MetaMask/connect-monorepo/pull/88))
 
 ## [0.1.1]
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -296,10 +296,6 @@ export class MetamaskConnectEVM {
       chainIds: [DEFAULT_CHAIN_ID],
     },
   ): Promise<{ accounts: Address[]; chainId: number }> {
-    if (this.#core.state !== 'connected') {
-      await this.disconnect();
-    }
-
     logger('request: connect', { account });
 
     if (!chainIds || chainIds.length === 0) {


### PR DESCRIPTION
## Explanation

This reverts commit a4d61253a03ae42c91f2cac5e5a4ece0d3ab8960.

Not certain if this is more useful than harmful. 

## References

See: https://consensyssoftware.atlassian.net/browse/WAPI-939?atlOrigin=eyJpIjoiN2EyNDZiZDJkYzI4NDM4MGJkMzRmY2UxMDg5NTIyNTEiLCJwIjoiaiJ9

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
