### PR TITLE
do not use @metamask/connect (unified package) for playground deps

### DIFF
--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -55,7 +55,9 @@
   },
   "dependencies": {
     "@metamask/chain-agnostic-permission": "^1.2.2",
-    "@metamask/connect": "workspace:^",
+    "@metamask/connect-evm": "workspace:^",
+    "@metamask/connect-multichain": "workspace:^",
+    "@metamask/connect-solana": "workspace:^",
     "@metamask/utils": "^11.8.1",
     "@tanstack/query-sync-storage-persister": "5.0.5",
     "@tanstack/react-query": ">=5.45.1",

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -57,7 +57,6 @@
     "@metamask/chain-agnostic-permission": "^1.2.2",
     "@metamask/connect-evm": "workspace:^",
     "@metamask/connect-multichain": "workspace:^",
-    "@metamask/connect-solana": "workspace:^",
     "@metamask/utils": "^11.8.1",
     "@tanstack/query-sync-storage-persister": "5.0.5",
     "@tanstack/react-query": ">=5.45.1",

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Scope, SessionData } from '@metamask/connect';
+import type { Scope, SessionData } from '@metamask/connect-multichain';
 import { hexToNumber, type CaipAccountId, type Hex } from '@metamask/utils';
 import { useAccount, useChainId, useConnect, useDisconnect } from 'wagmi';
 import { FEATURED_NETWORKS, convertCaipChainIdsToHex, TEST_IDS } from '@metamask/playground-ui';

--- a/playground/browser-playground/src/components/FeaturedNetworks.tsx
+++ b/playground/browser-playground/src/components/FeaturedNetworks.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { Scope } from '@metamask/connect';
+import type { Scope } from '@metamask/connect-multichain';
 import { FEATURED_NETWORKS, TEST_IDS } from '@metamask/playground-ui';
 import React from 'react';
 

--- a/playground/browser-playground/src/components/ScopeCard.tsx
+++ b/playground/browser-playground/src/components/ScopeCard.tsx
@@ -1,5 +1,5 @@
 import MetaMaskOpenRPCDocument from '@metamask/api-specs';
-import type { Scope, SessionData } from '@metamask/connect';
+import type { Scope, SessionData } from '@metamask/connect-multichain';
 import {
   injectParams,
   METHODS_REQUIRING_PARAM_INJECTION,

--- a/playground/browser-playground/src/helpers/SignHelpers.ts
+++ b/playground/browser-playground/src/helpers/SignHelpers.ts
@@ -8,7 +8,7 @@
 /* eslint-disable id-length -- Short error variable */
 /* eslint-disable camelcase -- RPC method names */
 /* eslint-disable import-x/no-nodejs-modules -- Buffer polyfill */
-import type { EIP1193Provider } from '@metamask/connect/evm';
+import type { EIP1193Provider } from '@metamask/connect-evm';
 import {
   createSignTypedDataParams,
   getDefaultPersonalSignMessage,

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -1,5 +1,5 @@
-import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect/evm';
-import type { EIP1193Provider } from '@metamask/connect/evm';
+import { MetamaskConnectEVM, createEVMClient } from '@metamask/connect-evm';
+import type { EIP1193Provider } from '@metamask/connect-evm';
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
 import type { Hex } from '@metamask/utils';
 import type React from 'react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,7 +4010,9 @@ __metadata:
     "@metamask/api-specs": "npm:^0.14.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"
-    "@metamask/connect": "workspace:^"
+    "@metamask/connect-evm": "workspace:^"
+    "@metamask/connect-multichain": "workspace:^"
+    "@metamask/connect-solana": "workspace:^"
     "@metamask/playground-ui": "workspace:^"
     "@metamask/utils": "npm:^11.8.1"
     "@open-rpc/meta-schema": "npm:^1.14.9"
@@ -4185,7 +4187,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/connect@workspace:^, @metamask/connect@workspace:packages/connect":
+"@metamask/connect-solana@workspace:^, @metamask/connect-solana@workspace:packages/connect-solana":
+  version: 0.0.0-use.local
+  resolution: "@metamask/connect-solana@workspace:packages/connect-solana"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/connect-multichain": "workspace:^"
+    "@metamask/solana-wallet-standard": "npm:^0.6.0"
+    "@types/jsdom": "npm:^21.1.7"
+    "@vitest/coverage-v8": "npm:^3.2.4"
+    "@wallet-standard/base": "npm:^1.1.0"
+    jsdom: "npm:^26.1.0"
+    prettier: "npm:^3.3.3"
+    tsup: "npm:^8.4.0"
+    typedoc: "npm:^0.28.14"
+    typedoc-plugin-missing-exports: "npm:^4.1.2"
+    typescript: "npm:^5.9.3"
+    vitest: "npm:^3.1.2"
+  languageName: unknown
+  linkType: soft
+
+"@metamask/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@metamask/connect@workspace:packages/connect"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,7 +4012,6 @@ __metadata:
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"
     "@metamask/connect-evm": "workspace:^"
     "@metamask/connect-multichain": "workspace:^"
-    "@metamask/connect-solana": "workspace:^"
     "@metamask/playground-ui": "workspace:^"
     "@metamask/utils": "npm:^11.8.1"
     "@open-rpc/meta-schema": "npm:^1.14.9"
@@ -4184,26 +4183,6 @@ __metadata:
     ws: "npm:^8.18.3"
   peerDependencies:
     "@react-native-async-storage/async-storage": ^1.23
-  languageName: unknown
-  linkType: soft
-
-"@metamask/connect-solana@workspace:^, @metamask/connect-solana@workspace:packages/connect-solana":
-  version: 0.0.0-use.local
-  resolution: "@metamask/connect-solana@workspace:packages/connect-solana"
-  dependencies:
-    "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/connect-multichain": "workspace:^"
-    "@metamask/solana-wallet-standard": "npm:^0.6.0"
-    "@types/jsdom": "npm:^21.1.7"
-    "@vitest/coverage-v8": "npm:^3.2.4"
-    "@wallet-standard/base": "npm:^1.1.0"
-    jsdom: "npm:^26.1.0"
-    prettier: "npm:^3.3.3"
-    tsup: "npm:^8.4.0"
-    typedoc: "npm:^0.28.14"
-    typedoc-plugin-missing-exports: "npm:^4.1.2"
-    typescript: "npm:^5.9.3"
-    vitest: "npm:^3.1.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Migrate browser playground from monolithic @metamask/connect to modular chain-specific packages (connect-evm, connect-multichain, connect-solana)
