### PR TITLE
feat: track active provider via local storage state

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Track active provider via local storage state ([#154](https://github.com/MetaMask/connect-monorepo/pull/154))
+
 ### Changed
 
 - Update to use hex chain ID format for `@metamask/connect-evm` API compatibility ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -12,6 +12,12 @@ import {
   useState,
 } from 'react';
 
+import {
+  isProviderActive,
+  setProviderActive,
+  removeProviderActive,
+} from '../utils/activeProviderStorage';
+
 /**
  * Converts CAIP-2 keyed RPC URLs map to hex-keyed format.
  * Example: { 'eip155:1': 'url' } -> { '0x1': 'url' }
@@ -107,6 +113,23 @@ export const LegacyEVMSDKProvider = ({
 
           setSDK(clientSDK);
           setProvider(providerInstance);
+
+          // Check if legacy-evm was previously active and restore connection state
+          // This handles page refresh scenarios where the SDK may have restored
+          // the session but didn't emit a connect event
+          if (isProviderActive('legacy-evm')) {
+            // Check if the SDK actually has a valid session
+            if (clientSDK.accounts.length > 0) {
+              setConnected(true);
+              setAccounts(clientSDK.accounts);
+              if (clientSDK.selectedChainId) {
+                setChainId(clientSDK.selectedChainId);
+              }
+            } else {
+              // SDK doesn't have accounts, clear stale localStorage state
+              removeProviderActive('legacy-evm');
+            }
+          }
         }
 
         return clientSDK;
@@ -125,6 +148,7 @@ export const LegacyEVMSDKProvider = ({
       // Ensure at least one chain ID is provided, default to mainnet if empty
       const chainIdsToUse = chainIds.length > 0 ? chainIds : ['0x1' as Hex];
       await sdkInstance.connect({ chainIds: chainIdsToUse });
+      setProviderActive('legacy-evm');
     } catch (error) {
       console.error('Failed to connect:', error);
     }
@@ -140,6 +164,7 @@ export const LegacyEVMSDKProvider = ({
       setConnected(false);
       setAccounts([]);
       setChainId(undefined);
+      removeProviderActive('legacy-evm');
     } catch (error) {
       console.error('Failed to disconnect:', error);
     }

--- a/playground/browser-playground/src/utils/activeProviderStorage.ts
+++ b/playground/browser-playground/src/utils/activeProviderStorage.ts
@@ -1,0 +1,124 @@
+/* eslint-disable no-restricted-globals -- localStorage is intentionally used for browser storage */
+/**
+ * Utility for managing active provider state in localStorage.
+ * This tracks which connection type(s) are currently active to ensure
+ * proper state restoration after page refresh.
+ */
+
+const STORAGE_KEY = 'browser-playground.active-provider';
+
+export type ProviderType = 'multichain' | 'legacy-evm' | 'wagmi';
+
+/**
+ * Gets the currently active providers from localStorage.
+ *
+ * @returns Array of active provider types, or empty array if none
+ */
+export function getActiveProviders(): ProviderType[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      return parsed as ProviderType[];
+    }
+    return [];
+  } catch (error) {
+    console.error(
+      '[activeProviderStorage] Failed to get active providers:',
+      error,
+    );
+    return [];
+  }
+}
+
+/**
+ * Checks if a specific provider is marked as active.
+ *
+ * @param provider - The provider type to check
+ * @returns true if the provider is active
+ */
+export function isProviderActive(provider: ProviderType): boolean {
+  return getActiveProviders().includes(provider);
+}
+
+/**
+ * Sets a provider as active. Handles mutual exclusivity between
+ * legacy-evm and wagmi (since they share the same underlying provider).
+ *
+ * @param provider - The provider type to set as active
+ */
+export function setProviderActive(provider: ProviderType): void {
+  try {
+    const current = getActiveProviders();
+
+    // Handle mutual exclusivity between legacy-evm and wagmi
+    // They share the same underlying EVM provider, so only one can be active
+    let updated: ProviderType[];
+    if (provider === 'legacy-evm') {
+      updated = current.filter(
+        (providerType) =>
+          providerType !== 'wagmi' && providerType !== 'legacy-evm',
+      );
+      updated.push('legacy-evm');
+    } else if (provider === 'wagmi') {
+      updated = current.filter(
+        (providerType) =>
+          providerType !== 'legacy-evm' && providerType !== 'wagmi',
+      );
+      updated.push('wagmi');
+    } else if (current.includes(provider)) {
+      // multichain already in list, no change needed
+      updated = current;
+    } else {
+      // multichain can coexist with either
+      updated = [...current, provider];
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.error(
+      `[activeProviderStorage] Failed to set provider "${provider}" as active:`,
+      error,
+    );
+  }
+}
+
+/**
+ * Removes a specific provider from the active list.
+ *
+ * @param provider - The provider type to remove
+ */
+export function removeProviderActive(provider: ProviderType): void {
+  try {
+    const current = getActiveProviders();
+    const updated = current.filter((providerType) => providerType !== provider);
+    if (updated.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    }
+  } catch (error) {
+    console.error(
+      `[activeProviderStorage] Failed to remove provider "${provider}" from active list:`,
+      error,
+    );
+  }
+}
+
+/**
+ * Clears all active provider state from localStorage.
+ * Called when disconnecting all connections.
+ */
+export function clearAllActiveProviders(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error(
+      '[activeProviderStorage] Failed to clear all active providers:',
+      error,
+    );
+  }
+}


### PR DESCRIPTION
## Explanation

While working on [E2E test migrations](https://consensyssoftware.atlassian.net/browse/WAPI-1036), an issue came up where, after we "Legacy EVM" connect, and then refresh, this same Legacy EVM Connection doesn't persist after refresh (in regards to Browser Playground Dapp State), but we do see both Multichain Connection and Wagmi Connection show up as existing and active.

This is due to the browser playground having three independent connection providers that all share the same underlying session storage (IndexedDB via `@metamask/connect-multichain`):

`SDKProvider (Multichain)` - Creates a `MultichainCore` instance

`LegacyEVMSDKProvider (Legacy EVM)` - Creates a `MetamaskConnectEVM` which wraps its own `MultichainCore`

`Wagmi Connector` - Also creates a `MetamaskConnectEVM` which wraps its own `MultichainCore`

The critical problem is that there's no distinction stored about which SDK layer initiated the connection. All three layers read from the same IndexedDB keys:
• `multichain-transport` - the transport type
• `cache_wallet_getSession` - the session data
• `cache_eth_accounts` - accounts

so, we see Multichain + Wagmi Instead of Legacy EVM because each of these providers check for their respective connections as follows

• | Multichain | `onNotification` callback receives session data during transport setup | ✅ Shows connected |
• | Legacy EVM | Waits for connect event from `#attemptSessionRecovery()` | 🔴  Event may not fire |
• | Wagmi | `isAuthorized()` checks if accounts exist via `getAccounts()` | ✅  Shows connected |

```ts
  async #attemptSessionRecovery(): Promise<void> {
    // Skip session recovery if transport is not initialized yet.
    // Transport is only initialized when there's a stored session or after connect() is called.
    // Only attempt recovery if we're in a state where transport should be available.
    if (
      this.#core.status !== 'connected' &&
      this.#core.status !== 'connecting'
    ) {
      return;
    }
```

The issue on Legacy EVM could be: If `this.#core.status` is `'loaded'` (which happens when no stored transport is found or transport setup fails), the session recovery is skipped entirely and no connect event fires.

## Fix

This PR proposes tracking the currently active provider(s) via local storage state.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1061

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
