### PR TITLE
chore: update playground and wagmi connector for hex chainId format

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -19,6 +19,7 @@ import type { ExactPartial, OneOf, UnionCompute } from '@wagmi/core/internal';
 import {
   type Address,
   getAddress,
+  type Hex,
   type ProviderConnectInfo,
   ResourceUnavailableRpcError,
   type RpcError,
@@ -90,7 +91,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         let signResponse: string | undefined;
         let connectWithResponse: unknown | undefined;
         if (!accounts?.length) {
-          const chainIds = config.chains.map((chain) => chain.id);
+          // Convert numeric chain IDs to hex format for connect-evm API
+          const chainIds = config.chains.map(
+            (chain) => `0x${chain.id.toString(16)}` as Hex,
+          );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
               signResponse = await instance.connectAndSign({
@@ -217,8 +221,9 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
+        const hexChainId = `0x${chainId.toString(16)}` as Hex;
         await instance.switchChain({
-          chainId,
+          chainId: hexChainId,
           chainConfiguration: {
             blockExplorerUrls: addEthereumChainParameter?.blockExplorerUrls
               ? [...addEthereumChainParameter.blockExplorerUrls]
@@ -293,9 +298,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           })();
           metamaskPromise = createEVMClient({
             api: {
+              // Use hex chain IDs as keys for supportedNetworks
               supportedNetworks: Object.fromEntries(
                 config.chains.map((chain) => [
-                  `eip155:${chain.id}`,
+                  `0x${chain.id.toString(16)}`,
                   chain.rpcUrls.default?.http[0],
                 ]),
               ),

--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -93,7 +93,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (!accounts?.length) {
           // Convert numeric chain IDs to hex format for connect-evm API
           const chainIds = config.chains.map(
-            (chain) => `0x${chain.id.toString(16)}` as Hex,
+            (chain): Hex => `0x${chain.id.toString(16)}`,
           );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
@@ -130,13 +130,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (signResponse) {
           provider.emit('connectAndSign', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             signResponse,
           });
         } else if (connectWithResponse) {
           provider.emit('connectWith', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             connectWithResponse,
           });
         }
@@ -221,7 +221,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
-        const hexChainId = `0x${chainId.toString(16)}` as Hex;
+        const hexChainId: Hex = `0x${chainId.toString(16)}`;
         await instance.switchChain({
           chainId: hexChainId,
           chainConfiguration: {

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -33,10 +33,15 @@ const sdk = await createEVMClient({
     name: 'My DApp',
     url: 'https://mydapp.com',
   },
+  api: {
+    supportedNetworks: {
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY',
+    },
+  },
 });
 
-// Connect to MetaMask
-await sdk.connect({ chainId: 1 }); // Connect to Ethereum Mainnet
+// Connect to MetaMask (chainIds use hex format)
+await sdk.connect({ chainIds: ['0x1'] }); // Connect to Ethereum Mainnet
 
 // Get the EIP-1193 provider
 const provider = await sdk.getProvider();
@@ -59,16 +64,23 @@ const sdk = await createEVMClient({
     name: 'My DApp',
     url: 'https://mydapp.com',
   },
+  api: {
+    // Chain IDs are specified in hex format
+    supportedNetworks: {
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY', // Ethereum Mainnet
+      '0x89': 'https://polygon-rpc.com', // Polygon
+    },
+  },
 });
 
 // Connect with default chain (mainnet)
 const { accounts, chainId } = await sdk.connect();
 
-// Connect to a specific chain
-await sdk.connect({ chainId: 137 }); // Polygon
+// Connect to specific chains (chainIds use hex format)
+await sdk.connect({ chainIds: ['0x89'] }); // Polygon
 
-// Connect to a specific chain and account
-await sdk.connect({ chainId: 1, account: '0x...' });
+// Connect to specific chains and account
+await sdk.connect({ chainIds: ['0x1'], account: '0x...' });
 ```
 
 ### React Native Support
@@ -85,8 +97,9 @@ const sdk = await createEVMClient({
     url: 'https://mydapp.com',
   },
   api: {
+    // Chain IDs are specified in hex format
     supportedNetworks: {
-      'eip155:1': 'https://mainnet.infura.io/v3/YOUR_KEY',
+      '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY',
     },
   },
   // React Native: use Linking.openURL for deeplinks

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -985,10 +985,7 @@ export async function createEVMClient(
     );
   }
 
-  validSupportedChainsUrls(
-    options.api.supportedNetworks,
-    'supportedNetworks',
-  );
+  validSupportedChainsUrls(options.api.supportedNetworks, 'supportedNetworks');
 
   const supportedNetworksCaipChainId = Object.entries(
     options.api.supportedNetworks,

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -14,11 +14,7 @@ import {
   isRejectionError,
   TransportType,
 } from '@metamask/connect-multichain';
-import {
-  numberToHex,
-  hexToNumber,
-  isHexString as isHex,
-} from '@metamask/utils';
+import { hexToNumber } from '@metamask/utils';
 
 import { IGNORED_METHODS } from './constants';
 import { enableDebug, logger } from './logger';
@@ -636,7 +632,9 @@ export class MetamaskConnectEVM {
 
     if (isAccountsRequest(request)) {
       const { method } = request;
-      const decimalChainId = hexToNumber(this.#provider.selectedChainId || '0x1')
+      const decimalChainId = hexToNumber(
+        this.#provider.selectedChainId ?? '0x1',
+      );
       const scope: Scope = `eip155:${decimalChainId}`;
       const params: unknown[] = [];
 
@@ -680,7 +678,10 @@ export class MetamaskConnectEVM {
     }
 
     // Get chain ID from config or use current chain
-    const chainId =  chainConfiguration.chainId as unknown as Hex || this.#provider.selectedChainId || '0x1';
+    const chainId =
+      (chainConfiguration.chainId as unknown as Hex) ??
+      this.#provider.selectedChainId ??
+      '0x1';
     const decimalChainId = hexToNumber(chainId);
     const scope: Scope = `eip155:${decimalChainId}`;
     const params = [chainConfiguration];
@@ -967,7 +968,7 @@ export async function createEVMClient(
     debug?: boolean;
     api: {
       supportedNetworks: Record<Hex, string>;
-    }
+    };
   },
 ): Promise<MetamaskConnectEVM> {
   enableDebug(options.debug);
@@ -984,23 +985,25 @@ export async function createEVMClient(
     );
   }
 
-  validSupportedChainsUrls(options.api.supportedNetworks, 'supportedNetworks');
-
-  const supportedNetworksCaipChainId = Object.entries(options.api.supportedNetworks).reduce(
-    (acc, [hexChainId, url]) => {
-      const decimalChainId = parseInt(hexChainId, 16);
-      const caip2ChainId = `eip155:${decimalChainId}`;
-      acc[caip2ChainId] = url;
-      return acc;
-    },
-    {} as Record<string, string>,
+  validSupportedChainsUrls(
+    options.api.supportedNetworks,
+    'supportedNetworks',
   );
+
+  const supportedNetworksCaipChainId = Object.entries(
+    options.api.supportedNetworks,
+  ).reduce<Record<string, string>>((acc, [hexChainId, url]) => {
+    const decimalChainId = parseInt(hexChainId, 16);
+    const caip2ChainId = `eip155:${decimalChainId}`;
+    acc[caip2ChainId] = url;
+    return acc;
+  }, {});
 
   try {
     const core = await createMultichainClient({
       ...options,
       api: {
-        supportedNetworks: supportedNetworksCaipChainId
+        supportedNetworks: supportedNetworksCaipChainId,
       },
     });
 

--- a/packages/connect-evm/src/provider.ts
+++ b/packages/connect-evm/src/provider.ts
@@ -5,7 +5,7 @@
 /* eslint-disable jsdoc/require-returns -- Inherited from abstract class */
 import type { MultichainCore, Scope } from '@metamask/connect-multichain';
 import { EventEmitter } from '@metamask/connect-multichain';
-import { hexToNumber, numberToHex } from '@metamask/utils';
+import { hexToNumber } from '@metamask/utils';
 
 import { INTERCEPTABLE_METHODS } from './constants';
 import { logger } from './logger';

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Scope, SessionData } from '@metamask/connect';
-import { hexToNumber, type CaipAccountId } from '@metamask/utils';
+import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useChainId, useConnect, useDisconnect } from 'wagmi';
 import { FEATURED_NETWORKS, convertCaipChainIdsToHex, TEST_IDS } from '@metamask/playground-ui';
 import { useSDK } from './sdk';
@@ -93,8 +93,7 @@ function App() {
   const connectLegacyEVM = useCallback(async () => {
     const selectedScopesArray = customScopes.filter((scope) => scope.length);
     // Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
-    // Then convert hex chain IDs to numbers for the connect method
-    const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map(id => hexToNumber(id));
+    const chainIds = convertCaipChainIdsToHex(selectedScopesArray) as Hex[];
     await legacyConnect(chainIds);
   }, [customScopes, legacyConnect]);
 

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -23,7 +23,7 @@ function convertCaipToHexKeys(
     (acc, [caipChainId, url]) => {
       // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
       const match = caipChainId.match(/^eip155:(\d+)$/);
-      if (match) {
+      if (match?.[1]) {
         const decimalChainId = parseInt(match[1], 10);
         const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
         acc[hexChainId] = url;

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -1,6 +1,7 @@
 import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect/evm';
 import type { EIP1193Provider } from '@metamask/connect/evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
+import type { Hex } from '@metamask/utils';
 import type React from 'react';
 import {
   createContext,
@@ -11,6 +12,28 @@ import {
   useState,
 } from 'react';
 
+/**
+ * Converts CAIP-2 keyed RPC URLs map to hex-keyed format.
+ * Example: { 'eip155:1': 'url' } -> { '0x1': 'url' }
+ */
+function convertCaipToHexKeys(
+  caipMap: Record<string, string>,
+): Record<Hex, string> {
+  return Object.entries(caipMap).reduce(
+    (acc, [caipChainId, url]) => {
+      // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
+      const match = caipChainId.match(/^eip155:(\d+)$/);
+      if (match) {
+        const decimalChainId = parseInt(match[1], 10);
+        const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
+        acc[hexChainId] = url;
+      }
+      return acc;
+    },
+    {} as Record<Hex, string>,
+  );
+}
+
 const LegacyEVMSDKContext = createContext<
   | {
       sdk: MetamaskConnectEVM | undefined;
@@ -18,7 +41,7 @@ const LegacyEVMSDKContext = createContext<
       provider: EIP1193Provider | undefined;
       chainId: string | undefined;
       accounts: string[];
-      connect: (chainIds: number[]) => Promise<void>;
+      connect: (chainIds: Hex[]) => Promise<void>;
       disconnect: () => Promise<void>;
     }
   | undefined
@@ -40,7 +63,8 @@ export const LegacyEVMSDKProvider = ({
     if (!sdkRef.current) {
       const setupSDK = async () => {
         const infuraApiKey = process.env.INFURA_API_KEY || '';
-        const supportedNetworks = infuraApiKey
+        // Get CAIP-keyed RPC URLs and convert to hex-keyed format
+        const caipNetworks = infuraApiKey
           ? getInfuraRpcUrls(infuraApiKey)
           : {
               // Fallback public RPC endpoints if no Infura key is provided
@@ -49,6 +73,7 @@ export const LegacyEVMSDKProvider = ({
               'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
               'eip155:137': 'https://polygon-rpc.com',
             };
+        const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 
         const clientSDK = await createEVMClient({
           dapp: {
@@ -91,14 +116,14 @@ export const LegacyEVMSDKProvider = ({
     }
   }, []);
 
-  const connect = useCallback(async (chainIds: number[]) => {
+  const connect = useCallback(async (chainIds: Hex[]) => {
     try {
       if (!sdkRef.current) {
         throw new Error('SDK not initialized');
       }
       const sdkInstance = await sdkRef.current;
       // Ensure at least one chain ID is provided, default to mainnet if empty
-      const chainIdsToUse = chainIds.length > 0 ? chainIds : [1];
+      const chainIdsToUse = chainIds.length > 0 ? chainIds : ['0x1' as Hex];
       await sdkInstance.connect({ chainIds: chainIdsToUse });
     } catch (error) {
       console.error('Failed to connect:', error);

--- a/playground/browser-playground/src/wagmi/metamask-connector.ts
+++ b/playground/browser-playground/src/wagmi/metamask-connector.ts
@@ -112,7 +112,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (!accounts?.length) {
           // Convert numeric chain IDs to hex format for connect-evm API
           const chainIds = config.chains.map(
-            (chain) => `0x${chain.id.toString(16)}` as Hex,
+            (chain): Hex => `0x${chain.id.toString(16)}`,
           );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
@@ -149,13 +149,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (signResponse) {
           provider.emit('connectAndSign', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             signResponse,
           });
         } else if (connectWithResponse) {
           provider.emit('connectWith', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             connectWithResponse,
           });
         }
@@ -240,7 +240,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
-        const hexChainId = `0x${chainId.toString(16)}` as Hex;
+        const hexChainId: Hex = `0x${chainId.toString(16)}`;
         await instance.switchChain({
           chainId: hexChainId,
           chainConfiguration: {

--- a/playground/browser-playground/src/wagmi/metamask-connector.ts
+++ b/playground/browser-playground/src/wagmi/metamask-connector.ts
@@ -38,6 +38,7 @@ import type { ExactPartial, OneOf, UnionCompute } from '@wagmi/core/internal';
 import {
   type Address,
   getAddress,
+  type Hex,
   type ProviderConnectInfo,
   ResourceUnavailableRpcError,
   type RpcError,
@@ -109,7 +110,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         let signResponse: string | undefined;
         let connectWithResponse: unknown | undefined;
         if (!accounts?.length) {
-          const chainIds = config.chains.map((chain) => chain.id);
+          // Convert numeric chain IDs to hex format for connect-evm API
+          const chainIds = config.chains.map(
+            (chain) => `0x${chain.id.toString(16)}` as Hex,
+          );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
               signResponse = await instance.connectAndSign({
@@ -236,8 +240,9 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
+        const hexChainId = `0x${chainId.toString(16)}` as Hex;
         await instance.switchChain({
-          chainId,
+          chainId: hexChainId,
           chainConfiguration: {
             blockExplorerUrls: addEthereumChainParameter?.blockExplorerUrls
               ? [...addEthereumChainParameter.blockExplorerUrls]
@@ -312,9 +317,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           })();
           metamaskPromise = createEVMClient({
             api: {
+              // Use hex chain IDs as keys for supportedNetworks
               supportedNetworks: Object.fromEntries(
                 config.chains.map((chain) => [
-                  `eip155:${chain.id}`,
+                  `0x${chain.id.toString(16)}`,
                   chain.rpcUrls.default?.http[0],
                 ]),
               ),

--- a/playground/node-playground/src/index.ts
+++ b/playground/node-playground/src/index.ts
@@ -16,7 +16,7 @@ import {
   getInfuraRpcUrls,
   type SessionData,
 } from '@metamask/connect-multichain';
-import { hexToNumber } from '@metamask/utils';
+import { hexToNumber, type Hex } from '@metamask/utils';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
 import inquirer from 'inquirer';
@@ -29,11 +29,33 @@ type AppState = 'DISCONNECTED' | 'CONNECTING' | 'CONNECTED' | 'SIGNING';
 type ConnectorType = 'multichain' | 'evm';
 
 const AVAILABLE_CHAINS = [
-  { id: 1, name: 'Ethereum Mainnet', caip: 'eip155:1' },
-  { id: 137, name: 'Polygon', caip: 'eip155:137' },
-  { id: 59144, name: 'Linea', caip: 'eip155:59144' },
-  { id: 11155111, name: 'Sepolia Testnet', caip: 'eip155:11155111' },
+  { id: 1, hex: '0x1' as Hex, name: 'Ethereum Mainnet', caip: 'eip155:1' },
+  { id: 137, hex: '0x89' as Hex, name: 'Polygon', caip: 'eip155:137' },
+  { id: 59144, hex: '0xe708' as Hex, name: 'Linea', caip: 'eip155:59144' },
+  { id: 11155111, hex: '0xaa36a7' as Hex, name: 'Sepolia Testnet', caip: 'eip155:11155111' },
 ] as const;
+
+/**
+ * Converts CAIP-2 keyed RPC URLs map to hex-keyed format.
+ * Example: { 'eip155:1': 'url' } -> { '0x1': 'url' }
+ */
+function convertCaipToHexKeys(
+  caipMap: Record<string, string>,
+): Record<Hex, string> {
+  return Object.entries(caipMap).reduce(
+    (acc, [caipChainId, url]) => {
+      // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
+      const match = caipChainId.match(/^eip155:(\d+)$/);
+      if (match) {
+        const decimalChainId = parseInt(match[1], 10);
+        const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
+        acc[hexChainId] = url;
+      }
+      return acc;
+    },
+    {} as Record<Hex, string>,
+  );
+}
 
 // Store our application state in a simple object
 const state: {
@@ -158,7 +180,7 @@ const handleConnect = async () => {
       );
     } else if (state.connectorType === 'evm') {
       // Connect using EVM connector (Ethereum Mainnet only)
-      await state.evmSdk?.connect({ chainIds: [1] });
+      await state.evmSdk?.connect({ chainIds: ['0x1'] });
     }
   } catch (error: unknown) {
     if (state.spinner) {
@@ -282,7 +304,7 @@ const handleSwitchChain = async () => {
       message: 'Select a chain to switch to:',
       choices: availableChains.map((chainOption) => ({
         name: chainOption.name,
-        value: chainOption.id,
+        value: chainOption.hex,
       })),
     },
   ]);
@@ -294,7 +316,7 @@ const handleSwitchChain = async () => {
   try {
     await state.evmSdk.switchChain({ chainId: chain });
     const chainName =
-      AVAILABLE_CHAINS.find((chainOption) => chainOption.id === chain)?.name ??
+      AVAILABLE_CHAINS.find((chainOption) => chainOption.hex === chain)?.name ??
       'chain';
     state.spinner.succeed(`Successfully switched to ${chainName}.`);
   } catch (error: unknown) {
@@ -376,6 +398,8 @@ const main = async (): Promise<void> => {
 
   const infuraApiKey = process.env.INFURA_API_KEY ?? 'demo';
   const supportedNetworks = getInfuraRpcUrls(infuraApiKey);
+  // Convert CAIP-keyed RPC URLs to hex-keyed format for EVM SDK
+  const hexKeyedNetworks = convertCaipToHexKeys(supportedNetworks);
 
   // Initialize Multichain SDK
   state.metamaskConnectMultichain = await createMultichainClient({
@@ -395,7 +419,7 @@ const main = async (): Promise<void> => {
       url: 'https://playground.metamask.io',
     },
     api: {
-      supportedNetworks,
+      supportedNetworks: hexKeyedNetworks,
     },
     eventHandlers: {
       connect: ({ accounts, chainId }) => {

--- a/playground/node-playground/src/index.ts
+++ b/playground/node-playground/src/index.ts
@@ -46,7 +46,7 @@ function convertCaipToHexKeys(
     (acc, [caipChainId, url]) => {
       // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
       const match = caipChainId.match(/^eip155:(\d+)$/);
-      if (match) {
+      if (match?.[1]) {
         const decimalChainId = parseInt(match[1], 10);
         const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
         acc[hexChainId] = url;

--- a/playground/react-native-playground/app/index.tsx
+++ b/playground/react-native-playground/app/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { SafeAreaView, ScrollView, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import type { Scope, SessionData } from '@metamask/connect-multichain';
-import { hexToNumber, type CaipAccountId } from '@metamask/utils';
+import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { TEST_IDS } from '@metamask/playground-ui';
 
@@ -77,8 +77,7 @@ export default function Page() {
 	const connectLegacyEVM = useCallback(async () => {
 		const selectedScopesArray = customScopes.filter((scope) => scope.length);
 		// Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
-		// Then convert hex chain IDs to numbers for the connect method
-		const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map(id => hexToNumber(id));
+		const chainIds = convertCaipChainIdsToHex(selectedScopesArray) as Hex[];
 		await legacyConnect(chainIds);
 	}, [customScopes, legacyConnect]);
 

--- a/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -25,7 +25,7 @@ function convertCaipToHexKeys(
     (acc, [caipChainId, url]) => {
       // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
       const match = caipChainId.match(/^eip155:(\d+)$/);
-      if (match) {
+      if (match?.[1]) {
         const decimalChainId = parseInt(match[1], 10);
         const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
         acc[hexChainId] = url;

--- a/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -2,6 +2,7 @@ import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect-evm';
 import type { EIP1193Provider } from '@metamask/connect-evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
+import type { Hex } from '@metamask/utils';
 import type React from 'react';
 import {
   createContext,
@@ -13,6 +14,28 @@ import {
 } from 'react';
 import { Linking } from 'react-native';
 
+/**
+ * Converts CAIP-2 keyed RPC URLs map to hex-keyed format.
+ * Example: { 'eip155:1': 'url' } -> { '0x1': 'url' }
+ */
+function convertCaipToHexKeys(
+  caipMap: Record<string, string>,
+): Record<Hex, string> {
+  return Object.entries(caipMap).reduce(
+    (acc, [caipChainId, url]) => {
+      // Extract the numeric part from CAIP-2 format (e.g., 'eip155:1' -> 1)
+      const match = caipChainId.match(/^eip155:(\d+)$/);
+      if (match) {
+        const decimalChainId = parseInt(match[1], 10);
+        const hexChainId = `0x${decimalChainId.toString(16)}` as Hex;
+        acc[hexChainId] = url;
+      }
+      return acc;
+    },
+    {} as Record<Hex, string>,
+  );
+}
+
 const LegacyEVMSDKContext = createContext<
   | {
       sdk: MetamaskConnectEVM | undefined;
@@ -20,7 +43,7 @@ const LegacyEVMSDKContext = createContext<
       provider: EIP1193Provider | undefined;
       chainId: string | undefined;
       accounts: string[];
-      connect: (chainIds: number[]) => Promise<void>;
+      connect: (chainIds: Hex[]) => Promise<void>;
       disconnect: () => Promise<void>;
     }
   | undefined
@@ -42,7 +65,8 @@ export const LegacyEVMSDKProvider = ({
     if (!sdkRef.current) {
       const setupSDK = async () => {
         const infuraApiKey = process.env.EXPO_PUBLIC_INFURA_API_KEY || '';
-        const supportedNetworks = infuraApiKey
+        // Get CAIP-keyed RPC URLs and convert to hex-keyed format
+        const caipNetworks = infuraApiKey
           ? getInfuraRpcUrls(infuraApiKey)
           : {
               // Fallback public RPC endpoints if no Infura key is provided
@@ -51,6 +75,7 @@ export const LegacyEVMSDKProvider = ({
               'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
               'eip155:137': 'https://polygon-rpc.com',
             };
+        const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 
         // Type assertion needed because createEVMClient's type doesn't include mobile/transport
         // but they are passed through to createMultichainClient at runtime
@@ -108,14 +133,14 @@ export const LegacyEVMSDKProvider = ({
     }
   }, []);
 
-  const connect = useCallback(async (chainIds: number[]) => {
+  const connect = useCallback(async (chainIds: Hex[]) => {
     try {
       if (!sdkRef.current) {
         throw new Error('SDK not initialized');
       }
       const sdkInstance = await sdkRef.current;
       // Ensure at least one chain ID is provided, default to mainnet if empty
-      const chainIdsToUse = chainIds.length > 0 ? chainIds : [1];
+      const chainIdsToUse = chainIds.length > 0 ? chainIds : ['0x1' as Hex];
       await sdkInstance.connect({ chainIds: chainIdsToUse });
     } catch (error) {
       console.error('Failed to connect:', error);

--- a/playground/react-native-playground/src/wagmi/metamask-connector.ts
+++ b/playground/react-native-playground/src/wagmi/metamask-connector.ts
@@ -112,7 +112,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (!accounts?.length) {
           // Convert numeric chain IDs to hex format for connect-evm API
           const chainIds = config.chains.map(
-            (chain) => `0x${chain.id.toString(16)}` as Hex,
+            (chain): Hex => `0x${chain.id.toString(16)}`,
           );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
@@ -149,13 +149,13 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         if (signResponse) {
           provider.emit('connectAndSign', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             signResponse,
           });
         } else if (connectWithResponse) {
           provider.emit('connectWith', {
             accounts,
-            chainId: currentChainId,
+            chainId: `0x${currentChainId.toString(16)}`,
             connectWithResponse,
           });
         }
@@ -240,7 +240,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
-        const hexChainId = `0x${chainId.toString(16)}` as Hex;
+        const hexChainId: Hex = `0x${chainId.toString(16)}`;
         await instance.switchChain({
           chainId: hexChainId,
           chainConfiguration: {

--- a/playground/react-native-playground/src/wagmi/metamask-connector.ts
+++ b/playground/react-native-playground/src/wagmi/metamask-connector.ts
@@ -38,6 +38,7 @@ import type { ExactPartial, OneOf, UnionCompute } from '@wagmi/core/internal';
 import {
   type Address,
   getAddress,
+  type Hex,
   type ProviderConnectInfo,
   ResourceUnavailableRpcError,
   type RpcError,
@@ -109,7 +110,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
         let signResponse: string | undefined;
         let connectWithResponse: unknown | undefined;
         if (!accounts?.length) {
-          const chainIds = config.chains.map((chain) => chain.id);
+          // Convert numeric chain IDs to hex format for connect-evm API
+          const chainIds = config.chains.map(
+            (chain) => `0x${chain.id.toString(16)}` as Hex,
+          );
           if (parameters.connectAndSign || parameters.connectWith) {
             if (parameters.connectAndSign) {
               signResponse = await instance.connectAndSign({
@@ -236,8 +240,9 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
 
       try {
         const instance = await this.getInstance();
+        const hexChainId = `0x${chainId.toString(16)}` as Hex;
         await instance.switchChain({
-          chainId,
+          chainId: hexChainId,
           chainConfiguration: {
             blockExplorerUrls: addEthereumChainParameter?.blockExplorerUrls
               ? [...addEthereumChainParameter.blockExplorerUrls]
@@ -312,9 +317,10 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
           })();
           metamaskPromise = createEVMClient({
             api: {
+              // Use hex chain IDs as keys for supportedNetworks
               supportedNetworks: Object.fromEntries(
                 config.chains.map((chain) => [
-                  `eip155:${chain.id}`,
+                  `0x${chain.id.toString(16)}`,
                   chain.rpcUrls.default?.http[0],
                 ]),
               ),


### PR DESCRIPTION
Update all consumers to use hex format for chainIds following the
connect-evm API change from number to Hex type.

## Explanation
Updates playground applications and wagmi connector to use hex-formatted chain IDs, aligning with the connect-evm API changes in PR #150.

**Changes:**
- Convert `chainIds` parameter from `number[]` to `Hex[]` in all connect calls
- Convert `supportedNetworks` keys from CAIP-2 format (`eip155:1`) to hex (`0x1`)
- Add `convertCaipToHexKeys()` helper for converting existing CAIP-keyed RPC URL maps
- Update README documentation with correct hex format examples

**Files changed:**
- `integrations/wagmi/metamask-connector.ts`
- `playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx`
- `playground/browser-playground/src/App.tsx`
- `playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx`
- `playground/react-native-playground/app/index.tsx`
- `playground/node-playground/src/index.ts`
- `packages/connect-evm/README.md`