### PR TITLE
Fix: QR rejection handling

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `createMultichainClient()` now accepts an optional `debug` param option which enables console debug logs when set to `true`. Defaults to `false`. ([#149](https://github.com/MetaMask/connect-monorepo/pull/149))
 
+### Fixed
+
+- Fix QR rejection handling: properly propagate user rejection errors from MetaMask Mobile to the dApp ([#156](https://github.com/MetaMask/connect-monorepo/pull/156))
+- Close QR modal automatically when user rejects connection ([#156](https://github.com/MetaMask/connect-monorepo/pull/156))
+- Use `@metamask/rpc-errors` for EIP-1193 compliant error handling ([#156](https://github.com/MetaMask/connect-monorepo/pull/156))
+
 ## [0.5.2]
 
 ### Changed

--- a/packages/connect-multichain/src/connect.test.ts
+++ b/packages/connect-multichain/src/connect.test.ts
@@ -485,7 +485,8 @@ function testSuite<T extends MultichainOptions>({
 
       // For web-mobile, timeout might be expected due to deeplink hanging
       if (!timedOut) {
-        t.expect(connectError).toBe(sessionError);
+        // Check error message matches (error object may be wrapped with EIP-1193 code)
+        t.expect(connectError.message).toBe(sessionError.message);
         t.expect(sdk.status === 'disconnected').toBe(true);
       } else {
         // If timed out, at least verify it's not connected

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -399,14 +399,18 @@ export class MetaMaskConnectMultichain extends MultichainCore {
                     // Ignore Request expired errors to allow modal to regenerate expired qr codes
                     if (error.code !== ErrorCode.REQUEST_EXPIRED) {
                       this.status = 'disconnected';
+                      // Close the modal on error
+                      await this.options.ui.factory.unload(error);
                       reject(error);
                     }
                     // If request is expires, the QRCode will automatically be regenerated we can ignore this case
                   } else {
                     this.status = 'disconnected';
-                    reject(
-                      error instanceof Error ? error : new Error(String(error)),
-                    );
+                    const normalizedError =
+                      error instanceof Error ? error : new Error(String(error));
+                    // Close the modal on error
+                    await this.options.ui.factory.unload(normalizedError);
+                    reject(normalizedError);
                   }
                 }
               })().catch(() => {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -44,16 +44,10 @@ t.describe('MWPTransport', () => {
 
           const requestId = 'test-request-123';
           transport.pendingRequests.set(requestId, {
-            request: {
-              jsonrpc: '2.0',
-              id: requestId,
-              method: 'wallet_createSession',
-            } as any,
-            method: 'wallet_createSession',
             resolve: mockResolve,
             reject: mockReject,
             timeout: mockTimeout,
-          });
+          } as any);
 
           // Simulate error message from mobile wallet (user rejection)
           const errorMessage = {
@@ -103,16 +97,10 @@ t.describe('MWPTransport', () => {
 
           const requestId = 'test-request-456';
           transport.pendingRequests.set(requestId, {
-            request: {
-              jsonrpc: '2.0',
-              id: requestId,
-              method: 'wallet_createSession',
-            } as any,
-            method: 'wallet_createSession',
             resolve: mockResolve,
             reject: mockReject,
             timeout: mockTimeout,
-          });
+          } as any);
 
           // Simulate success message from mobile wallet
           const successMessage = {
@@ -161,16 +149,10 @@ t.describe('MWPTransport', () => {
 
           const requestId = 'test-request-789';
           transport.pendingRequests.set(requestId, {
-            request: {
-              jsonrpc: '2.0',
-              id: requestId,
-              method: 'wallet_createSession',
-            } as any,
-            method: 'wallet_createSession',
             resolve: mockResolve,
             reject: mockReject,
             timeout: mockTimeout,
-          });
+          } as any);
 
           // Error without message field (invalid format per EIP-1193)
           const errorMessage = {
@@ -208,16 +190,10 @@ t.describe('MWPTransport', () => {
 
         const requestId = 'test-request-custom';
         transport.pendingRequests.set(requestId, {
-          request: {
-            jsonrpc: '2.0',
-            id: requestId,
-            method: 'wallet_createSession',
-          } as any,
-          method: 'wallet_createSession',
           resolve: mockResolve,
           reject: mockReject,
           timeout: mockTimeout,
-        });
+        } as any);
 
         // Error with custom code (e.g., 4100 = Unauthorized)
         const errorMessage = {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable id-length -- vitest alias */
+/* eslint-disable no-empty-function -- Empty mock functions */
+import * as t from 'vitest';
+
+import { MWPTransport } from '.';
+import type { StoreAdapter } from '../../../domain';
+
+t.describe('MWPTransport', () => {
+  let mockDappClient: any;
+  let mockKvstore: StoreAdapter;
+  let transport: MWPTransport;
+
+  t.beforeEach(() => {
+    mockDappClient = {
+      on: t.vi.fn(),
+      reconnect: t.vi.fn(),
+      send: t.vi.fn(),
+      disconnect: t.vi.fn(),
+      isConnected: t.vi.fn().mockReturnValue(false),
+    };
+
+    mockKvstore = {
+      get: t.vi.fn(),
+      set: t.vi.fn(),
+      del: t.vi.fn(),
+    };
+
+    transport = new MWPTransport(mockDappClient, mockKvstore);
+  });
+
+  t.afterEach(() => {
+    t.vi.clearAllMocks();
+  });
+
+  t.describe('handleMessage error handling', () => {
+    t.it(
+      'should reject promise when WebSocket message contains error',
+      async () => {
+        return new Promise<void>((resolve) => {
+          // Setup: Add a pending request
+          const mockResolve = t.vi.fn();
+          const mockReject = t.vi.fn();
+          const mockTimeout = setTimeout(() => {}, 60000) as any;
+
+          const requestId = 'test-request-123';
+          transport.pendingRequests.set(requestId, {
+            request: {
+              jsonrpc: '2.0',
+              id: requestId,
+              method: 'wallet_createSession',
+            } as any,
+            method: 'wallet_createSession',
+            resolve: mockResolve,
+            reject: mockReject,
+            timeout: mockTimeout,
+          });
+
+          // Simulate error message from mobile wallet (user rejection)
+          const errorMessage = {
+            data: {
+              id: requestId,
+              error: {
+                code: 4001,
+                message: 'User rejected the request',
+              },
+            },
+          };
+
+          // Get the message handler that was registered
+          const messageHandler = mockDappClient.on.mock.calls.find(
+            (call: any[]) => call[0] === 'message',
+          )?.[1];
+
+          t.expect(messageHandler).toBeDefined();
+
+          // Trigger the message handler
+          messageHandler?.(errorMessage);
+
+          // Verify: Promise should be rejected with error including code
+          t.expect(mockReject).toHaveBeenCalled();
+          const rejectedError = mockReject.mock.calls[0][0];
+          t.expect(rejectedError.message).toBe('User rejected the request');
+          t.expect(rejectedError.code).toBe(4001); // EIP-1193 standard error code
+          t.expect(mockResolve).not.toHaveBeenCalled();
+
+          // Verify: Request should be removed from pending requests
+          t.expect(transport.pendingRequests.has(requestId)).toBe(false);
+
+          clearTimeout(mockTimeout);
+          resolve();
+        });
+      },
+    );
+
+    t.it(
+      'should resolve promise when WebSocket message contains success result',
+      async () => {
+        return new Promise<void>((resolve) => {
+          // Setup: Add a pending request
+          const mockResolve = t.vi.fn();
+          const mockReject = t.vi.fn();
+          const mockTimeout = setTimeout(() => {}, 60000) as any;
+
+          const requestId = 'test-request-456';
+          transport.pendingRequests.set(requestId, {
+            request: {
+              jsonrpc: '2.0',
+              id: requestId,
+              method: 'wallet_createSession',
+            } as any,
+            method: 'wallet_createSession',
+            resolve: mockResolve,
+            reject: mockReject,
+            timeout: mockTimeout,
+          });
+
+          // Simulate success message from mobile wallet
+          const successMessage = {
+            data: {
+              id: requestId,
+              result: {
+                sessionScopes: {
+                  'eip155:1': {
+                    methods: ['eth_sendTransaction'],
+                    notifications: [],
+                    accounts: ['eip155:1:0x123'],
+                  },
+                },
+              },
+            },
+          };
+
+          // Get the message handler
+          const messageHandler = mockDappClient.on.mock.calls.find(
+            (call: any[]) => call[0] === 'message',
+          )?.[1];
+
+          // Trigger the message handler
+          messageHandler?.(successMessage);
+
+          // Verify: Promise should be resolved
+          t.expect(mockResolve).toHaveBeenCalled();
+          t.expect(mockReject).not.toHaveBeenCalled();
+
+          // Verify: Request should be removed from pending requests
+          t.expect(transport.pendingRequests.has(requestId)).toBe(false);
+
+          clearTimeout(mockTimeout);
+          resolve();
+        });
+      },
+    );
+
+    t.it(
+      'should use default error message when error.message is missing',
+      async () => {
+        return new Promise<void>((resolve) => {
+          const mockResolve = t.vi.fn();
+          const mockReject = t.vi.fn();
+          const mockTimeout = setTimeout(() => {}, 60000) as any;
+
+          const requestId = 'test-request-789';
+          transport.pendingRequests.set(requestId, {
+            request: {
+              jsonrpc: '2.0',
+              id: requestId,
+              method: 'wallet_createSession',
+            } as any,
+            method: 'wallet_createSession',
+            resolve: mockResolve,
+            reject: mockReject,
+            timeout: mockTimeout,
+          });
+
+          // Error without message field
+          const errorMessage = {
+            data: {
+              id: requestId,
+              error: {
+                code: 4001,
+              },
+            },
+          };
+
+          const messageHandler = mockDappClient.on.mock.calls.find(
+            (call: any[]) => call[0] === 'message',
+          )?.[1];
+
+          messageHandler?.(errorMessage);
+
+          // Verify: Should use default error message and code
+          t.expect(mockReject).toHaveBeenCalled();
+          const rejectedError = mockReject.mock.calls[0][0];
+          t.expect(rejectedError.message).toBe('Request rejected by user');
+          t.expect(rejectedError.code).toBe(4001); // Should use provided code or default to 4001
+
+          clearTimeout(mockTimeout);
+          resolve();
+        });
+      },
+    );
+
+    t.it('should preserve custom error codes from wallet', async () => {
+      return new Promise<void>((resolve) => {
+        const mockResolve = t.vi.fn();
+        const mockReject = t.vi.fn();
+        const mockTimeout = setTimeout(() => {}, 60000) as any;
+
+        const requestId = 'test-request-custom';
+        transport.pendingRequests.set(requestId, {
+          request: {
+            jsonrpc: '2.0',
+            id: requestId,
+            method: 'wallet_createSession',
+          } as any,
+          method: 'wallet_createSession',
+          resolve: mockResolve,
+          reject: mockReject,
+          timeout: mockTimeout,
+        });
+
+        // Error with custom code (e.g., 4100 = Unauthorized)
+        const errorMessage = {
+          data: {
+            id: requestId,
+            error: {
+              code: 4100,
+              message: 'Unauthorized',
+            },
+          },
+        };
+
+        const messageHandler = mockDappClient.on.mock.calls.find(
+          (call: any[]) => call[0] === 'message',
+        )?.[1];
+
+        messageHandler?.(errorMessage);
+
+        // Verify: Should preserve the custom error code
+        t.expect(mockReject).toHaveBeenCalled();
+        const rejectedError = mockReject.mock.calls[0][0];
+        t.expect(rejectedError.message).toBe('Unauthorized');
+        t.expect(rejectedError.code).toBe(4100);
+
+        clearTimeout(mockTimeout);
+        resolve();
+      });
+    });
+  });
+});

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -152,7 +152,7 @@ t.describe('MWPTransport', () => {
     );
 
     t.it(
-      'should use default error message when error.message is missing',
+      'should return internal error when error format is invalid (missing message)',
       async () => {
         return new Promise<void>((resolve) => {
           const mockResolve = t.vi.fn();
@@ -172,7 +172,7 @@ t.describe('MWPTransport', () => {
             timeout: mockTimeout,
           });
 
-          // Error without message field
+          // Error without message field (invalid format per EIP-1193)
           const errorMessage = {
             data: {
               id: requestId,
@@ -188,11 +188,11 @@ t.describe('MWPTransport', () => {
 
           messageHandler?.(errorMessage);
 
-          // Verify: Should use default error message and code
+          // Verify: Should return internal error for malformed error payload
           t.expect(mockReject).toHaveBeenCalled();
           const rejectedError = mockReject.mock.calls[0][0];
-          t.expect(rejectedError.message).toBe('Request rejected by user');
-          t.expect(rejectedError.code).toBe(4001); // Should use provided code or default to 4001
+          t.expect(rejectedError.code).toBe(-32603); // Internal JSON-RPC error
+          t.expect(rejectedError.message).toContain('4001'); // Original error info preserved
 
           clearTimeout(mockTimeout);
           resolve();

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -108,10 +108,10 @@ export class MWPTransport implements ExtendedTransport {
       connectionTimeout: number;
       resumeTimeout: number;
     } = {
-        requestTimeout: DEFAULT_REQUEST_TIMEOUT,
-        connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
-        resumeTimeout: DEFAULT_RESUME_TIMEOUT,
-      },
+      requestTimeout: DEFAULT_REQUEST_TIMEOUT,
+      connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
+      resumeTimeout: DEFAULT_RESUME_TIMEOUT,
+    },
   ) {
     this.dappClient.on('message', this.handleMessage.bind(this));
     if (
@@ -179,7 +179,7 @@ export class MWPTransport implements ExtendedTransport {
               ...messagePayload,
               method:
                 request.method === 'wallet_getSession' ||
-                  request.method === 'wallet_createSession'
+                request.method === 'wallet_createSession'
                   ? 'wallet_sessionChanged'
                   : request.method,
             } as unknown as {
@@ -191,7 +191,7 @@ export class MWPTransport implements ExtendedTransport {
               ...messagePayload,
               method:
                 request.method === 'wallet_getSession' ||
-                  request.method === 'wallet_createSession'
+                request.method === 'wallet_createSession'
                   ? 'wallet_sessionChanged'
                   : request.method,
               params: requestWithName.result,

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -109,10 +109,10 @@ export class MWPTransport implements ExtendedTransport {
       connectionTimeout: number;
       resumeTimeout: number;
     } = {
-        requestTimeout: DEFAULT_REQUEST_TIMEOUT,
-        connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
-        resumeTimeout: DEFAULT_RESUME_TIMEOUT,
-      },
+      requestTimeout: DEFAULT_REQUEST_TIMEOUT,
+      connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
+      resumeTimeout: DEFAULT_RESUME_TIMEOUT,
+    },
   ) {
     this.dappClient.on('message', this.handleMessage.bind(this));
     if (
@@ -190,7 +190,7 @@ export class MWPTransport implements ExtendedTransport {
               ...messagePayload,
               method:
                 request.method === 'wallet_getSession' ||
-                  request.method === 'wallet_createSession'
+                request.method === 'wallet_createSession'
                   ? 'wallet_sessionChanged'
                   : request.method,
             } as unknown as {
@@ -202,7 +202,7 @@ export class MWPTransport implements ExtendedTransport {
               ...messagePayload,
               method:
                 request.method === 'wallet_getSession' ||
-                  request.method === 'wallet_createSession'
+                request.method === 'wallet_createSession'
                   ? 'wallet_sessionChanged'
                   : request.method,
               params: requestWithName.result,
@@ -449,7 +449,9 @@ export class MWPTransport implements ExtendedTransport {
 
               // Handle error response (e.g., user rejected the connection)
               if (messagePayload.error) {
-                return rejectConnection(this.parseWalletError(messagePayload.error));
+                return rejectConnection(
+                  this.parseWalletError(messagePayload.error),
+                );
               }
 
               // Success case - store session, notify, and resolve

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Display Wagmi connection errors in UI instead of only logging to console ([#156](https://github.com/MetaMask/connect-monorepo/pull/156))
+
 ## [0.1.1]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -2,7 +2,11 @@ import { useState, useEffect, useCallback } from 'react';
 import type { Scope, SessionData } from '@metamask/connect';
 import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useChainId, useConnect, useDisconnect } from 'wagmi';
-import { FEATURED_NETWORKS, convertCaipChainIdsToHex, TEST_IDS } from '@metamask/playground-ui';
+import {
+  FEATURED_NETWORKS,
+  convertCaipChainIdsToHex,
+  TEST_IDS,
+} from '@metamask/playground-ui';
 import { useSDK } from './sdk';
 import { useLegacyEVMSDK } from './sdk/LegacyEVMSDKProvider';
 import DynamicInputs, { INPUT_LABEL_TYPE } from './components/DynamicInputs';
@@ -46,7 +50,11 @@ function App() {
   } = useLegacyEVMSDK();
   const { address: wagmiAddress, isConnected: wagmiConnected } = useAccount();
   const wagmiChainId = useChainId();
-  const { connectors, connectAsync: wagmiConnectAsync, status: wagmiStatus } = useConnect();
+  const {
+    connectors,
+    connectAsync: wagmiConnectAsync,
+    status: wagmiStatus,
+  } = useConnect();
   const { disconnect: wagmiDisconnect } = useDisconnect();
 
   // On mount, check if wagmi is connected but not marked as active provider
@@ -80,7 +88,7 @@ function App() {
       for (const scope of scopes) {
         const { accounts } =
           session.sessionScopes?.[
-          scope as keyof typeof session.sessionScopes
+            scope as keyof typeof session.sessionScopes
           ] ?? {};
         if (accounts && accounts.length > 0) {
           allAccounts.push(...accounts);
@@ -123,7 +131,9 @@ function App() {
     const selectedScopesArray = customScopes.filter((scope) => scope.length);
     // Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
     // Then convert hex chain IDs to numbers for the connect method
-    const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map(id => hexToNumber(id));
+    const chainIds = convertCaipChainIdsToHex(selectedScopesArray).map((id) =>
+      hexToNumber(id),
+    );
     // Use first chain or default to mainnet (1), ensuring it's a valid wagmi chain
     const chainId = (chainIds[0] || 1) as 1 | 10 | 11155111 | 42220;
 
@@ -160,7 +170,14 @@ function App() {
     if (wagmiConnected) {
       wagmiDisconnect();
     }
-  }, [sdkDisconnect, legacyDisconnect, wagmiDisconnect, isConnected, legacyConnected, wagmiConnected]);
+  }, [
+    sdkDisconnect,
+    legacyDisconnect,
+    wagmiDisconnect,
+    isConnected,
+    legacyConnected,
+    wagmiConnected,
+  ]);
 
   const availableOptions = Object.keys(FEATURED_NETWORKS).reduce<
     { name: string; value: string }[]
@@ -173,9 +190,15 @@ function App() {
 
   const isConnecting = status === 'connecting';
   return (
-    <div data-testid={TEST_IDS.app.container} className="min-h-screen bg-gray-50 flex justify-center">
+    <div
+      data-testid={TEST_IDS.app.container}
+      className="min-h-screen bg-gray-50 flex justify-center"
+    >
       <div className="max-w-6xl w-full p-8">
-        <h1 data-testid={TEST_IDS.app.title} className="text-slate-800 text-4xl font-bold mb-8 text-center">
+        <h1
+          data-testid={TEST_IDS.app.title}
+          className="text-slate-800 text-4xl font-bold mb-8 text-center"
+        >
           MetaMask MultiChain API Test Dapp
         </h1>
         <section className="bg-white rounded-lg p-8 mb-6 shadow-sm">
@@ -230,14 +253,20 @@ function App() {
                 disabled={wagmiStatus === 'pending'}
                 className="bg-purple-500 text-white px-5 py-2 rounded text-base hover:bg-purple-600 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
               >
-                {wagmiStatus === 'pending' ? 'Connecting...' : 'Connect (Wagmi)'}
+                {wagmiStatus === 'pending'
+                  ? 'Connecting...'
+                  : 'Connect (Wagmi)'}
               </button>
             )}
 
             {isConnected && (
               <button
                 type="button"
-                data-testid={scopesHaveChanged() ? TEST_IDS.app.btnReconnect : TEST_IDS.app.btnDisconnect}
+                data-testid={
+                  scopesHaveChanged()
+                    ? TEST_IDS.app.btnReconnect
+                    : TEST_IDS.app.btnDisconnect
+                }
                 onClick={scopesHaveChanged() ? connect : disconnect}
                 className="bg-blue-500 text-white px-5 py-2 rounded text-base hover:bg-blue-600 transition-colors"
               >
@@ -260,23 +289,39 @@ function App() {
           </div>
         </section>
         {(error || legacyError) && (
-          <section data-testid={TEST_IDS.app.sectionError} className="bg-white rounded-lg p-8 mb-6 shadow-sm">
+          <section
+            data-testid={TEST_IDS.app.sectionError}
+            className="bg-white rounded-lg p-8 mb-6 shadow-sm"
+          >
             <h2 className="text-2xl font-bold text-red-600 mb-4">Error</h2>
             {error && (
               <p className="text-gray-700 mb-2">
-                <span className="font-semibold">Multichain:</span> {error.message.toString()}
-                {(error as any).code && <span className="ml-2 text-sm text-gray-500">(code: {(error as any).code})</span>}
+                <span className="font-semibold">Multichain:</span>{' '}
+                {error.message.toString()}
+                {(error as any).code && (
+                  <span className="ml-2 text-sm text-gray-500">
+                    (code: {(error as any).code})
+                  </span>
+                )}
               </p>
             )}
             {legacyError && (
               <p className="text-gray-700">
-                <span className="font-semibold">Legacy EVM:</span> {legacyError.message.toString()}
-                {(legacyError as any).code && <span className="ml-2 text-sm text-gray-500">(code: {(legacyError as any).code})</span>}
+                <span className="font-semibold">Legacy EVM:</span>{' '}
+                {legacyError.message.toString()}
+                {(legacyError as any).code && (
+                  <span className="ml-2 text-sm text-gray-500">
+                    (code: {(legacyError as any).code})
+                  </span>
+                )}
               </p>
             )}
           </section>
         )}
-        <section data-testid={TEST_IDS.app.sectionConnected} className="bg-white rounded-lg p-8 mb-6 shadow-sm">
+        <section
+          data-testid={TEST_IDS.app.sectionConnected}
+          className="bg-white rounded-lg p-8 mb-6 shadow-sm"
+        >
           {Object.keys(session?.sessionScopes ?? {}).length > 0 && (
             <section data-testid={TEST_IDS.app.sectionScopes} className="mb-6">
               <h2 className="text-2xl font-bold text-gray-800 mb-6">

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -31,6 +31,9 @@ function App() {
     isProviderActive('wagmi'),
   );
 
+  // Track Wagmi connection errors
+  const [wagmiError, setWagmiError] = useState<Error | null>(null);
+
   const {
     error,
     status,
@@ -128,6 +131,9 @@ function App() {
   }, [customScopes, legacyConnect]);
 
   const connectWagmi = useCallback(async () => {
+    // Clear any previous error
+    setWagmiError(null);
+
     const selectedScopesArray = customScopes.filter((scope) => scope.length);
     // Convert CAIP-2 chain IDs to hex, filtering out Solana and other non-EVM networks
     // Then convert hex chain IDs to numbers for the connect method
@@ -146,8 +152,9 @@ function App() {
         });
         setProviderActive('wagmi');
         setWagmiIsActiveProvider(true);
-      } catch (error) {
-        console.error('Wagmi connection error:', error);
+      } catch (err) {
+        console.error('Wagmi connection error:', err);
+        setWagmiError(err instanceof Error ? err : new Error(String(err)));
       }
     }
   }, [customScopes, connectors, wagmiConnectAsync]);
@@ -288,7 +295,7 @@ function App() {
             )}
           </div>
         </section>
-        {(error || legacyError) && (
+        {(error || legacyError || wagmiError) && (
           <section
             data-testid={TEST_IDS.app.sectionError}
             className="bg-white rounded-lg p-8 mb-6 shadow-sm"
@@ -306,12 +313,23 @@ function App() {
               </p>
             )}
             {legacyError && (
-              <p className="text-gray-700">
+              <p className="text-gray-700 mb-2">
                 <span className="font-semibold">Legacy EVM:</span>{' '}
                 {legacyError.message.toString()}
                 {(legacyError as any).code && (
                   <span className="ml-2 text-sm text-gray-500">
                     (code: {(legacyError as any).code})
+                  </span>
+                )}
+              </p>
+            )}
+            {wagmiError && (
+              <p className="text-gray-700">
+                <span className="font-semibold">Wagmi:</span>{' '}
+                {wagmiError.message.toString()}
+                {(wagmiError as any).code && (
+                  <span className="ml-2 text-sm text-gray-500">
+                    (code: {(wagmiError as any).code})
                   </span>
                 )}
               </p>

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
     chainId: legacyChainId,
     accounts: legacyAccounts,
     sdk: legacySDK,
+    error: legacyError,
     connect: legacyConnect,
     disconnect: legacyDisconnect,
   } = useLegacyEVMSDK();
@@ -79,7 +80,7 @@ function App() {
       for (const scope of scopes) {
         const { accounts } =
           session.sessionScopes?.[
-            scope as keyof typeof session.sessionScopes
+          scope as keyof typeof session.sessionScopes
           ] ?? {};
         if (accounts && accounts.length > 0) {
           allAccounts.push(...accounts);
@@ -258,10 +259,21 @@ function App() {
             )}
           </div>
         </section>
-        {error && (
+        {(error || legacyError) && (
           <section data-testid={TEST_IDS.app.sectionError} className="bg-white rounded-lg p-8 mb-6 shadow-sm">
             <h2 className="text-2xl font-bold text-red-600 mb-4">Error</h2>
-            <p className="text-gray-700">{error.message.toString()}</p>
+            {error && (
+              <p className="text-gray-700 mb-2">
+                <span className="font-semibold">Multichain:</span> {error.message.toString()}
+                {(error as any).code && <span className="ml-2 text-sm text-gray-500">(code: {(error as any).code})</span>}
+              </p>
+            )}
+            {legacyError && (
+              <p className="text-gray-700">
+                <span className="font-semibold">Legacy EVM:</span> {legacyError.message.toString()}
+                {(legacyError as any).code && <span className="ml-2 text-sm text-gray-500">(code: {(legacyError as any).code})</span>}
+              </p>
+            )}
           </section>
         )}
         <section data-testid={TEST_IDS.app.sectionConnected} className="bg-white rounded-lg p-8 mb-6 shadow-sm">

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -42,15 +42,15 @@ function convertCaipToHexKeys(
 
 const LegacyEVMSDKContext = createContext<
   | {
-    sdk: MetamaskConnectEVM | undefined;
-    connected: boolean;
-    provider: EIP1193Provider | undefined;
-    chainId: string | undefined;
-    accounts: string[];
-    error: Error | null;
-    connect: (chainIds: Hex[]) => Promise<void>;
-    disconnect: () => Promise<void>;
-  }
+      sdk: MetamaskConnectEVM | undefined;
+      connected: boolean;
+      provider: EIP1193Provider | undefined;
+      chainId: string | undefined;
+      accounts: string[];
+      error: Error | null;
+      connect: (chainIds: Hex[]) => Promise<void>;
+      disconnect: () => Promise<void>;
+    }
   | undefined
 >(undefined);
 
@@ -75,12 +75,12 @@ export const LegacyEVMSDKProvider = ({
         const caipNetworks = infuraApiKey
           ? getInfuraRpcUrls(infuraApiKey)
           : {
-            // Fallback public RPC endpoints if no Infura key is provided
-            'eip155:1': 'https://eth.llamarpc.com',
-            'eip155:5': 'https://goerli.infura.io/v3/demo',
-            'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
-            'eip155:137': 'https://polygon-rpc.com',
-          };
+              // Fallback public RPC endpoints if no Infura key is provided
+              'eip155:1': 'https://eth.llamarpc.com',
+              'eip155:5': 'https://goerli.infura.io/v3/demo',
+              'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
+              'eip155:137': 'https://polygon-rpc.com',
+            };
         const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 
         const clientSDK = await createEVMClient({

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -7,6 +7,7 @@ import {
   useWallet,
 } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import type { WalletError } from '@solana/wallet-adapter-base';
 import type React from 'react';
 import {
   createContext,
@@ -28,6 +29,8 @@ type SolanaSDKContextType = {
   isRegistered: boolean;
   endpoint: string;
   setEndpoint: (endpoint: string) => void;
+  walletError: Error | null;
+  clearWalletError: () => void;
 };
 
 const SolanaSDKContext = createContext<SolanaSDKContextType | undefined>(
@@ -43,7 +46,10 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
   const [client, setClient] = useState<SolanaClient | null>(null);
   const [isRegistered, setIsRegistered] = useState(false);
   const [endpoint, setEndpoint] = useState(SOLANA_DEVNET_ENDPOINT);
+  const [walletError, setWalletError] = useState<Error | null>(null);
   const initRef = useRef(false);
+
+  const clearWalletError = useCallback(() => setWalletError(null), []);
 
   useEffect(() => {
     if (initRef.current) return;
@@ -74,14 +80,24 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const contextValue = useMemo(
-    () => ({ client, isRegistered, endpoint, setEndpoint }),
-    [client, isRegistered, endpoint],
+    () => ({ client, isRegistered, endpoint, setEndpoint, walletError, clearWalletError }),
+    [client, isRegistered, endpoint, walletError, clearWalletError],
   );
+
+  // Handle wallet adapter errors (connection rejections, etc.)
+  // Skip WalletNotSelectedError as it's a transient state during wallet selection
+  const onWalletError = useCallback((error: WalletError) => {
+    console.error('Solana wallet error:', error.name, error.message);
+    // Only set meaningful errors (not WalletNotSelectedError which is transient)
+    if (error.name !== 'WalletNotSelectedError') {
+      setWalletError(error);
+    }
+  }, []);
 
   return (
     <SolanaSDKContext.Provider value={contextValue}>
       <ConnectionProvider endpoint={endpoint} config={{ commitment: 'confirmed' }}>
-        <WalletProvider wallets={[]} autoConnect>
+        <WalletProvider wallets={[]} autoConnect onError={onWalletError}>
           <WalletModalProvider>{children}</WalletModalProvider>
         </WalletProvider>
       </ConnectionProvider>


### PR DESCRIPTION
## Explanation

### Problem

When users scan a QR code and reject the connection on MetaMask Mobile, the error was not propagated to the dApp. The connection would just hang instead of showing an error, and the QR modal would remain open.

### Solution

**Error Handling:**
- Handle error responses in `initialConnectionMessageHandler` (for initial QR connections)
- Handle error responses in `handleMessage` (for ongoing requests)
- Use `@metamask/rpc-errors` (`providerErrors.custom()`) for proper EIP-1193 compliant errors
- Preserve wallet error codes when provided, default to `4001` (User Rejected Request)

**Modal Behavior:**
- Close QR modal automatically when user rejects connection (call `unload()` on error)

**Playground Improvements:**
- Display errors for Legacy EVM + Solana connections
- Display errors for Wagmi connections (was only logging to console)

**Code Quality:**
- Refactored `initialConnectionMessageHandler` to use early returns (reduced nesting from 5 to 2 levels)
- Combined ID-based and method-based message matching into single flow
- Removed manual error construction in favor of standard MetaMask error library

### Testing

- Tested QR rejection with Connect Multichain, Legacy EVM, and Wagmi
- All 259 unit tests passing
- Added new unit tests for error handling
- Verified modal closes on rejection
- Verified errors display in UI for all three connection methods

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes