### PR TITLE
build: revert `playground-ui` versioning (not published yet, so should be `0.0.0`)

### DIFF
--- a/playground/playground-ui/package.json
+++ b/playground/playground-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/playground-ui",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Shared UI logic and utilities for MetaMask playground applications",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Explanation

This PR fixes versioning for `playground-ui` utility package which is yet to be released, so should be at `0.0.0`.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
