### PR TITLE
fix(connect-multichain): rename IndexedDB DB_NAME from mmsdk to mmconnect

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `beforeunload` event listener not being properly removed on disconnect due to `.bind()` creating different function references, causing a listener leak on each connect/disconnect cycle ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
+- Rename `StoreAdapterWeb.DB_NAME` from `mmsdk` to `mmconnect` to prevent IndexedDB collisions when the legacy MetaMask SDK and MM Connect run in the same browser context ([#177](https://github.com/MetaMask/connect-monorepo/pull/177))
 
 ## [0.5.3]
 

--- a/packages/connect-multichain/src/store/adapters/web.ts
+++ b/packages/connect-multichain/src/store/adapters/web.ts
@@ -11,7 +11,7 @@ type KvStores = 'sdk-kv-store' | 'key-value-pairs';
 export class StoreAdapterWeb extends StoreAdapter {
   static readonly stores: KvStores[] = ['sdk-kv-store', 'key-value-pairs'];
 
-  static readonly DB_NAME = 'mmsdk';
+  static readonly DB_NAME = 'mmconnect';
 
   readonly platform = 'web';
 

--- a/packages/connect-multichain/src/store/index.test.ts
+++ b/packages/connect-multichain/src/store/index.test.ts
@@ -290,9 +290,12 @@ t.describe(`Store with WebAdapter`, () => {
 });
 
 t.describe('StoreAdapterWeb DB naming', () => {
-  t.it('DB_NAME is mmconnect (not mmsdk, to avoid legacy SDK collisions)', () => {
-    t.expect(StoreAdapterWeb.DB_NAME).toBe('mmconnect');
-  });
+  t.it(
+    'DB_NAME is mmconnect (not mmsdk, to avoid legacy SDK collisions)',
+    () => {
+      t.expect(StoreAdapterWeb.DB_NAME).toBe('mmconnect');
+    },
+  );
 
   t.it('opens IndexedDB with mmconnect prefix and default suffix', () => {
     const idbFactory = new IDBFactory();
@@ -300,7 +303,7 @@ t.describe('StoreAdapterWeb DB naming', () => {
 
     t.vi.stubGlobal('window', { indexedDB: idbFactory });
 
-    new StoreAdapterWeb();
+    const _adapter = new StoreAdapterWeb();
 
     t.expect(openSpy).toHaveBeenCalledOnce();
     const calledWith = openSpy.mock.calls[0]?.[0];
@@ -313,7 +316,7 @@ t.describe('StoreAdapterWeb DB naming', () => {
 
     t.vi.stubGlobal('window', { indexedDB: idbFactory });
 
-    new StoreAdapterWeb('-my-suffix');
+    const _adapter = new StoreAdapterWeb('-my-suffix');
 
     t.expect(openSpy).toHaveBeenCalledOnce();
     const calledWith = openSpy.mock.calls[0]?.[0];

--- a/packages/connect-multichain/src/store/index.test.ts
+++ b/packages/connect-multichain/src/store/index.test.ts
@@ -289,6 +289,38 @@ t.describe(`Store with WebAdapter`, () => {
   );
 });
 
+t.describe('StoreAdapterWeb DB naming', () => {
+  t.it('DB_NAME is mmconnect (not mmsdk, to avoid legacy SDK collisions)', () => {
+    t.expect(StoreAdapterWeb.DB_NAME).toBe('mmconnect');
+  });
+
+  t.it('opens IndexedDB with mmconnect prefix and default suffix', () => {
+    const idbFactory = new IDBFactory();
+    const openSpy = t.vi.spyOn(idbFactory, 'open');
+
+    t.vi.stubGlobal('window', { indexedDB: idbFactory });
+
+    new StoreAdapterWeb();
+
+    t.expect(openSpy).toHaveBeenCalledOnce();
+    const calledWith = openSpy.mock.calls[0]?.[0];
+    t.expect(calledWith).toBe('mmconnect-kv-store');
+  });
+
+  t.it('opens IndexedDB with mmconnect prefix and custom suffix', () => {
+    const idbFactory = new IDBFactory();
+    const openSpy = t.vi.spyOn(idbFactory, 'open');
+
+    t.vi.stubGlobal('window', { indexedDB: idbFactory });
+
+    new StoreAdapterWeb('-my-suffix');
+
+    t.expect(openSpy).toHaveBeenCalledOnce();
+    const calledWith = openSpy.mock.calls[0]?.[0];
+    t.expect(calledWith).toBe('mmconnect-my-suffix');
+  });
+});
+
 t.describe(`Store with RNAdapter`, () => {
   // Test RN storage with mocked AsyncStorage
   createStoreTests(


### PR DESCRIPTION
## Summary

- Renames `StoreAdapterWeb.DB_NAME` from `'mmsdk'` to `'mmconnect'` in `packages/connect-multichain/src/store/adapters/web.ts`
- All IndexedDB database names are constructed from this constant, so the change propagates automatically (e.g. `mmsdk-kv-store` → `mmconnect-kv-store`)
- Adds unit tests asserting the new DB name value and that IndexedDB is opened with the correct prefix

## Why

The legacy MetaMask SDK uses `mmsdk`-prefixed IndexedDB databases. MM Connect was using the same prefix, meaning both SDKs could open the same database if running side-by-side in a browser. This is a forward-looking collision-avoidance change for scenarios where an app hasn't fully migrated away from the legacy SDK.

## Test plan

- [x] `yarn workspace @metamask/connect-multichain test` passes
- [x] Verify in browser DevTools → Application → IDB that the database is now named `mmconnect-kv-store` (not `mmsdk-kv-store`)

## Jira

[WAPI-1105](https://consensyssoftware.atlassian.net/browse/WAPI-1105)

[WAPI-1105]: https://consensyssoftware.atlassian.net/browse/WAPI-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ