### PR TITLE
fix: preserve instance-scoped event listeners on disconnect and fix beforeunload listener leak

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `display_uri` and `wallet_sessionChanged` events not firing after disconnect and reconnect in headless mode ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
+
 ### Changed
 
 - **BREAKING** Standardize `chainId` to use `Hex` format throughout the public API ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `display_uri` and `wallet_sessionChanged` events not firing after disconnect and reconnect in headless mode ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
-
 ### Changed
 
 - **BREAKING** Standardize `chainId` to use `Hex` format throughout the public API ([#150](https://github.com/MetaMask/connect-monorepo/pull/150))
@@ -23,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `debug` option param used by `createEVMClient()` now enables console debug logs of the underlying `MultichainClient` instance ([#149](https://github.com/MetaMask/connect-monorepo/pull/149))
 - update `connect()` and `createEVMClient()` typings to be more accurate ([#153](https://github.com/MetaMask/connect-monorepo/pull/153))
 - update `switchChain()` to return `Promise<void>` ([#153](https://github.com/MetaMask/connect-monorepo/pull/153))
+
+### Fixed
+
+- Fix `display_uri` and `wallet_sessionChanged` events not firing after disconnect and reconnect in headless mode ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
 
 ## [0.4.1]
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -489,8 +489,10 @@ export class MetamaskConnectEVM {
     this.#onDisconnect();
     this.#clearConnectionState();
 
-    this.#core.off('wallet_sessionChanged', this.#sessionChangedHandler);
-    this.#core.off('display_uri', this.#displayUriHandler);
+    // Note: We intentionally do NOT remove the display_uri and wallet_sessionChanged
+    // listeners here. These are instance-scoped listeners that should remain active
+    // for the lifetime of the SDK instance, allowing reconnection to work properly.
+    // Session-scoped listeners (like the notification handler below) are removed.
 
     if (this.#removeNotificationHandler) {
       this.#removeNotificationHandler();

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `beforeunload` event listener not being properly removed on disconnect due to `.bind()` creating different function references, causing a listener leak on each connect/disconnect cycle ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
+
 ## [0.5.3]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -329,21 +329,20 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   #createBeforeUnloadListener(): () => void {
+    const handler = this.#onBeforeUnload.bind(this);
+
     if (
       typeof window !== 'undefined' &&
       typeof window.addEventListener !== 'undefined'
     ) {
-      window.addEventListener('beforeunload', this.#onBeforeUnload.bind(this));
+      window.addEventListener('beforeunload', handler);
     }
     return () => {
       if (
         typeof window !== 'undefined' &&
         typeof window.removeEventListener !== 'undefined'
       ) {
-        window.removeEventListener(
-          'beforeunload',
-          this.#onBeforeUnload.bind(this),
-        );
+        window.removeEventListener('beforeunload', handler);
       }
     };
   }


### PR DESCRIPTION
## Summary

- **`display_uri` / `wallet_sessionChanged` not firing on reconnect**: `MetamaskConnectEVM.disconnect()` was removing the `display_uri` and `wallet_sessionChanged` listeners from the core instance, but `connect()` never re-registered them. After a disconnect→reconnect cycle (especially in headless mode), the QR code URI was never emitted and session scope updates were silently lost. Fix: stop removing these instance-scoped listeners on disconnect — they should live for the lifetime of the SDK instance. Session-scoped listeners (notification handler) are still correctly cleaned up.

- **`beforeunload` listener never actually removed (memory leak)**: `#createBeforeUnloadListener()` called `.bind(this)` separately in `addEventListener` and `removeEventListener`, producing two different function references. Since `removeEventListener` requires the exact same reference, the cleanup was silently a no-op, leaking a listener on every connect/disconnect cycle. Fix: store the bound function once and reuse it.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
