### PR TITLE
fix: resolve Solana connect race condition causing WalletNotSelectedError

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons
 
+### Fixed
+
+- Fix Solana connect race condition that caused `WalletNotSelectedError` when extension not installed
+
 ## [0.1.1]
 
 ### Added

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -1,5 +1,4 @@
 import { createSolanaClient, type SolanaClient } from '@metamask/connect-solana';
-import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
 import {
   ConnectionProvider,
   WalletProvider,
@@ -10,7 +9,6 @@ import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import type React from 'react';
 import {
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,


### PR DESCRIPTION
### Summary
- Fixes `WalletNotSelectedError` being thrown when clicking "Connect (Solana)" without the extension installed
- Resolves timing issue between `select()` and `connect()` calls in the Solana wallet adapter

### Before

https://github.com/user-attachments/assets/8175f44c-5a74-4af4-8243-65bf7ef5045c

### After

https://github.com/user-attachments/assets/70baf488-7b5e-4bd2-a850-87e676aa17c4

### Problem
When connecting to Solana, the previous code called `select()` followed immediately by `connect()`. Since `select()` triggers an async React state update, `connect()` was executing before the wallet was actually selected, causing `WalletNotSelectedError` to appear in the console.

### Solution
Use an effect-based approach that waits for the wallet to be selected before initiating the connection:
1. `connectSolana()` calls `select()` and sets a `solanaPendingConnect` flag
2. A `useEffect` watches for when both the flag is set and the wallet becomes available
3. The effect then calls `connect()`, ensuring proper sequencing

### Testing Steps
- [ ] Click "Connect (Solana)" without MetaMask extension installed
- [ ] Verify no `WalletNotSelectedError` in console
- [ ] Verify QR code modal appears promptly
- [ ] Complete connection flow and verify wallet connects successfully