### PR TITLE
fix: skip Solana wallet standard registration when Metamask extension exists

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Solana wallet-standard integration for MetaMask Connect ([#123](https://github.com/MetaMask/connect-monorepo/pull/123))
+- Add Solana wallet-standard integration for MetaMask Connect
+
+### Fixed
+
+- Prevents MetaMask Connect from registering on the Solana wallet-standard registry when Metamask extension is installed ([#164](https://github.com/MetaMask/connect-monorepo/pull/164))
 
 [Unreleased]: https://github.com/MetaMask/connect-monorepo/

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@metamask/connect-multichain": "workspace:^",
     "@metamask/solana-wallet-standard": "^0.6.0",
+    "@wallet-standard/app": "~1.1.0",
     "@wallet-standard/base": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -148,7 +148,7 @@ describe('createSolanaClient', () => {
 
         expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
         });
       });
     });

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -10,6 +10,7 @@ import type {
   SolanaConnectOptions,
   SolanaSupportedNetworks,
 } from './types';
+import { isMetamaskExtensionRegistered } from './utils';
 
 /**
  * Creates a new Solana client for connecting to MetaMask via wallet-standard.
@@ -73,8 +74,16 @@ export async function createSolanaClient(
     core,
     getWallet: (walletName?: string) =>
       getWalletStandard({ client, walletName }),
-    registerWallet: async (walletName = 'MetaMask Connect') =>
-      registerSolanaWalletStandard({ client, walletName }),
+    registerWallet: async (walletName = 'MetaMask'): Promise<void> => {
+      if (isMetamaskExtensionRegistered()) {
+        console.debug(
+          '[MetaMask Connect] MetaMask Solana wallet already registered, skipping...',
+        );
+        return;
+      }
+
+      await registerSolanaWalletStandard({ client, walletName });
+    },
     disconnect: async () => await core.disconnect(),
   };
 }

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -10,7 +10,7 @@ import type {
   SolanaConnectOptions,
   SolanaSupportedNetworks,
 } from './types';
-import { isMetamaskExtensionRegistered } from './utils';
+import { isMetamaskExtensionRegistered, logger, enableDebug } from './utils';
 
 /**
  * Creates a new Solana client for connecting to MetaMask via wallet-standard.
@@ -53,6 +53,10 @@ import { isMetamaskExtensionRegistered } from './utils';
 export async function createSolanaClient(
   options: SolanaConnectOptions,
 ): Promise<SolanaClient> {
+  if (options.debug) {
+    enableDebug();
+  }
+
   const defaultNetworks: SolanaSupportedNetworks = {
     mainnet: 'https://api.mainnet-beta.solana.com',
   };
@@ -76,9 +80,7 @@ export async function createSolanaClient(
       getWalletStandard({ client, walletName }),
     registerWallet: async (walletName = 'MetaMask'): Promise<void> => {
       if (isMetamaskExtensionRegistered()) {
-        console.debug(
-          '[MetaMask Connect] MetaMask Solana wallet already registered, skipping...',
-        );
+        logger('MetaMask extension is already registered. Skipping...');
         return;
       }
 

--- a/packages/connect-solana/src/mocks/connect-multichain.ts
+++ b/packages/connect-solana/src/mocks/connect-multichain.ts
@@ -1,3 +1,5 @@
 import { vi } from 'vitest';
 
 export const createMultichainClient = vi.fn();
+export const enableDebug = vi.fn();
+export const createLogger = vi.fn();

--- a/packages/connect-solana/src/utils.ts
+++ b/packages/connect-solana/src/utils.ts
@@ -1,0 +1,14 @@
+import { getWallets } from '@wallet-standard/app';
+
+/**
+ * Check if MetaMask extension is registered on Solana wallet-standard registry
+ *
+ * @returns True if extension is registered, false otherwise
+ */
+export const isMetamaskExtensionRegistered = (): boolean => {
+  const wallets = getWallets();
+
+  return wallets
+    .get()
+    .some((wallet) => wallet.name.toLowerCase().includes('metamask'));
+};

--- a/packages/connect-solana/src/utils.ts
+++ b/packages/connect-solana/src/utils.ts
@@ -1,4 +1,18 @@
+import {
+  createLogger,
+  enableDebug as debug,
+} from '@metamask/connect-multichain';
 import { getWallets } from '@wallet-standard/app';
+
+const namespace = 'metamask-connect:solana';
+
+// @ts-expect-error logger needs to be typed properly
+export const logger = createLogger(namespace, '93');
+
+export const enableDebug = (): void => {
+  // @ts-expect-error logger needs to be typed properly
+  debug(namespace);
+};
 
 /**
  * Check if MetaMask extension is registered on Solana wallet-standard registry

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change Solana wallet standard query to Metamask instead of Metamask Connect ([#164](https://github.com/MetaMask/connect-monorepo/pull/164))
+
+## [0.2.0]
+
 ### Added
 
 - Add Solana wallet standard integration ([#123](https://github.com/MetaMask/connect-monorepo/pull/123))
 
 ### Changed
 
-- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons
+- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons ([#161](https://github.com/MetaMask/connect-monorepo/pull/161))
 
 ## [0.1.1]
 
@@ -31,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.1.1...@metamask/browser-playground@0.2.0
 [0.1.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.1.0...@metamask/browser-playground@0.1.1
 [0.1.0]: https://github.com/MetaMask/connect-monorepo/releases/tag/@metamask/browser-playground@0.1.0

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change Solana wallet standard query to Metamask instead of Metamask Connect ([#164](https://github.com/MetaMask/connect-monorepo/pull/164))
+- Change Solana Wallet Standard filter to find wallet name 'Metamask' rather than 'Metamask Connect' ([#164](https://github.com/MetaMask/connect-monorepo/pull/164))
 
 ## [0.2.0]
 

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -164,7 +164,7 @@ function App() {
   const connectSolana = useCallback(async () => {
     // Find the MetaMask wallet in registered wallets
     const metamaskWallet = wallets.find((w) =>
-      w.adapter.name.toLowerCase().includes('metamask connect'),
+      w.adapter.name.toLowerCase().includes('metamask'),
     );
     if (metamaskWallet) {
       try {

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -1,4 +1,7 @@
-import { createSolanaClient, type SolanaClient } from '@metamask/connect-solana';
+import {
+  createSolanaClient,
+  type SolanaClient,
+} from '@metamask/connect-solana';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
 import {
   ConnectionProvider,
@@ -50,6 +53,7 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
     initRef.current = true;
 
     createSolanaClient({
+      debug: true,
       dapp: {
         name: 'MetaMask Connect Playground',
         url: window.location.origin,
@@ -80,7 +84,10 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <SolanaSDKContext.Provider value={contextValue}>
-      <ConnectionProvider endpoint={endpoint} config={{ commitment: 'confirmed' }}>
+      <ConnectionProvider
+        endpoint={endpoint}
+        config={{ commitment: 'confirmed' }}
+      >
         <WalletProvider wallets={[]} autoConnect>
           <WalletModalProvider>{children}</WalletModalProvider>
         </WalletProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,6 +4198,7 @@ __metadata:
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@types/jsdom": "npm:^21.1.7"
     "@vitest/coverage-v8": "npm:^3.2.4"
+    "@wallet-standard/app": "npm:~1.1.0"
     "@wallet-standard/base": "npm:^1.1.0"
     jsdom: "npm:^26.1.0"
     prettier: "npm:^3.3.3"
@@ -9640,7 +9641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-standard/app@npm:^1.1.0":
+"@wallet-standard/app@npm:^1.1.0, @wallet-standard/app@npm:~1.1.0":
   version: 1.1.0
   resolution: "@wallet-standard/app@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When both the MetaMask extension and SDK are present, registering the SDK wallet would create a duplicate "MetaMask" entry in wallet adapters, confusing users. This change ensures only one MetaMask wallet appears in the wallet selection UI.

This PR prevents duplicate wallet registration when the MetaMask browser extension is already installed and registered in the Solana wallet-standard registry. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes [WAPI-1069](https://consensyssoftware.atlassian.net/browse/WAPI-1069?atlOrigin=eyJpIjoiMjc0YjllMTJiMzFmNDU0M2FiNGY5OGNhZTk0ZWQyNzEiLCJwIjoiaiJ9)

### Manual testing steps

1. Installl & build - `yarn && yarn build`
2. Launch playground `yarn workspace @metamask/browser-playground start`
3. With the extension installed, open console, click `Connect(Solana)`.
4. Logs should have `MetaMask extension is already registered.`. 
5. For the reverse behavior, disconnect, disable extension, refresh.
6. Click `Connect(Solana)`, you should see MMConnect's QR code pop-up. Console won't show the log from step `3.`, meaning MM Connect got registered. 


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


[WAPI-1069]: https://consensyssoftware.atlassian.net/browse/WAPI-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ