### PR TITLE
Fix sessionProperties: `undefined` being sent to wallet in transport files

### DIFF
--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -246,7 +246,11 @@ export class DefaultTransport implements ExtendedTransport {
       );
       const createSessionParams: CreateSessionParams<RPCAPI> = {
         optionalScopes,
-        sessionProperties: options?.sessionProperties,
+        // Only include sessionProperties if defined (undefined values are preserved
+        // by postMessage's structured clone algorithm and cause wallet validation errors)
+        ...(options?.sessionProperties && {
+          sessionProperties: options.sessionProperties,
+        }),
       };
       const response = await this.request(
         { method: 'wallet_createSession', params: createSessionParams },

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -382,7 +382,10 @@ export class MWPTransport implements ExtendedTransport {
             );
             const sessionRequest: CreateSessionParams<RPCAPI> = {
               optionalScopes,
-              sessionProperties: options?.sessionProperties,
+              // Only include sessionProperties if defined (undefined values cause wallet validation errors)
+              ...(options?.sessionProperties && {
+                sessionProperties: options.sessionProperties,
+              }),
             };
             const request = {
               jsonrpc: '2.0',


### PR DESCRIPTION
## Fix `sessionProperties: undefined` being sent to wallet in transport files

### Problem
PR #138 attempted to fix empty `sessionProperties` causing `wallet_createSession` to fail, but the fix was incomplete. While `multichain/index.ts` was updated to pass `undefined` instead of empty objects, the transport files still created objects like:

```js
const createSessionParams = {
  optionalScopes,
  sessionProperties: options?.sessionProperties, // undefined value still included
};
```

`window.postMessage` uses the **structured clone algorithm** which preserves `undefined` values (unlike `JSON.stringify` which omits them). This caused the wallet to receive `{ sessionProperties: undefined }` and reject it with "Invalid sessionProperties requested".

### Solution
Use conditional spreading to only include `sessionProperties` when defined:

```js
const createSessionParams = {
  optionalScopes,
  ...(options?.sessionProperties && { sessionProperties: options.sessionProperties }),
};
```
