### PR TITLE
chore: rename class variable state to status + type SDKState to ConnectionStatus

### DIFF
--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -797,7 +797,7 @@ export class MetamaskConnectEVM {
     // Skip session recovery if transport is not initialized yet.
     // Transport is only initialized when there's a stored session or after connect() is called.
     // Only attempt recovery if we're in a state where transport should be available.
-    if (this.#core.state !== 'connected' && this.#core.state !== 'connecting') {
+    if (this.#core.status !== 'connected' && this.#core.status !== 'connecting') {
       return;
     }
     try {

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** Rename `state` property to `status` on `MultichainCore` for improved clarity ([#125](https://github.com/MetaMask/connect-monorepo/pull/125))
 - **BREAKING** Rename `createMetamaskConnect` to `createMultichainClient` for a cleaner naming convention ([#114](https://github.com/MetaMask/connect-monorepo/pull/114))
 - Provider is now always available via `sdk.provider` regardless of connection state (wrapper handles disconnected state internally)([#80](https://github.com/MetaMask/connect-monorepo/pull/80))
 

--- a/packages/connect-multichain/src/connect.test.ts
+++ b/packages/connect-multichain/src/connect.test.ts
@@ -134,7 +134,7 @@ function testSuite<T extends MultichainOptions>({
       ] as any;
       sdk = await createSDK(testOptions);
 
-      t.expect(sdk.state).toBe('loaded');
+      t.expect(sdk.status).toBe('loaded');
       // Provider is always available via wrapper transport (handles connection state internally)
       t.expect(sdk.provider).toBeDefined();
       t.expect(() => sdk.transport).toThrow();
@@ -181,10 +181,10 @@ function testSuite<T extends MultichainOptions>({
         //Expect to find all the transport mocks DISCONNECTED
         t.expect(mockedData.mockDefaultTransport.__isConnected).toBe(false);
         t.expect(mockedData.mockDappClient.state).toBe('DISCONNECTED');
-        t.expect(sdk.state === 'disconnected').toBe(true);
+        t.expect(sdk.status === 'disconnected').toBe(true);
       } else {
         // If timed out, at least verify it's not connected
-        t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.state);
+        t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.status);
       }
       
       // Ensure both promises are fully handled to prevent unhandled rejections
@@ -192,7 +192,7 @@ function testSuite<T extends MultichainOptions>({
       
       // Disconnect SDK to clean up any ongoing async operations
       try {
-        if (sdk.state !== 'disconnected' && sdk.state !== 'pending') {
+        if (sdk.status !== 'disconnected' && sdk.status !== 'pending') {
           await sdk.disconnect().catch(() => {
             // Ignore disconnect errors
           });
@@ -226,14 +226,14 @@ function testSuite<T extends MultichainOptions>({
 
         sdk = await createSDK(testOptions);
 
-        t.expect(sdk.state).toBe('loaded');
+        t.expect(sdk.status).toBe('loaded');
         // Provider is always available via wrapper transport (handles connection state internally)
         t.expect(sdk.provider).toBeDefined();
         t.expect(() => sdk.transport).toThrow();
 
         await sdk.connect(scopes, caipAccountIds);
 
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
         t.expect(sdk.storage).toBeDefined();
         t.expect(sdk.transport).toBeDefined();
         t.expect(sdk.provider).toBeDefined();;
@@ -266,7 +266,7 @@ function testSuite<T extends MultichainOptions>({
         );
 
         sdk = await createSDK(testOptions);
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
         t.expect(sdk.transport).toBeDefined();
         t.expect(sdk.provider).toBeDefined();;
         t.expect(sdk.storage).toBeDefined();
@@ -303,7 +303,7 @@ function testSuite<T extends MultichainOptions>({
         t.expect(sdk.transport).toBeDefined();
         t.expect(sdk.provider).toBeDefined();;
         t.expect(sdk.storage).toBeDefined();
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
 
         if (isWebEnv) {
           t.expect(mockedData.mockDefaultTransport.__isConnected).toBe(true);
@@ -345,7 +345,7 @@ function testSuite<T extends MultichainOptions>({
 
         unloadSpy = t.vi.spyOn((sdk as any).options.ui.factory, 'unload');
 
-        t.expect(sdk.state).toBe('loaded');
+        t.expect(sdk.status).toBe('loaded');
         t.expect(() => sdk.transport).toThrow();
 
         if (platform !== 'web' && platform !== 'web-mobile') {
@@ -380,7 +380,7 @@ function testSuite<T extends MultichainOptions>({
           ),
         ]);
 
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
         t.expect(sdk.storage).toBeDefined();
         t.expect(sdk.provider).toBeDefined();;
         t.expect(sdk.transport).toBeDefined();
@@ -414,7 +414,7 @@ function testSuite<T extends MultichainOptions>({
 
       sdk = await createSDK(testOptions);
 
-      t.expect(sdk.state).toBe('loaded');
+      t.expect(sdk.status).toBe('loaded');
       t.expect(() => sdk.transport).toThrow();
 
       // Add timeout wrapper for web-mobile platform to prevent hanging
@@ -455,10 +455,10 @@ function testSuite<T extends MultichainOptions>({
       // For web-mobile, timeout might be expected due to deeplink hanging
       if (!timedOut) {
         t.expect(connectError).toBe(sessionError);
-        t.expect(sdk.state === 'disconnected').toBe(true);
+        t.expect(sdk.status === 'disconnected').toBe(true);
       } else {
         // If timed out, at least verify it's not connected
-        t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.state);
+        t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.status);
       }
       
       // Ensure both promises are fully handled to prevent unhandled rejections
@@ -466,7 +466,7 @@ function testSuite<T extends MultichainOptions>({
       
       // Disconnect SDK to clean up any ongoing async operations
       try {
-        if (sdk.state !== 'disconnected' && sdk.state !== 'pending') {
+        if (sdk.status !== 'disconnected' && sdk.status !== 'pending') {
           await sdk.disconnect().catch(() => {
             // Ignore disconnect errors
           });
@@ -519,7 +519,7 @@ function testSuite<T extends MultichainOptions>({
 
       sdk = await createSDK(testOptions);
       await sdk.connect(scopes, caipAccountIds);
-      t.expect(sdk.state).toBe('connected');
+      t.expect(sdk.status).toBe('connected');
       t.expect(sdk.provider).toBeDefined();;
       t.expect(sdk.transport).toBeDefined();
 
@@ -542,7 +542,7 @@ function testSuite<T extends MultichainOptions>({
 
           sdk = await createSDK(testOptions);
 
-          t.expect(sdk.state).toBe('connected');
+          t.expect(sdk.status).toBe('connected');
           t.expect(sdk.provider).toBeDefined();;
           t.expect(sdk.transport).toBeDefined();
 

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -12,7 +12,7 @@ import type { StoreClient } from '../store/client';
 import type { InvokeMethodOptions, RPCAPI, Scope } from './api/types';
 import type { MultichainOptions, ExtendedTransport } from './types';
 
-export type SDKState =
+export type ConnectionStatus =
   | 'pending'
   | 'loaded'
   | 'disconnected'
@@ -34,7 +34,7 @@ export enum TransportType {
 export abstract class MultichainCore extends EventEmitter<SDKEvents> {
   abstract storage: StoreClient;
 
-  abstract state: SDKState;
+  abstract status: ConnectionStatus;
 
   abstract provider: MultichainApiClient<RPCAPI>;
 

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -60,7 +60,7 @@ function testSuite<T extends MultichainOptions>({
         sdk = await createSDK(testOptions);
         // Verify initialization through observable state - SDK should be in a valid state
         t.expect(sdk).toBeDefined();
-        t.expect(['pending', 'loaded', 'connected']).toContain(sdk.state);
+        t.expect(['pending', 'loaded', 'connected']).toContain(sdk.status);
       },
     );
 
@@ -110,7 +110,7 @@ function testSuite<T extends MultichainOptions>({
         t.expect(mockLogger).not.toHaveBeenCalled();
 
         // Verify initialization and analytics setup through observable effects
-        t.expect(sdk.state).toBe('loaded');
+        t.expect(sdk.status).toBe('loaded');
         t.expect(loggerModule.enableDebug).toHaveBeenCalledWith(
           'metamask-sdk:core',
         );
@@ -121,7 +121,7 @@ function testSuite<T extends MultichainOptions>({
       `${platform} should properly initialize if no transport is found during init`,
       async () => {
         sdk = await createSDK(testOptions);
-        t.expect(sdk.state).toBe('loaded');
+        t.expect(sdk.status).toBe('loaded');
         t.expect(() => sdk.transport).toThrow();
       },
     );
@@ -147,7 +147,7 @@ function testSuite<T extends MultichainOptions>({
 
         sdk = await createSDK(testOptions);
 
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
 
         t.expect(sdk.transport).toBeDefined();
         t.expect(sdk.storage).toBeDefined();
@@ -184,7 +184,7 @@ function testSuite<T extends MultichainOptions>({
 
         t.expect(sdk).toBeDefined();
 
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
         t.expect(onNotification).toHaveBeenCalledWith({
           method: 'stateChanged',
           params: 'connected',
@@ -248,7 +248,7 @@ function testSuite<T extends MultichainOptions>({
         sdk = await createSDK(testOptions);
 
         t.expect(sdk).toBeDefined();
-        t.expect(sdk.state).toBe('pending');
+        t.expect(sdk.status).toBe('pending');
 
         // Access the mock logger from the module
         const mockLogger = (loggerModule as any).__mockLogger;

--- a/packages/connect-multichain/src/invoke.test.ts
+++ b/packages/connect-multichain/src/invoke.test.ts
@@ -115,14 +115,14 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 
 			sdk = await createSDK(testOptions);
 
-			t.expect(sdk.state).toBe('loaded');
+			t.expect(sdk.status).toBe('loaded');
 			// Provider is always available via wrapper transport (handles connection state internally)
 			t.expect(sdk.provider).toBeDefined();
 			t.expect(() => sdk.transport).toThrow();
 
 			await sdk.connect(scopes, caipAccountIds);
 
-			t.expect(sdk.state).toBe('connected');
+			t.expect(sdk.status).toBe('connected');
 			t.expect(sdk.storage).toBeDefined();
 			t.expect(sdk.transport).toBeDefined();
 			if (platform === 'web-mobile') {
@@ -157,7 +157,7 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 
 				sdk = await createSDK(testOptions);
 				await sdk.connect(scopes, caipAccountIds);
-				t.expect(sdk.state).toBe('connected');
+				t.expect(sdk.status).toBe('connected');
 
 				if (platform === 'web-mobile') {
 					sdk.transport.getActiveSession = t.vi.fn().mockResolvedValue({id: 'mock-session-id'});
@@ -201,13 +201,13 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 				},
 			});
 
-			t.expect(sdk.state).toBe('loaded');
+			t.expect(sdk.status).toBe('loaded');
 			t.expect(() => sdk.provider).toThrow();
 			t.expect(() => sdk.transport).toThrow();
 
 			await sdk.connect(scopes, caipAccountIds);
 
-			t.expect(sdk.state).toBe('connected');
+			t.expect(sdk.status).toBe('connected');
 
 			const options = { scope: 'eip155:1', request: { method: 'eth_accounts', params: [] } } as InvokeMethodOptions;
 			const result = await sdk.invokeMethod(options);
@@ -234,7 +234,7 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 					params: [],
 				},
 			} as InvokeMethodOptions;
-			t.expect(sdk.state).toBe('connected');
+			t.expect(sdk.status).toBe('connected');
 			t.expect(sdk.provider).toBeDefined();;
 
 			if (platform === 'web-mobile') {

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -133,7 +133,7 @@ function testSuite<T extends MultichainOptions>({
 
       sdk = await createSDK(testOptions);
 
-      t.expect(sdk.state).toBe('connected');
+      t.expect(sdk.status).toBe('connected');
       t.expect(sdk.transport).toBeDefined();
       t.expect(sdk.provider).toBeDefined();
       t.expect(sdk.storage).toBeDefined();
@@ -218,7 +218,7 @@ function testSuite<T extends MultichainOptions>({
         );
 
         sdk = await createSDK(testOptions);
-        t.expect(sdk.state).toBe('connected');
+        t.expect(sdk.status).toBe('connected');
 
         t.expect(sdk).toBeDefined();
         t.expect(sdk.transport).toBeDefined();
@@ -284,7 +284,7 @@ function testSuite<T extends MultichainOptions>({
         sdk = await createSDK(testOptions);
 
         t.expect(sdk).toBeDefined();
-        t.expect(sdk.state === 'loaded').toBe(true);
+        t.expect(sdk.status === 'loaded').toBe(true);
 
         // For web-mobile, connect might hang waiting for deeplink
         // Use a shorter timeout and handle both success and timeout cases
@@ -328,11 +328,11 @@ function testSuite<T extends MultichainOptions>({
         // Verify state is disconnected after error (or timeout)
         // For web-mobile, if it timed out, the state might still be 'loaded' or 'connecting'
         if (!timedOut) {
-          t.expect(sdk.state === 'disconnected').toBe(true);
+          t.expect(sdk.status === 'disconnected').toBe(true);
           t.expect(connectError).toBeDefined();
         } else {
           // If timed out, at least verify it's not connected
-          t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.state);
+          t.expect(['loaded', 'disconnected', 'connecting']).toContain(sdk.status);
         }
         
         // Ensure both promises are fully handled to prevent unhandled rejections
@@ -341,7 +341,7 @@ function testSuite<T extends MultichainOptions>({
         
         // Disconnect SDK to clean up any ongoing async operations
         try {
-          if (sdk.state !== 'disconnected' && sdk.state !== 'pending') {
+          if (sdk.status !== 'disconnected' && sdk.status !== 'pending') {
             await sdk.disconnect().catch(() => {
               // Ignore disconnect errors
             });

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
   const [caipAccountIds, setCaipAccountIds] = useState<CaipAccountId[]>([]);
   const {
     error,
-    state,
+    status,
     session,
     connect: sdkConnect,
     disconnect: sdkDisconnect,
@@ -119,9 +119,9 @@ function App() {
     }
   }, [customScopes, connectors, wagmiConnectAsync]);
 
-  const isConnected = state === 'connected';
+  const isConnected = status === 'connected';
   const isDisconnected =
-    state === 'disconnected' || state === 'pending' || state === 'loaded';
+    status === 'disconnected' || status === 'pending' || status === 'loaded';
 
   const disconnect = useCallback(async () => {
     // Disconnect all connections if connected
@@ -145,7 +145,7 @@ function App() {
     return all;
   }, []);
 
-  const isConnecting = state === 'connecting';
+  const isConnecting = status === 'connecting';
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center">
       <div className="max-w-6xl w-full p-8">

--- a/playground/browser-playground/src/sdk/SDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/SDKProvider.tsx
@@ -6,7 +6,7 @@ import {
   type InvokeMethodOptions,
   type MultichainCore,
   type Scope,
-  type SDKState,
+  type ConnectionStatus,
   type SessionData,
 } from '@metamask/connect';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
@@ -25,7 +25,7 @@ import {
 const SDKContext = createContext<
   | {
       session: SessionData | undefined;
-      state: SDKState;
+      status: ConnectionStatus;
       error: Error | null;
       connect: (
         scopes: Scope[],
@@ -38,7 +38,7 @@ const SDKContext = createContext<
 >(undefined);
 
 export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
-  const [state, setState] = useState<SDKState>('pending');
+  const [status, setStatus] = useState<ConnectionStatus>('pending');
   const [session, setSession] = useState<SessionData | undefined>(undefined);
   const [error, setError] = useState<Error | null>(null);
 
@@ -65,7 +65,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
             ) {
               setSession(payload.params as SessionData);
             } else if (payload.method === 'stateChanged') {
-              setState(payload.params as SDKState);
+              setStatus(payload.params as ConnectionStatus);
             }
           },
         },
@@ -116,7 +116,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
     <SDKContext.Provider
       value={{
         session,
-        state,
+        status,
         error,
         connect,
         disconnect,

--- a/playground/react-native-playground/src/sdk/SDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/SDKProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { createMultichainClient, type SDKState, type InvokeMethodOptions, type Scope, type SessionData, type MultichainCore, getInfuraRpcUrls } from '@metamask/connect-multichain';
+import { createMultichainClient, type ConnectionStatus, type InvokeMethodOptions, type Scope, type SessionData, type MultichainCore, getInfuraRpcUrls } from '@metamask/connect-multichain';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
 import type { CaipAccountId } from '@metamask/utils';
 import type React from 'react';
@@ -10,7 +10,7 @@ import { Linking } from 'react-native';
 const SDKContext = createContext<
 	| {
 		session: SessionData | undefined;
-		state: SDKState;
+		status: ConnectionStatus;
 		error: Error | null;
 		connect: (scopes: Scope[], caipAccountIds: CaipAccountId[]) => Promise<void>;
 		disconnect: () => Promise<void>;
@@ -20,7 +20,7 @@ const SDKContext = createContext<
 >(undefined);
 
 export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
-	const [state, setState] = useState<SDKState>('pending');
+	const [status, setStatus] = useState<ConnectionStatus>('pending');
 	const [session, setSession] = useState<SessionData | undefined>(undefined);
 	const [error, setError] = useState<Error | null>(null);
 
@@ -48,7 +48,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
 						if (payload.method === 'wallet_sessionChanged' || payload.method === 'wallet_createSession' || payload.method === 'wallet_getSession') {
 							setSession(payload.params as SessionData);
 						} else if (payload.method === 'stateChanged') {
-							setState(payload.params as SDKState);
+							setStatus(payload.params as ConnectionStatus);
 						}
 					},
 				},
@@ -102,7 +102,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
 		<SDKContext.Provider
 			value={{
 				session,
-				state,
+				status,
 				error,
 				connect,
 				disconnect,


### PR DESCRIPTION
**Type rename: `SDKState` → `ConnectionStatus`**
- `packages/connect-multichain/src/domain/multichain/index.ts` - renamed the type and updated abstract class

**Property rename: `state` → `status`**
- `packages/connect-multichain/src/multichain/index.ts`:
  - `_state` → `_status`
  - `get state()` → `get status()`
  - `set state()` → `set status()`
  - All internal usages of `this.state` → `this.status`

Wonder if we should also change the Mobile-Wallet-Protocols use of `state` to mean `status` as well