### PR TITLE
fix: move browser-playground deps to devDependencies

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons
+- **BREAKING**: Update connect/disconnect button labels to include connector names ("Connect" → "Connect (Multichain)", "Disconnect" → "Disconnect (Multichain)" / "Disconnect All") for clarity and consistency with other connector buttons ([#161](https://github.com/MetaMask/connect-monorepo/pull/161))
 
 ## [0.1.1]
 

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -50,41 +50,35 @@
       "last 1 safari version"
     ]
   },
-  "dependencies": {
-    "@metamask/chain-agnostic-permission": "^1.2.2",
-    "@metamask/connect-evm": "workspace:^",
-    "@metamask/connect-multichain": "workspace:^",
-    "@metamask/utils": "^11.8.1",
-    "@solana/wallet-adapter-react": "^0.15.35",
-    "@solana/wallet-adapter-react-ui": "^0.9.35",
-    "@solana/wallet-standard-chains": "^1.1.1",
-    "@solana/web3.js": "^1.98.0",
-    "@tanstack/query-sync-storage-persister": "5.0.5",
-    "@tanstack/react-query": ">=5.45.1",
-    "@tanstack/react-query-persist-client": "5.0.5",
-    "@wagmi/core": "^2.22.1",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "viem": "2.*",
-    "wagmi": "^2.19.2"
-  },
   "devDependencies": {
     "@craco/craco": "^7.1.0",
     "@lavamoat/allow-scripts": "^3.0.4",
     "@lavamoat/preinstall-always-fail": "^2.0.0",
     "@metamask/api-specs": "^0.14.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/chain-agnostic-permission": "^1.2.2",
+    "@metamask/connect-evm": "workspace:^",
+    "@metamask/connect-multichain": "workspace:^",
     "@metamask/playground-ui": "workspace:^",
+    "@metamask/utils": "^11.8.1",
     "@open-rpc/meta-schema": "^1.14.9",
     "@open-rpc/schema-utils-js": "^2.0.5",
+    "@solana/wallet-adapter-react": "^0.15.35",
+    "@solana/wallet-adapter-react-ui": "^0.9.35",
+    "@solana/wallet-standard-chains": "^1.1.1",
+    "@solana/web3.js": "^1.98.0",
     "@tailwindcss/postcss": "^4.0.0",
+    "@tanstack/query-sync-storage-persister": "5.0.5",
+    "@tanstack/react-query": ">=5.45.1",
     "@tanstack/react-query-devtools": "5.0.5",
+    "@tanstack/react-query-persist-client": "5.0.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@types/chrome": "^0.0.279",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.9.0",
     "@types/react": "19.1.0",
+    "@wagmi/core": "^2.22.1",
     "@yarnpkg/types": "^4.0.0",
     "autoprefixer": "^10.4.21",
     "buffer": "^6.0.3",
@@ -96,6 +90,8 @@
     "prettier": "^3.3.3",
     "prettier-plugin-packagejson": "^2.4.5",
     "process": "^0.11.10",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "react-scripts": "5.0.1",
     "serve": "^14.2.5",
     "tailwindcss": "^4.1.11",
@@ -103,7 +99,9 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.28.14",
     "typedoc-plugin-missing-exports": "^4.1.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "viem": "2.*",
+    "wagmi": "^2.19.2"
   },
   "packageManager": "yarn@4.1.1",
   "engines": {
@@ -122,7 +120,13 @@
       "@solana/web3.js>rpc-websockets>bufferutil": false,
       "@solana/web3.js>rpc-websockets>utf-8-validate": false,
       "@metamask/connect>@metamask/mobile-wallet-protocol-dapp-client>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false,
-      "@metamask/connect>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false
+      "@metamask/connect>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false,
+      "@metamask/connect-multichain>@metamask/mobile-wallet-protocol-core>centrifuge>protobufjs": false,
+      "@tailwindcss/postcss>@tailwindcss/oxide": false,
+      "react-scripts>tailwindcss>postcss-load-config>tsx>esbuild": false,
+      "viem>ws>bufferutil": false,
+      "viem>ws>utf-8-validate": false,
+      "wagmi>@wagmi/connectors>cbw-sdk>keccak": false
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28199,11 +28199,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28199,11 +28199,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Problem
When `@metamask/browser-playground` is installed as a devDependency in metamask-mobile, t[he `ox` package (a transitive dependency of `viem`) causes TypeScript lint failures. ](https://github.com/MetaMask/metamask-mobile/pull/25518/changes/BASE..0de1fb5cd1c3c5d8c42fce033f490127bc012352#r2758604554)The `ox` package ships raw `.ts` source files which TypeScript type-checks even with `skipLibCheck: true`.

### Solution
Move all runtime dependencies to `devDependencies` in browser-playground. This is the correct configuration because:

1. **Only static files are published** - The package's `files` field is `["build/"]`, meaning only pre-built static assets are included
2. **Not a runtime library** - The `index.js` entry point throws an error stating the package cannot be run directly
3. **Dependencies are bundled** - All dependencies are bundled into the static output during build

### Result
When consuming projects install `@metamask/browser-playground`, they get only the `build/` folder without installing `viem`, `ox`, or any other transitive dependencies. E2E tests continue to work because they serve the pre-bundled static files.
