### PR TITLE
build: resolve failed github pages publishing workflow on mm connect dapps

### DIFF
--- a/.github/workflows/deploy-browser-playground-to-gh-pages.yml
+++ b/.github/workflows/deploy-browser-playground-to-gh-pages.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Build all packages (workspace dependencies) in topological order
           # This ensures @metamask/connect and other dependencies are built first
-          yarn workspaces foreach --all --topological-dev --verbose --no-private run build
+          yarn workspaces foreach --all --topological-dev --verbose run build
 
       - name: Build browser playground
         working-directory: playground/browser-playground

--- a/.github/workflows/deploy-legacy-evm-to-gh-pages.yml
+++ b/.github/workflows/deploy-legacy-evm-to-gh-pages.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Build all packages (workspace dependencies) in topological order
           # This ensures @metamask/connect-evm and other dependencies are built first
-          yarn workspaces foreach --all --topological-dev --verbose --no-private run build
+          yarn workspaces foreach --all --topological-dev --verbose run build
 
       - name: Build wagmi integration
         working-directory: playground/legacy-evm-react-vite-playground

--- a/.github/workflows/deploy-wagmi-to-gh-pages.yml
+++ b/.github/workflows/deploy-wagmi-to-gh-pages.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Build all packages (workspace dependencies) in topological order
           # This ensures @metamask/connect-evm and other dependencies are built first
-          yarn workspaces foreach --all --topological-dev --verbose --no-private run build
+          yarn workspaces foreach --all --topological-dev --verbose run build
 
       - name: Build wagmi integration
         working-directory: integrations/wagmi


### PR DESCRIPTION
## Explanation

This PR removes `--no-private` flag from workflow commands to make sure dapp deployments are successful on release.
Issue further explained [here](https://consensyssoftware.atlassian.net/browse/WAPI-1056).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1056 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
