### PR TITLE
feat: update `getInfuraRpcUrls` to return eip155 entries keyed as hex chain IDs in the `connect-evm` package

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `switchChain()` now expects `chainId: Hex` instead of `chainId: number | Hex`
   - `createEVMClient()` param option `api.supportedNetworks` now expects hex chain IDs as keys (e.g., `'0x1'`) instead of CAIP chain IDs
   - Event handler types for `connectAndSign` and `connectWith` now use `Hex` for `chainId`
+- **BREAKING** `getInfuraRpcUrls` now returns a rpc url map keyed by hex chain ID rather than CAIP Chain ID ([#152](https://github.com/MetaMask/connect-monorepo/pull/152))
 - The `debug` option param used by `createEVMClient()` now enables console debug logs of the underlying `MultichainClient` instance. ([#149](https://github.com/MetaMask/connect-monorepo/pull/149))
 
 ## [0.4.1]

--- a/packages/connect-evm/src/index.ts
+++ b/packages/connect-evm/src/index.ts
@@ -1,4 +1,4 @@
-export { getInfuraRpcUrls } from '@metamask/connect-multichain';
+export { getInfuraRpcUrls } from './utils/infura';
 export { createEVMClient, type MetamaskConnectEVM } from './connect';
 export type { EIP1193Provider } from './provider';
 

--- a/packages/connect-evm/src/utils/infura.ts
+++ b/packages/connect-evm/src/utils/infura.ts
@@ -16,7 +16,7 @@ export const getInfuraRpcUrls = (infuraAPIKey: string): RpcUrlsMap => {
         return acc;
       }
       const chainId = numberToHex(parseInt(reference, 10));
-      acc[chainId] = url;
+      acc[chainId] = url as string;
       return acc;
     },
     {},

--- a/packages/connect-evm/src/utils/infura.ts
+++ b/packages/connect-evm/src/utils/infura.ts
@@ -1,0 +1,25 @@
+import type { RpcUrlsMap } from '@metamask/connect-multichain';
+import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import {
+  KnownCaipNamespace,
+  numberToHex,
+  parseCaipChainId,
+} from '@metamask/utils';
+
+export const getInfuraRpcUrls = (infuraAPIKey: string): RpcUrlsMap => {
+  const caipMap = getInfuraRpcUrlsMultichain(infuraAPIKey);
+  const hexMap = Object.entries(caipMap).reduce<Record<Hex, string>>(
+    (acc, [key, url]) => {
+      const { namespace, reference } = parseCaipChainId(key as CaipChainId);
+      if (namespace !== KnownCaipNamespace.Eip155) {
+        return acc;
+      }
+      const chainId = numberToHex(parseInt(reference, 10));
+      acc[chainId] = url;
+      return acc;
+    },
+    {},
+  );
+  return hexMap;
+};


### PR DESCRIPTION
## Explanation

Previously `getInfuraRpcUrls` from the `conect-evm` package was re-exporting the same function from `connect-multichain` which is key'ed by CAIP Chain ID. This changes the one exported in `connect-evm` to be keyed by hex chain ID instead, that way it can be used as is when passed into the `createEvmClient` factory.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
