### PR TITLE
feat: Add `status` to `ConnectEvm`

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ConnectEvm.status` property which exposes the current `ConnectionStatus` ([#136](https://github.com/MetaMask/connect-monorepo/pull/136))
+
 ## [0.2.0]
 
 ### Added

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1,6 +1,7 @@
 import { analytics } from '@metamask/analytics';
 import type { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 import type {
+  ConnectionStatus,
   MultichainCore,
   MultichainOptions,
   Scope,
@@ -914,6 +915,15 @@ export class MetamaskConnectEVM {
    */
   get selectedChainId(): Hex | undefined {
     return this.#provider.selectedChainId;
+  }
+
+  /**
+   * Gets the current connection status
+   *
+   * @returns The current connection status
+   */
+  get status(): ConnectionStatus {
+    return this.#core.status;
   }
 }
 


### PR DESCRIPTION
## Explanation

Passesthrough the `ConnectMultichain.status` value in `ConnectEvm` on a new `status` getter since there is no other way to know the current `ConnectMultichain` connection status otherwise if you don't have a listener set up

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
