### PR TITLE
build: ensure browser playground is deployed to gh pages on new releases

### DIFF
--- a/.github/workflows/deploy-browser-playground-to-gh-pages.yml
+++ b/.github/workflows/deploy-browser-playground-to-gh-pages.yml
@@ -1,0 +1,68 @@
+name: Deploy Browser Playground to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        required: true
+        type: string
+    secrets:
+      PUBLISH_DOCS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      destination_dir:
+        description: 'Destination directory on GitHub Pages (e.g., "latest", "1.0.2", "browser-playground")'
+        required: true
+        type: string
+
+jobs:
+  deploy-browser-playground-to-gh-pages:
+    name: Deploy Browser Playground to GitHub Pages
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+
+    steps:
+      - name: Ensure `destination_dir` is not empty
+        if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install Yarn
+        run: corepack enable
+
+      - name: Restore Yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies via Yarn
+        run: yarn --immutable
+
+      - name: Build workspace dependencies
+        run: |
+          # Build all packages (workspace dependencies) in topological order
+          # This ensures @metamask/connect and other dependencies are built first
+          yarn workspaces foreach --all --topological-dev --verbose --no-private run build
+
+      - name: Build browser playground
+        working-directory: playground/browser-playground
+        run: yarn build
+
+      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+        with:
+          # This `PUBLISH_DOCS_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `github-pages` environment.
+          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+          publish_dir: ./playground/browser-playground/build
+          destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -110,10 +110,32 @@ jobs:
 
   publish-wagmi-to-latest-gh-pages:
     name: Publish Wagmi Integration to `latest` directory of `gh-pages` branch
-    needs: publish-npm
+    needs: publish-wagmi-to-gh-pages
     permissions:
       contents: write
     uses: ./.github/workflows/deploy-wagmi-to-gh-pages.yml
+    with:
+      destination_dir: latest
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-browser-playground-to-gh-pages:
+    name: Publish Browser Playground to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    needs: get-release-version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/deploy-browser-playground-to-gh-pages.yml
+    with:
+      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-browser-playground-to-latest-gh-pages:
+    name: Publish Browser Playground to `latest` directory of `gh-pages` branch
+    needs: publish-browser-playground-to-gh-pages
+    permissions:
+      contents: write
+    uses: ./.github/workflows/deploy-browser-playground-to-gh-pages.yml
     with:
       destination_dir: latest
     secrets:


### PR DESCRIPTION
## Explanation

This PR ensures the browser playground is automatically re-deployed when a new release is cut.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-917

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
