### PR TITLE
update browser playground button names

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons
+
 ## [0.1.1]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -195,7 +195,7 @@ function App() {
                 onClick={connect}
                 className="bg-blue-500 text-white px-5 py-2 rounded text-base hover:bg-blue-600 transition-colors"
               >
-                Connecting
+                Connecting (Multichain)
               </button>
             )}
 
@@ -206,7 +206,7 @@ function App() {
                 onClick={connect}
                 className="bg-blue-500 text-white px-5 py-2 rounded text-base hover:bg-blue-600 transition-colors"
               >
-                Connect
+                Connect (Multichain)
               </button>
             )}
 
@@ -241,8 +241,8 @@ function App() {
                 className="bg-blue-500 text-white px-5 py-2 rounded text-base hover:bg-blue-600 transition-colors"
               >
                 {scopesHaveChanged()
-                  ? `Re Establishing Connection`
-                  : `Disconnect`}
+                  ? `Re Establishing Connection (Multichain)`
+                  : `Disconnect (Multichain)`}
               </button>
             )}
 
@@ -253,7 +253,7 @@ function App() {
                 onClick={disconnect}
                 className="bg-red-500 text-white px-5 py-2 rounded text-base hover:bg-red-600 transition-colors"
               >
-                Disconnect
+                Disconnect All
               </button>
             )}
           </div>

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons
 - Update to use hex chain ID format for `@metamask/connect-evm` API compatibility ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
 
 ## [0.1.0]

--- a/playground/react-native-playground/app/index.tsx
+++ b/playground/react-native-playground/app/index.tsx
@@ -137,22 +137,22 @@ export default function Page() {
 						<DynamicInputs availableOptions={availableOptions} inputArray={customScopes} handleCheckboxChange={handleCheckboxChange} label={INPUT_LABEL_TYPE.SCOPE} />
 					</View>
 
-					{isConnecting && (
-						<>
-							<TouchableOpacity testID={TEST_IDS.app.btnConnect()} onPress={connect} style={sharedStyles.button} disabled>
-								<Text style={sharedStyles.buttonText}>Connecting...</Text>
-							</TouchableOpacity>
-							<TouchableOpacity testID={TEST_IDS.app.btnCancel} onPress={disconnect} style={sharedStyles.buttonCancel}>
-								<Text style={sharedStyles.buttonText}>Cancel</Text>
-							</TouchableOpacity>
-						</>
-					)}
-
-					{isDisconnected && (
-						<TouchableOpacity testID={TEST_IDS.app.btnConnect()} onPress={connect} style={sharedStyles.button}>
-							<Text style={sharedStyles.buttonText}>Connect</Text>
+				{isConnecting && (
+					<>
+						<TouchableOpacity testID={TEST_IDS.app.btnConnect()} onPress={connect} style={sharedStyles.button} disabled>
+							<Text style={sharedStyles.buttonText}>Connecting (Multichain)...</Text>
 						</TouchableOpacity>
-					)}
+						<TouchableOpacity testID={TEST_IDS.app.btnCancel} onPress={disconnect} style={sharedStyles.buttonCancel}>
+							<Text style={sharedStyles.buttonText}>Cancel</Text>
+						</TouchableOpacity>
+					</>
+				)}
+
+				{isDisconnected && (
+					<TouchableOpacity testID={TEST_IDS.app.btnConnect()} onPress={connect} style={sharedStyles.button}>
+						<Text style={sharedStyles.buttonText}>Connect (Multichain)</Text>
+					</TouchableOpacity>
+				)}
 
 					{!legacyConnected && (
 						<TouchableOpacity testID={TEST_IDS.app.btnConnect('legacy')} onPress={connectLegacyEVM} style={[sharedStyles.button, styles.legacyButton]}>
@@ -180,17 +180,17 @@ export default function Page() {
 						</TouchableOpacity>
 					)}
 
-					{isConnected && (
-						<TouchableOpacity testID={scopesHaveChanged() ? TEST_IDS.app.btnReconnect : TEST_IDS.app.btnDisconnect} onPress={scopesHaveChanged() ? connect : disconnect} style={sharedStyles.button}>
-							<Text style={sharedStyles.buttonText}>{scopesHaveChanged() ? 'Re Establishing Connection' : 'Disconnect'}</Text>
-						</TouchableOpacity>
-					)}
+				{isConnected && (
+					<TouchableOpacity testID={scopesHaveChanged() ? TEST_IDS.app.btnReconnect : TEST_IDS.app.btnDisconnect} onPress={scopesHaveChanged() ? connect : disconnect} style={sharedStyles.button}>
+						<Text style={sharedStyles.buttonText}>{scopesHaveChanged() ? 'Re Establishing Connection (Multichain)' : 'Disconnect (Multichain)'}</Text>
+					</TouchableOpacity>
+				)}
 
-					{(isConnected || legacyConnected || wagmiConnected) && (
-						<TouchableOpacity testID={TEST_IDS.app.btnDisconnect} onPress={disconnect} style={sharedStyles.buttonCancel}>
-							<Text style={sharedStyles.buttonText}>Disconnect</Text>
-						</TouchableOpacity>
-					)}
+				{(isConnected || legacyConnected || wagmiConnected) && (
+					<TouchableOpacity testID={TEST_IDS.app.btnDisconnect} onPress={disconnect} style={sharedStyles.buttonCancel}>
+						<Text style={sharedStyles.buttonText}>Disconnect All</Text>
+					</TouchableOpacity>
+				)}
 				</View>
 
 				{error && (


### PR DESCRIPTION
## Add connector labels to playground buttons

Update connect/disconnect button labels in both browser and React Native playgrounds to clarify which connector each button controls:

- "Connect" → "Connect (Multichain)"
- "Disconnect" → "Disconnect (Multichain)" for multichain-specific disconnect
- "Disconnect" → "Disconnect All" for the button that disconnects all connectors

This matches the existing labeling pattern used by "Connect (Legacy EVM)" and "Connect (Wagmi)" buttons.