### PR TITLE
fix: Fix empty `sessionProperties` causing initial connection request to fail

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `ConnectEvm.connect()` not being able to establish an initial connection due to empty object `sessionProperties` ([#138](https://github.com/MetaMask/connect-monorepo/pull/138))
+
 ## [0.3.0]
 
 ### Added

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -325,7 +325,7 @@ export class MetamaskConnectEVM {
     await this.#core.connect(
       caipChainIds as Scope[],
       caipAccountIds as CaipAccountId[],
-      {},
+      undefined,
       forceRequest,
     );
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ConnectMultichain.connect()` will send `sessionProperties` as undefined when called with an empty object `{}` in order to ensure that the initial `wallet_createSession` request does not fail immediately ([#138](https://github.com/MetaMask/connect-monorepo/pull/138))
+
 ## [0.5.1]
 
 ### Fixed

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -708,10 +708,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       logger('Error tracking connection_initiated event', error);
     }
 
+    // Needed because empty object will cause wallet_createSession to return an error
+    const nonEmptySessionProperites = Object.keys(sessionProperties ?? {}).length > 0 ? sessionProperties : undefined;
+
     if (this.#transport?.isConnected() && !secure) {
       return this.#handleConnection(
         this.#transport
-          .connect({ scopes, caipAccountIds, sessionProperties, forceRequest })
+          .connect({ scopes, caipAccountIds, sessionProperties: nonEmptySessionProperites, forceRequest })
           .then(async () => {
             if (this.#transport instanceof MWPTransport) {
               return this.storage.setTransport(TransportType.MWP);
@@ -727,7 +730,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (platformType === PlatformType.MetaMaskMobileWebview) {
       const defaultTransport = await this.#setupDefaultTransport();
       return this.#handleConnection(
-        defaultTransport.connect({ scopes, caipAccountIds, sessionProperties, forceRequest }),
+        defaultTransport.connect({ scopes, caipAccountIds, sessionProperties: nonEmptySessionProperites, forceRequest }),
         scopes,
         transportType,
       );
@@ -738,7 +741,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       const defaultTransport = await this.#setupDefaultTransport();
       // Web transport has no initial payload
       return this.#handleConnection(
-        defaultTransport.connect({ scopes, caipAccountIds, sessionProperties, forceRequest }),
+        defaultTransport.connect({ scopes, caipAccountIds, sessionProperties: nonEmptySessionProperites, forceRequest }),
         scopes,
         transportType,
       );
@@ -755,7 +758,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (secure && !shouldShowInstallModal) {
       // Desktop is not preferred option, so we use deeplinks (mobile web)
       return this.#handleConnection(
-        this.#deeplinkConnect(scopes, caipAccountIds, sessionProperties),
+        this.#deeplinkConnect(scopes, caipAccountIds, nonEmptySessionProperites),
         scopes,
         transportType,
       );
@@ -763,7 +766,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
     // Show install modal for RN, Web + Node
     return this.#handleConnection(
-      this.#showInstallModal(shouldShowInstallModal, scopes, caipAccountIds, sessionProperties),
+      this.#showInstallModal(shouldShowInstallModal, scopes, caipAccountIds, nonEmptySessionProperites),
       scopes,
       transportType,
     );


### PR DESCRIPTION
## Explanation

`wallet_createSession` throws if an [empty object is passed ](https://github.com/MetaMask/core/blob/48097e22873198612b3f49c3a7fc0df7c4f4f5b3/packages/multichain-api-middleware/src/handlers/wallet-createSession.ts#L101)into the `sessionProperties` param. This PR fixes `ConnectEvm.connect()` to not pass an empty `sessionProperties` object to `ConnectMultichain.connect()`. It also fixes `ConnectMultichain.connect()` to check if `sessionProperties` is empty and sets it to undefined for subsequent calls if so.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
