### PR TITLE
feat: fully support `display_uri` on MetaMask Connect

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -283,6 +283,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
               chainChanged: this.onChainChanged.bind(this),
               connect: this.onConnect.bind(this),
               disconnect: this.onDisconnect.bind(this),
+              displayUri: this.onDisplayUri.bind(this),
             },
             ...(parameters.mobile && { mobile: parameters.mobile }),
           });

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `display_uri` event support for custom QR code UI implementations ([#130](https://github.com/MetaMask/connect-monorepo/pull/130))
+  - `display_uri` event on `EIP1193Provider` emitted when QR code link is available
+  - `displayUri` callback in `EventHandlers` for event-based subscriptions
+  - Forwarded from `@metamask/connect-multichain` core to EIP-1193 provider layer
 - Add `mobile.preferredOpenLink` option support for React Native deeplink handling in wagmi connector ([#118](https://github.com/MetaMask/connect-monorepo/pull/118))
   - Allows React Native apps to use `Linking.openURL()` instead of `window.location.href` for opening MetaMask deeplinks
   - Required for wagmi connector usage in React Native environments

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -96,6 +96,9 @@ export class MetamaskConnectEVM {
   /** The handler for the wallet_sessionChanged event */
   readonly #sessionChangedHandler: (session?: SessionData) => void;
 
+  /** The handler for the display_uri event */
+  readonly #displayUriHandler: (uri: string) => void;
+
   /** The clean-up function for the notification handler */
   #removeNotificationHandler?: () => void;
 
@@ -130,6 +133,13 @@ export class MetamaskConnectEVM {
       'wallet_sessionChanged',
       this.#sessionChangedHandler.bind(this),
     );
+
+    /**
+     * Handles the display_uri event.
+     * Forwards the QR code URI to the provider for custom UI implementations.
+     */
+    this.#displayUriHandler = this.#onDisplayUri.bind(this);
+    this.#core.on('display_uri', this.#displayUriHandler);
 
     // Attempt to set the permitted accounts if there's a valid previous session.
     // TODO (wenfix): does it make sense to catch here?
@@ -466,6 +476,7 @@ export class MetamaskConnectEVM {
     this.#clearConnectionState();
 
     this.#core.off('wallet_sessionChanged', this.#sessionChangedHandler);
+    this.#core.off('display_uri', this.#displayUriHandler);
 
     if (this.#removeNotificationHandler) {
       this.#removeNotificationHandler();
@@ -782,6 +793,18 @@ export class MetamaskConnectEVM {
     this.#eventHandlers?.disconnect?.();
 
     this.#onAccountsChanged([]);
+  }
+
+  /**
+   * Handles display_uri events and emits them to the provider.
+   * This allows consumers to display their own custom QR code UI.
+   *
+   * @param uri - The deeplink URI to be displayed as a QR code
+   */
+  #onDisplayUri(uri: string): void {
+    logger('handler: display_uri', uri);
+    this.#provider.emit('display_uri', uri);
+    this.#eventHandlers?.displayUri?.(uri);
   }
 
   /**

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -12,6 +12,12 @@ export type EIP1193ProviderEvents = {
   accountsChanged: [Address[]];
   chainChanged: [Hex];
   message: [{ type: string; data: unknown }];
+  /**
+   * Emitted when a QR code URI is available for display.
+   * This allows consumers to show their own custom QR code UI.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  display_uri: [string];
   connectAndSign: [
     { accounts: readonly Address[]; chainId: number; signResponse: string },
   ];
@@ -29,6 +35,7 @@ export type EventHandlers = {
   disconnect: () => void;
   accountsChanged: (accounts: Address[]) => void;
   chainChanged: (chainId: Hex) => void;
+  displayUri: (uri: string) => void;
   connectAndSign: (result: {
     accounts: readonly Address[];
     chainId: number;

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `display_uri` event emission for QR code links to support custom UI implementations ([#130](https://github.com/MetaMask/connect-monorepo/pull/130))
+  - Emitted when QR code link is generated during connection
+  - Emitted when QR code is regenerated on expiration
+  - Emitted for deeplink connections on mobile web
+- Add `onDisplayUri` callback to `InstallWidgetProps` for notifying when QR codes are generated/regenerated ([#130](https://github.com/MetaMask/connect-monorepo/pull/130))
+- Add headless mode support that emits `display_uri` without rendering modal UI ([#130](https://github.com/MetaMask/connect-monorepo/pull/130))
 - Add `sessionProperties` parameter to `connect()` method for passing custom session configuration to wallets([#80](https://github.com/MetaMask/connect-monorepo/pull/80))
 - Introduce `MultichainApiClientWrapperTransport` to provide the provider interface before connection is established([#80](https://github.com/MetaMask/connect-monorepo/pull/80))
 

--- a/packages/connect-multichain/src/domain/ui/types.ts
+++ b/packages/connect-multichain/src/domain/ui/types.ts
@@ -12,6 +12,13 @@ export type InstallWidgetProps = Components.MmInstallModal & {
   startDesktopOnboarding: () => void;
   createConnectionRequest: () => Promise<ConnectionRequest>;
   generateQRCode: (connectionRequest: ConnectionRequest) => Promise<QRLink>;
+  /**
+   * Callback invoked when a QR code link is generated or regenerated.
+   * This allows consumers to display their own custom QR code UI.
+   *
+   * @param uri - The deeplink URI to be displayed as a QR code
+   */
+  onDisplayUri?: (uri: QRLink) => void;
 };
 
 export type OTPCodeWidgetProps = Components.MmOtpModal & {

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -411,6 +411,9 @@ export class MultichainSDK extends MultichainCore {
               resolve();
             }
           },
+          (uri: string) => {
+            this.emit('display_uri', uri);
+          },
         )
         .catch((error) => {
           reject(error instanceof Error ? error : new Error(String(error)));
@@ -426,12 +429,86 @@ export class MultichainSDK extends MultichainCore {
   ): Promise<void> {
     // create the listener only once to avoid memory leaks
     this.#beforeUnloadListener ??= this.#createBeforeUnloadListener();
-    await this.#renderInstallModalAsync(
-      desktopPreferred,
-      scopes,
-      caipAccountIds,
-      sessionProperties,
-    );
+
+    // In headless mode, don't render UI but still emit display_uri events
+    if (this.options.ui.headless) {
+      await this.#headlessConnect(scopes, caipAccountIds, sessionProperties);
+    } else {
+      await this.#renderInstallModalAsync(
+        desktopPreferred,
+        scopes,
+        caipAccountIds,
+        sessionProperties,
+      );
+    }
+  }
+
+  /**
+   * Handles connection in headless mode without rendering any UI.
+   * Emits display_uri events to allow consumers to build custom QR code UI.
+   *
+   * @param scopes - The requested permission scopes
+   * @param caipAccountIds - The requested account IDs
+   * @param sessionProperties - Optional session properties
+   */
+  async #headlessConnect(
+    scopes: Scope[],
+    caipAccountIds: CaipAccountId[],
+    sessionProperties?: SessionProperties,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (
+        this.dappClient.state === 'CONNECTED' ||
+        this.dappClient.state === 'CONNECTING'
+      ) {
+        this.dappClient.disconnect().catch(() => {
+          // Ignore disconnect errors
+        });
+      }
+
+      // Listen for session_request to generate and emit the QR code link
+      this.dappClient.on(
+        'session_request',
+        (sessionRequest: SessionRequest) => {
+          const connectionRequest: ConnectionRequest = {
+            sessionRequest,
+            metadata: {
+              dapp: this.options.dapp,
+              sdk: {
+                version: getVersion(),
+                platform: getPlatformType(),
+              },
+            },
+          };
+
+          // Generate and emit the QR code link
+          const deeplink = this.options.ui.factory.createConnectionDeeplink(connectionRequest);
+          this.emit('display_uri', deeplink);
+        },
+      );
+
+      // Start the connection
+      this.transport
+        .connect({ scopes, caipAccountIds, sessionProperties })
+        .then(async () => {
+          this.status = 'connected';
+          await this.storage.setTransport(TransportType.MWP);
+          resolve();
+        })
+        .catch(async (error) => {
+          if (error instanceof ProtocolError) {
+            // In headless mode, we don't auto-regenerate QR codes
+            // since there's no modal to display them
+            this.status = 'disconnected';
+            await this.storage.removeTransport();
+            reject(error);
+          } else {
+            this.status = 'disconnected';
+            await this.storage.removeTransport();
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+    });
   }
 
   async #setupDefaultTransport(): Promise<DefaultTransport> {
@@ -502,6 +579,10 @@ export class MultichainSDK extends MultichainCore {
               this.options.ui.factory.createConnectionUniversalLink(
                 connectionRequest,
               );
+
+            // Emit display_uri event for deeplink connections
+            this.emit('display_uri', deeplink);
+
             if (this.options.mobile?.preferredOpenLink) {
               this.options.mobile.preferredOpenLink(deeplink, '_self');
             } else {

--- a/playground/browser-playground/src/wagmi/metamask-connector.ts
+++ b/playground/browser-playground/src/wagmi/metamask-connector.ts
@@ -301,6 +301,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
               chainChanged: this.onChainChanged.bind(this),
               connect: this.onConnect.bind(this),
               disconnect: this.onDisconnect.bind(this),
+              displayUri: this.onDisplayUri.bind(this),
             },
             ...(parameters.mobile && { mobile: parameters.mobile }),
           });

--- a/playground/react-native-playground/src/wagmi/metamask-connector.ts
+++ b/playground/react-native-playground/src/wagmi/metamask-connector.ts
@@ -301,6 +301,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
               chainChanged: this.onChainChanged.bind(this),
               connect: this.onConnect.bind(this),
               disconnect: this.onDisconnect.bind(this),
+              displayUri: this.onDisplayUri.bind(this),
             },
             ...(parameters.mobile && { mobile: parameters.mobile }),
           });


### PR DESCRIPTION
## Explanation

This PR updates `@metamask/connect-evm` and `@metamask/connect-multichain` to fully support `display_uri` event, ensuring backwards compatibility with libraries using `metamask-sdk`

### What Was Missing (Now Implemented)

1. ~~**No `display_uri` emission**~~: ✅ Now emits `display_uri` events when QR codes are generated/regenerated
2. ~~**Wagmi connector not wired up**~~: ✅ `onDisplayUri` handler now wired to `displayUri` event handler
3. ~~**Headless mode incomplete**~~: ✅ Headless mode now emits `display_uri` without rendering modal

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-965

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
