### PR TITLE
feat: expose `ui` param option for `createEVMClient`

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added:
+### Added
+
 - `createEVMClient` now accepts `ui` in its param options. See `@metamask/connect-multichain` for usage ([#140](https://github.com/MetaMask/connect-monorepo/pull/140))
 
 ## [0.3.1]

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+- `createEVMClient` now accepts `ui` in its param options. See `@metamask/connect-multichain` for usage ([#140](https://github.com/MetaMask/connect-monorepo/pull/140))
+
 ### Fixed
 
 - Fix `ConnectEvm.connect()` not being able to establish an initial connection due to empty object `sessionProperties` ([#138](https://github.com/MetaMask/connect-monorepo/pull/138))

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `createEVMClient` now accepts `ui` in its param options. See `@metamask/connect-multichain` for usage ([#140](https://github.com/MetaMask/connect-monorepo/pull/140))
+- `createEVMClient` now accepts `ui` in its param options. See `@metamask/connect-multichain` for examples of usage ([#140](https://github.com/MetaMask/connect-monorepo/pull/140))
 
 ## [0.3.1]
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -939,12 +939,17 @@ export class MetamaskConnectEVM {
  * @param options.dapp - Dapp identification and branding settings
  * @param options.api - API configuration including read-only RPC map
  * @param options.api.supportedNetworks - A map of CAIP chain IDs to RPC URLs for read-only requests
+ * @param options.ui - UI configuration options
+ * @param options.ui.headless - Whether to run without UI
+ * @param options.ui.preferExtension - Whether to prefer browser extension
+ * @param options.ui.showInstallModal - Whether to render installation modal for desktop extension
  * @param options.eventEmitter - The event emitter to use for the Metamask Connect/EVM layer
  * @param options.eventHandlers - The event handlers to use for the Metamask Connect/EVM layer
  * @returns The Metamask Connect/EVM layer instance
  */
 export async function createEVMClient(
-  options: Pick<MultichainOptions, 'dapp' | 'api'> & {
+  options: Pick<MultichainOptions, 'dapp' | 'api'> &
+  { ui?: Omit<MultichainOptions['ui'], 'factory'>; } & {
     eventHandlers?: Partial<EventHandlers>;
     debug?: boolean;
   },


### PR DESCRIPTION
## Explanation

Adds `ui` param option to `createEVMClient()` which exposes the underlying `MetaMaskConnectMultichain`  `ui` param option

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
