### PR TITLE
feat: use hex instead of decimal chainId for connect-evm

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -19,6 +19,7 @@ import type { ExactPartial, OneOf, UnionCompute } from '@wagmi/core/internal';
 import {
   type Address,
   getAddress,
+  type Hex,
   type ProviderConnectInfo,
   ResourceUnavailableRpcError,
   type RpcError,
@@ -90,7 +91,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         let signResponse: string | undefined;
         let connectWithResponse: unknown | undefined;
         if (!accounts?.length) {
-          const chainIds = config.chains.map((chain) => chain.id);
+          // Convert numeric chain IDs to hex format for connect-evm API
+          const chainIds = config.chains.map(
+            (chain): Hex => `0x${chain.id.toString(16)}`,
+          );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
               signResponse = await instance.connectAndSign({
@@ -126,13 +130,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (signResponse) {
           provider.emit('connectAndSign', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             signResponse,
           });
         } else if (connectWithResponse) {
           provider.emit('connectWith', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             connectWithResponse,
           });
         }
@@ -217,8 +221,9 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
+        const hexChainId: Hex = `0x${chainId.toString(16)}`;
         await instance.switchChain({
-          chainId,
+          chainId: hexChainId,
           chainConfiguration: {
             blockExplorerUrls: addEthereumChainParameter?.blockExplorerUrls
               ? [...addEthereumChainParameter.blockExplorerUrls]
@@ -293,9 +298,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           })();
           metamaskPromise = createEVMClient({
             api: {
+              // Use hex chain IDs as keys for supportedNetworks
               supportedNetworks: Object.fromEntries(
                 config.chains.map((chain) => [
-                  `eip155:${chain.id}`,
+                  `0x${chain.id.toString(16)}`,
                   chain.rpcUrls.default?.http[0],
                 ]),
               ),

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** Standardize `chainId` to use `Hex` format throughout the public API ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
+  - `connect()`, `connectAndSign()`, and `connectWith()` now expect `chainIds` as hex strings instead of decimal numbers
+  - `connect()` now returns `{ accounts, chainId: Hex }` instead of `{ accounts, chainId: number }`
+  - `switchChain()` now expects `chainId: Hex` instead of `chainId: number | Hex`
+  - `createEVMClient()` param option `api.supportedNetworks` now expects hex chain IDs as keys (e.g., `'0x1'`) instead of CAIP chain IDs
+  - Event handler types for `connectAndSign` and `connectWith` now use `Hex` for `chainId`
 - The `debug` option param used by `createEVMClient()` now enables console debug logs of the underlying `MultichainClient` instance. ([#149](https://github.com/MetaMask/connect-monorepo/pull/149))
 
 ## [0.4.1]

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -33,10 +33,15 @@ const sdk = await createEVMClient({
     name: 'My DApp',
     url: 'https://mydapp.com',
   },
+  api: {
+    supportedNetworks: {
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY',
+    },
+  },
 });
 
-// Connect to MetaMask
-await sdk.connect({ chainId: 1 }); // Connect to Ethereum Mainnet
+// Connect to MetaMask (chainIds use hex format)
+await sdk.connect({ chainIds: ['0x1'] }); // Connect to Ethereum Mainnet
 
 // Get the EIP-1193 provider
 const provider = await sdk.getProvider();
@@ -59,16 +64,23 @@ const sdk = await createEVMClient({
     name: 'My DApp',
     url: 'https://mydapp.com',
   },
+  api: {
+    // Chain IDs are specified in hex format
+    supportedNetworks: {
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY', // Ethereum Mainnet
+      '0x89': 'https://polygon-rpc.com', // Polygon
+    },
+  },
 });
 
 // Connect with default chain (mainnet)
 const { accounts, chainId } = await sdk.connect();
 
-// Connect to a specific chain
-await sdk.connect({ chainId: 137 }); // Polygon
+// Connect to specific chains (chainIds use hex format)
+await sdk.connect({ chainIds: ['0x89'] }); // Polygon
 
-// Connect to a specific chain and account
-await sdk.connect({ chainId: 1, account: '0x...' });
+// Connect to specific chains and account
+await sdk.connect({ chainIds: ['0x1'], account: '0x...' });
 ```
 
 ### React Native Support
@@ -85,8 +97,9 @@ const sdk = await createEVMClient({
     url: 'https://mydapp.com',
   },
   api: {
+    // Chain IDs are specified in hex format
     supportedNetworks: {
-      'eip155:1': 'https://mainnet.infura.io/v3/YOUR_KEY',
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY',
     },
   },
   // React Native: use Linking.openURL for deeplinks

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -14,11 +14,7 @@ import {
   isRejectionError,
   TransportType,
 } from '@metamask/connect-multichain';
-import {
-  numberToHex,
-  hexToNumber,
-  isHexString as isHex,
-} from '@metamask/utils';
+import { hexToNumber } from '@metamask/utils';
 
 import { IGNORED_METHODS } from './constants';
 import { enableDebug, logger } from './logger';
@@ -636,7 +632,9 @@ export class MetamaskConnectEVM {
 
     if (isAccountsRequest(request)) {
       const { method } = request;
-      const decimalChainId = hexToNumber(this.#provider.selectedChainId || '0x1')
+      const decimalChainId = hexToNumber(
+        this.#provider.selectedChainId ?? '0x1',
+      );
       const scope: Scope = `eip155:${decimalChainId}`;
       const params: unknown[] = [];
 
@@ -680,7 +678,10 @@ export class MetamaskConnectEVM {
     }
 
     // Get chain ID from config or use current chain
-    const chainId =  chainConfiguration.chainId as Hex || this.#provider.selectedChainId || '0x1';
+    const chainId =
+      (chainConfiguration.chainId as Hex) ||
+      this.#provider.selectedChainId ||
+      '0x1';
     const decimalChainId = hexToNumber(chainId);
     const scope: Scope = `eip155:${decimalChainId}`;
     const params = [chainConfiguration];
@@ -967,7 +968,7 @@ export async function createEVMClient(
     debug?: boolean;
     api: {
       supportedNetworks: Record<Hex, string>;
-    }
+    };
   },
 ): Promise<MetamaskConnectEVM> {
   enableDebug(options.debug);
@@ -986,21 +987,20 @@ export async function createEVMClient(
 
   validSupportedChainsUrls(options.api.supportedNetworks, 'supportedNetworks');
 
-  const supportedNetworksCaipChainId = Object.entries(options.api.supportedNetworks).reduce(
-    (acc, [hexChainId, url]) => {
-      const decimalChainId = parseInt(hexChainId, 16);
-      const caip2ChainId = `eip155:${decimalChainId}`;
-      acc[caip2ChainId] = url;
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
+  const supportedNetworksCaipChainId = Object.entries(
+    options.api.supportedNetworks,
+  ).reduce<Record<string, string>>((acc, [hexChainId, url]) => {
+    const decimalChainId = parseInt(hexChainId, 16);
+    const caip2ChainId = `eip155:${decimalChainId}`;
+    acc[caip2ChainId] = url;
+    return acc;
+  }, {});
 
   try {
     const core = await createMultichainClient({
       ...options,
       api: {
-        supportedNetworks: supportedNetworksCaipChainId
+        supportedNetworks: supportedNetworksCaipChainId,
       },
     });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -680,7 +680,7 @@ export class MetamaskConnectEVM {
     }
 
     // Get chain ID from config or use current chain
-    const chainId =  chainConfiguration.chainId as unknown as Hex || this.#provider.selectedChainId || '0x1';
+    const chainId =  chainConfiguration.chainId as Hex || this.#provider.selectedChainId || '0x1';
     const decimalChainId = hexToNumber(chainId);
     const scope: Scope = `eip155:${decimalChainId}`;
     const params = [chainConfiguration];

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -622,7 +622,7 @@ export class MetamaskConnectEVM {
 
     if (isSwitchChainRequest(request)) {
       return this.switchChain({
-        chainId: request.params[0].chainId as unknown as Hex,
+        chainId: request.params[0].chainId as Hex,
       });
     }
 

--- a/packages/connect-evm/src/provider.ts
+++ b/packages/connect-evm/src/provider.ts
@@ -5,7 +5,7 @@
 /* eslint-disable jsdoc/require-returns -- Inherited from abstract class */
 import type { MultichainCore, Scope } from '@metamask/connect-multichain';
 import { EventEmitter } from '@metamask/connect-multichain';
-import { hexToNumber, numberToHex } from '@metamask/utils';
+import { hexToNumber } from '@metamask/utils';
 
 import { INTERCEPTABLE_METHODS } from './constants';
 import { logger } from './logger';

--- a/packages/connect-evm/src/provider.ts
+++ b/packages/connect-evm/src/provider.ts
@@ -79,8 +79,8 @@ export class EIP1193Provider extends EventEmitter<EIP1193ProviderEvents> {
       throw new Error('No chain ID selected');
     }
 
-    const chainId = hexToNumber(this.#selectedChainId);
-    const scope: Scope = `eip155:${chainId}`;
+    const decimalChainId = hexToNumber(this.#selectedChainId);
+    const scope: Scope = `eip155:${decimalChainId}`;
 
     // Validate that the chain is configured in supportedNetworks
     // This check is performed here to provide better error messages
@@ -120,16 +120,8 @@ export class EIP1193Provider extends EventEmitter<EIP1193ProviderEvents> {
     return this.#selectedChainId;
   }
 
-  public set selectedChainId(chainId: Hex | number | undefined) {
-    const hexChainId =
-      chainId && typeof chainId === 'number' ? numberToHex(chainId) : chainId;
-
-    // Don't overwrite the selected chain ID with an undefined value
-    if (!hexChainId) {
-      return;
-    }
-
-    this.#selectedChainId = hexChainId as Hex;
+  public set selectedChainId(chainId: Hex | undefined) {
+    this.#selectedChainId = chainId;
   }
 
   // ==========================================

--- a/packages/connect-evm/src/types.ts
+++ b/packages/connect-evm/src/types.ts
@@ -7,7 +7,7 @@ export type CaipAccountId = `${string}:${string}:${string}`;
 export type CaipChainId = `${string}:${string}`;
 
 export type EIP1193ProviderEvents = {
-  connect: [{ chainId: string }];
+  connect: [{ chainId: Hex }];
   disconnect: [];
   accountsChanged: [Address[]];
   chainChanged: [Hex];
@@ -19,12 +19,12 @@ export type EIP1193ProviderEvents = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   display_uri: [string];
   connectAndSign: [
-    { accounts: readonly Address[]; chainId: number; signResponse: string },
+    { accounts: readonly Address[]; chainId: Hex; signResponse: string },
   ];
   connectWith: [
     {
       accounts: readonly Address[];
-      chainId: number;
+      chainId: Hex;
       connectWithResponse: unknown;
     },
   ];
@@ -38,12 +38,12 @@ export type EventHandlers = {
   displayUri: (uri: string) => void;
   connectAndSign: (result: {
     accounts: readonly Address[];
-    chainId: number;
+    chainId: Hex;
     signResponse: string;
   }) => void;
   connectWith: (result: {
     accounts: readonly Address[];
-    chainId: number;
+    chainId: Hex;
     connectWithResponse: unknown;
   }) => void;
 };
@@ -71,7 +71,7 @@ export type AddEthereumChainParameter = {
 // Specific provider request types
 type ConnectRequest = {
   method: 'wallet_requestPermissions' | 'eth_requestAccounts';
-  params: [chainId?: number, account?: string];
+  params: [chainId?: Hex, account?: string];
 };
 
 type RevokePermissionsRequest = {

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to use hex chain ID format for `@metamask/connect-evm` API compatibility ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
+
 ## [0.1.0]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Scope, SessionData } from '@metamask/connect';
-import { hexToNumber, type CaipAccountId } from '@metamask/utils';
+import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useChainId, useConnect, useDisconnect } from 'wagmi';
 import { FEATURED_NETWORKS, convertCaipChainIdsToHex, TEST_IDS } from '@metamask/playground-ui';
 import { useSDK } from './sdk';
@@ -93,8 +93,7 @@ function App() {
   const connectLegacyEVM = useCallback(async () => {
     const selectedScopesArray = customScopes.filter((scope) => scope.length);
     // Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
-    // Then convert hex chain IDs to numbers for the connect method
-    const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map(id => hexToNumber(id));
+    const chainIds = convertCaipChainIdsToHex(selectedScopesArray) as Hex[];
     await legacyConnect(chainIds);
   }, [customScopes, legacyConnect]);
 

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -1,6 +1,7 @@
 import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect/evm';
 import type { EIP1193Provider } from '@metamask/connect/evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
+import type { Hex } from '@metamask/utils';
 import type React from 'react';
 import {
   createContext,
@@ -11,6 +12,28 @@ import {
   useState,
 } from 'react';
 
+/**
+ * Converts CAIP-2 keyed RPC URLs map to hex-keyed format.
+ * Example: { 'eip155:1': 'url' } -> { '0x1': 'url' }
+ */
+function convertCaipToHexKeys(
+  caipMap: Record<string, string>,
+): Record<Hex, string> {
+  return Object.entries(caipMap).reduce(
+    (acc, [caipChainId, url]) => {
+      // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
+      const match = caipChainId.match(/^eip155:(\d+)$/);
+      if (match?.[1]) {
+        const decimalChainId = parseInt(match[1], 10);
+        const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
+        acc[hexChainId] = url;
+      }
+      return acc;
+    },
+    {} as Record<Hex, string>,
+  );
+}
+
 const LegacyEVMSDKContext = createContext<
   | {
       sdk: MetamaskConnectEVM | undefined;
@@ -18,7 +41,7 @@ const LegacyEVMSDKContext = createContext<
       provider: EIP1193Provider | undefined;
       chainId: string | undefined;
       accounts: string[];
-      connect: (chainIds: number[]) => Promise<void>;
+      connect: (chainIds: Hex[]) => Promise<void>;
       disconnect: () => Promise<void>;
     }
   | undefined
@@ -40,7 +63,8 @@ export const LegacyEVMSDKProvider = ({
     if (!sdkRef.current) {
       const setupSDK = async () => {
         const infuraApiKey = process.env.INFURA_API_KEY || '';
-        const supportedNetworks = infuraApiKey
+        // Get CAIP-keyed RPC URLs and convert to hex-keyed format
+        const caipNetworks = infuraApiKey
           ? getInfuraRpcUrls(infuraApiKey)
           : {
               // Fallback public RPC endpoints if no Infura key is provided
@@ -49,6 +73,7 @@ export const LegacyEVMSDKProvider = ({
               'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
               'eip155:137': 'https://polygon-rpc.com',
             };
+        const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 
         const clientSDK = await createEVMClient({
           dapp: {
@@ -91,14 +116,14 @@ export const LegacyEVMSDKProvider = ({
     }
   }, []);
 
-  const connect = useCallback(async (chainIds: number[]) => {
+  const connect = useCallback(async (chainIds: Hex[]) => {
     try {
       if (!sdkRef.current) {
         throw new Error('SDK not initialized');
       }
       const sdkInstance = await sdkRef.current;
       // Ensure at least one chain ID is provided, default to mainnet if empty
-      const chainIdsToUse = chainIds.length > 0 ? chainIds : [1];
+      const chainIdsToUse = chainIds.length > 0 ? chainIds : ['0x1' as Hex];
       await sdkInstance.connect({ chainIds: chainIdsToUse });
     } catch (error) {
       console.error('Failed to connect:', error);

--- a/playground/node-playground/CHANGELOG.md
+++ b/playground/node-playground/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@types/node` from ^20.4.1 to ^22.9.0 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `tsup` from ^8.0.1 to ^8.4.0 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
 - Bump `typescript` from ~5.2.2 to ~5.9.2 ([#11](https://github.com/MetaMask/connect-monorepo/pull/11))
+- Update to use hex chain ID format for `@metamask/connect-evm` API compatibility ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
 
 [Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to use hex chain ID format for `@metamask/connect-evm` API compatibility ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
+
 ## [0.1.0]
 
 ### Added

--- a/playground/react-native-playground/app/index.tsx
+++ b/playground/react-native-playground/app/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { SafeAreaView, ScrollView, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import type { Scope, SessionData } from '@metamask/connect-multichain';
-import { hexToNumber, type CaipAccountId } from '@metamask/utils';
+import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { TEST_IDS } from '@metamask/playground-ui';
 
@@ -77,8 +77,7 @@ export default function Page() {
 	const connectLegacyEVM = useCallback(async () => {
 		const selectedScopesArray = customScopes.filter((scope) => scope.length);
 		// Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
-		// Then convert hex chain IDs to numbers for the connect method
-		const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map(id => hexToNumber(id));
+		const chainIds = convertCaipChainIdsToHex(selectedScopesArray) as Hex[];
 		await legacyConnect(chainIds);
 	}, [customScopes, legacyConnect]);
 


### PR DESCRIPTION
## Explanation

# connect-evm
- **BREAKING** Standardize `chainId` to use `Hex` format throughout the public API ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
  - `connect()`, `connectAndSign()`, and `connectWith()` now expect `chainIds` as hex strings instead of decimal numbers
  - `connect()` now returns `{ accounts, chainId: Hex }` instead of `{ accounts, chainId: number }`
  - `switchChain()` now expects `chainId: Hex` instead of `chainId: number | Hex`
  - `createEVMClient()` param option `api.supportedNetworks` now expects hex chain IDs as keys (e.g., `'0x1'`) instead of CAIP chain IDs
  - Event handler types for `connectAndSign` and `connectWith` now use `Hex` for `chainId`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
