### PR TITLE
fix: Resolve Buffer polyfill requirement for browser/React Native consumers

### DIFF
--- a/integrations/wagmi/package.json
+++ b/integrations/wagmi/package.json
@@ -26,7 +26,6 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "@wagmi/cli": "^2.3.2",
-    "buffer": "^6.0.3",
     "typescript": "^5.9.3",
     "vite": "^5.4.20"
   }

--- a/integrations/wagmi/src/main.tsx
+++ b/integrations/wagmi/src/main.tsx
@@ -2,15 +2,12 @@ import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persist
 import { QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
-import { Buffer } from 'buffer'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { deserialize, serialize, WagmiProvider } from 'wagmi'
 
 import './index.css'
 
-// `@coinbase-wallet/sdk` uses `Buffer`
-globalThis.Buffer = Buffer
 
 import App from './App.tsx'
 import { config } from './wagmi.ts'

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -15,7 +15,10 @@
     "url": "https://github.com/MetaMask/connect-monorepo.git"
   },
   "license": "MIT",
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/polyfills/buffer-shim.ts",
+    "./dist/**/polyfills/buffer-shim.*"
+  ],
   "exports": {
     ".": {
       "browser": {
@@ -77,6 +80,7 @@
     "@metamask/utils": "^11.8.1",
     "@paulmillr/qr": "^0.2.1",
     "bowser": "^2.11.0",
+    "buffer": "^6.0.3",
     "cross-fetch": "^4.1.0",
     "eciesjs": "^0.4.15",
     "eventemitter3": "^5.0.1",

--- a/packages/connect-multichain/src/index.browser.ts
+++ b/packages/connect-multichain/src/index.browser.ts
@@ -1,3 +1,6 @@
+// Buffer polyfill must be imported first to set up globalThis.Buffer
+import './polyfills/buffer-shim';
+
 import type { CreateMultichainFN, StoreClient } from './domain';
 import { MultichainSDK } from './multichain';
 import { Store } from './store';

--- a/packages/connect-multichain/src/index.native.ts
+++ b/packages/connect-multichain/src/index.native.ts
@@ -1,3 +1,6 @@
+// Buffer polyfill must be imported first to set up global.Buffer
+import './polyfills/buffer-shim';
+
 import type { CreateMultichainFN, StoreClient } from './domain';
 import { MultichainSDK } from './multichain';
 import { Store } from './store';

--- a/packages/connect-multichain/src/polyfills/buffer-shim.ts
+++ b/packages/connect-multichain/src/polyfills/buffer-shim.ts
@@ -1,0 +1,24 @@
+/**
+ * Buffer polyfill for browser and React Native environments.
+ *
+ * This shim sets up the global Buffer object before any code that depends on it runs.
+ * It's imported at the top of platform-specific entry points (index.browser.ts, index.native.ts).
+ *
+ * Node.js environments already have Buffer globally available, so this is a no-op there.
+ */
+import { Buffer } from 'buffer';
+
+// Get the appropriate global object for the current environment
+const g =
+  typeof globalThis !== 'undefined'
+    ? globalThis
+    : typeof global !== 'undefined'
+      ? global
+      : typeof window !== 'undefined'
+        ? window
+        : ({} as typeof globalThis);
+
+// Only set Buffer if it's not already defined (avoid overwriting Node.js native Buffer)
+if (!g.Buffer) {
+  g.Buffer = Buffer;
+}

--- a/packages/connect-multichain/tsup.config.ts
+++ b/packages/connect-multichain/tsup.config.ts
@@ -8,7 +8,7 @@ const peerDependencies = Object.keys(pkg.peerDependencies || {});
 const optionalDependencies = Object.keys(pkg.optionalDependencies || {});
 
 // Dependencies that should be bundled
-const bundledDeps = [ 'readable-stream'];
+const bundledDeps = ['readable-stream'];
 // Shared dependencies that should be deduplicated
 const sharedDeps = ['eventemitter2', 'socket.io-client', 'debug', 'uuid', 'cross-fetch', '@metamask/sdk-analytics'];
 
@@ -24,7 +24,8 @@ const baseExternalDeps = [
   'extension-port-stream',
   '@metamask/utils',
   '@metamask/rpc-errors',
-  'ws'
+  'ws',
+  'buffer',
 ];
 
 // Platform-specific externals

--- a/playground/browser-playground/craco.config.js
+++ b/playground/browser-playground/craco.config.js
@@ -20,7 +20,6 @@ module.exports = {
       // === NODE.JS POLYFILLS ===
       webpackConfig.resolve.fallback = {
         ...webpackConfig.resolve.fallback,
-        buffer: require.resolve('buffer'),
         process: require.resolve('process/browser.js'),
       };
 
@@ -33,7 +32,6 @@ module.exports = {
       // === PROVIDE PLUGINS ===
       webpackConfig.plugins.push(
         new webpack.ProvidePlugin({
-          Buffer: ['buffer', 'Buffer'],
           process: 'process/browser.js',
         }),
         new webpack.DefinePlugin({

--- a/playground/react-native-playground/app/index.tsx
+++ b/playground/react-native-playground/app/index.tsx
@@ -3,7 +3,6 @@ import { SafeAreaView, ScrollView, View, Text, TouchableOpacity, StyleSheet } fr
 import { StatusBar } from 'expo-status-bar';
 import type { Scope, SessionData } from '@metamask/connect-multichain';
 import { hexToNumber, type CaipAccountId } from '@metamask/utils';
-import { Buffer } from 'buffer';
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { TEST_IDS } from '@metamask/playground-ui';
 
@@ -15,9 +14,6 @@ import { LegacyEVMCard } from '../src/components/LegacyEVMCard';
 import { WagmiCard } from '../src/components/WagmiCard';
 import { convertCaipChainIdsToHex } from '../src/helpers/ChainIdHelpers';
 import { colors, sharedStyles } from '../src/styles/shared';
-
-// Configure Buffer polyfill for React Native
-global.Buffer = Buffer;
 
 export default function Page() {
 	const [customScopes, setCustomScopes] = useState<Scope[]>(['eip155:1' as Scope]);

--- a/playground/react-native-playground/polyfills.ts
+++ b/playground/react-native-playground/polyfills.ts
@@ -1,5 +1,7 @@
-import { Buffer } from "buffer";
+import { Buffer } from 'buffer';
 
+// NOTE: Buffer polyfill is now handled by @metamask/connect-multichain
+// We still need to set it here for other libraries that may need it before connect-multichain loads
 global.Buffer = Buffer;
 
 // Polyfill for window object (used by wagmi connector and connect-multichain)

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -106,7 +106,16 @@ module.exports = defineConfig({
         await expectWorkspaceLicense(workspace);
 
         // All non-root packages must not have side effects.
-        expectWorkspaceField(workspace, 'sideEffects', false);
+        // Exception: connect-multichain needs sideEffects for Buffer polyfill
+        // (eciesjs requires Buffer globally; the polyfill shim sets globalThis.Buffer)
+        if (workspace.ident === '@metamask/connect-multichain') {
+          expectWorkspaceField(workspace, 'sideEffects', [
+            './src/polyfills/buffer-shim.ts',
+            './dist/**/polyfills/buffer-shim.*',
+          ]);
+        } else {
+          expectWorkspaceField(workspace, 'sideEffects', false);
+        }
 
         // All non-root packages must set up ESM- and CommonJS-compatible
         // exports correctly.

--- a/yarn.lock
+++ b/yarn.lock
@@ -28735,7 +28735,6 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.3"
     "@wagmi/cli": "npm:^2.3.2"
     "@wagmi/core": "npm:^2.22.1"
-    buffer: "npm:^6.0.3"
     idb-keyval: "npm:^6.2.1"
     react: "npm:19.1.0"
     react-dom: "npm:19.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4162,6 +4162,7 @@ __metadata:
     "@types/ws": "npm:^8.18.1"
     "@vitest/coverage-v8": "npm:^3.2.4"
     bowser: "npm:^2.11.0"
+    buffer: "npm:^6.0.3"
     cross-fetch: "npm:^4.1.0"
     deepmerge: "npm:^4.2.2"
     eciesjs: "npm:^0.4.15"


### PR DESCRIPTION
## Explanation

**The Problem:**
Consumers integrating `@metamask/connect-evm` or `@metamask/connect-multichain` in browser environments (Vite, CRA, React Native) encounter a runtime error: `Cannot read properties of undefined (reading 'isBuffer')`. The root cause is `eciesjs` (used for MWP encryption), which internally calls `Buffer.from()`. 

This created an **undocumented, implicit requirement**.

**The Solution:**
This PR transforms that implicit requirement into an **explicit, automatically-handled dependency**. The package now ships with the Buffer polyfill built-in, meaning consumers get a working integration out-of-the-box with zero configuration.

**How it works:**
- A lightweight shim (`src/polyfills/buffer-shim.ts`) sets up `globalThis.Buffer` before any dependent code runs
- The `buffer` package is added as a dependency but marked external, allowing npm/yarn to deduplicate it with other packages that may already include it
- Browser and React Native entry points import the shim first

**What this means for consumers:**
- No more manual bundler configuration required
- No more cryptic "isBuffer" errors
- Works out-of-the-box in Vite, CRA, and React Native
- If they already have Buffer polyfilled, the dependency is shared (no duplication)

## References

- https://consensyssoftware.atlassian.net/browse/WAPI-921

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes