### PR TITLE
feat: automatic Solana wallet standard registration

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add node.js builds [#169](https://github.com/MetaMask/connect-monorepo/pull/169)
 
+### Changed
+
+- Automatically register as MetaMask in the Solana Wallet Standard with override option [#178](https://github.com/MetaMask/connect-monorepo/pull/178)
+
 ## [0.1.0]
 
 ### Added

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Automatically register as MetaMask in the Solana Wallet Standard with override option [#178](https://github.com/MetaMask/connect-monorepo/pull/178)
+- **BREAKING:** Automatically register as MetaMask to Solana Wallet Standard registry upon instantiation - with option to skip auto-registration [#178](https://github.com/MetaMask/connect-monorepo/pull/178)
 
 ## [0.1.0]
 

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -112,8 +112,8 @@ describe('createSolanaClient', () => {
       });
     });
 
-    it('should skip auto-registration when autoRegister is false', async () => {
-      await createSolanaClient({ ...mockOptions, autoRegister: false });
+    it('should skip auto-registration when skipAutoRegister is true', async () => {
+      await createSolanaClient({ ...mockOptions, skipAutoRegister: true });
 
       expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
     });
@@ -136,7 +136,7 @@ describe('createSolanaClient', () => {
       it('should get wallet using getWalletStandard', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
         });
 
         const wallet = client.getWallet('CustomWallet');
@@ -151,7 +151,7 @@ describe('createSolanaClient', () => {
       it('should use default walletName when none provided', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
         });
 
         const wallet = client.getWallet();
@@ -166,7 +166,7 @@ describe('createSolanaClient', () => {
       it('should use custom walletName as default for getWallet', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
           walletName: 'My Custom Wallet',
         });
 
@@ -184,7 +184,7 @@ describe('createSolanaClient', () => {
       it('should register wallet using registerSolanaWalletStandard', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
         });
 
         await client.registerWallet('CustomWallet');
@@ -198,7 +198,7 @@ describe('createSolanaClient', () => {
       it('should register wallet with default name when no name provided', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
         });
 
         await client.registerWallet();
@@ -212,7 +212,7 @@ describe('createSolanaClient', () => {
       it('should use custom walletName as default for registerWallet', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
-          autoRegister: false,
+          skipAutoRegister: true,
           walletName: 'My Custom Wallet',
         });
 

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -117,38 +117,11 @@ describe('createSolanaClient', () => {
 
       expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
     });
-
-    it('should use custom walletName for auto-registration', async () => {
-      await createSolanaClient({
-        ...mockOptions,
-        walletName: 'My Custom Wallet',
-      });
-
-      expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
-        client: mockCore.provider,
-        walletName: 'My Custom Wallet',
-      });
-    });
   });
 
   describe('SolanaClient', () => {
     describe('getWallet', () => {
-      it('should get wallet using getWalletStandard', async () => {
-        const client = await createSolanaClient({
-          ...mockOptions,
-          skipAutoRegister: true,
-        });
-
-        const wallet = client.getWallet('CustomWallet');
-
-        expect(getWalletStandard).toHaveBeenCalledWith({
-          client: mockCore.provider,
-          walletName: 'CustomWallet',
-        });
-        expect(wallet).toBe(mockWallet);
-      });
-
-      it('should use default walletName when none provided', async () => {
+      it('should get wallet using getWalletStandard with MetaMask name', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
           skipAutoRegister: true,
@@ -159,43 +132,13 @@ describe('createSolanaClient', () => {
         expect(getWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
           walletName: 'MetaMask',
-        });
-        expect(wallet).toBe(mockWallet);
-      });
-
-      it('should use custom walletName as default for getWallet', async () => {
-        const client = await createSolanaClient({
-          ...mockOptions,
-          skipAutoRegister: true,
-          walletName: 'My Custom Wallet',
-        });
-
-        const wallet = client.getWallet();
-
-        expect(getWalletStandard).toHaveBeenCalledWith({
-          client: mockCore.provider,
-          walletName: 'My Custom Wallet',
         });
         expect(wallet).toBe(mockWallet);
       });
     });
 
     describe('registerWallet', () => {
-      it('should register wallet using registerSolanaWalletStandard', async () => {
-        const client = await createSolanaClient({
-          ...mockOptions,
-          skipAutoRegister: true,
-        });
-
-        await client.registerWallet('CustomWallet');
-
-        expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
-          client: mockCore.provider,
-          walletName: 'CustomWallet',
-        });
-      });
-
-      it('should register wallet with default name when no name provided', async () => {
+      it('should register wallet with MetaMask name', async () => {
         const client = await createSolanaClient({
           ...mockOptions,
           skipAutoRegister: true,
@@ -209,19 +152,13 @@ describe('createSolanaClient', () => {
         });
       });
 
-      it('should use custom walletName as default for registerWallet', async () => {
-        const client = await createSolanaClient({
-          ...mockOptions,
-          skipAutoRegister: true,
-          walletName: 'My Custom Wallet',
-        });
+      it('should no-op when auto-registration was used', async () => {
+        const client = await createSolanaClient(mockOptions);
 
+        vi.clearAllMocks();
         await client.registerWallet();
 
-        expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
-          client: mockCore.provider,
-          walletName: 'My Custom Wallet',
-        });
+        expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -102,10 +102,42 @@ describe('createSolanaClient', () => {
     expect(client.core).toBe(mockCore);
   });
 
+  describe('auto-registration', () => {
+    it('should auto-register the wallet by default', async () => {
+      await createSolanaClient(mockOptions);
+
+      expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
+        client: mockCore.provider,
+        walletName: 'MetaMask',
+      });
+    });
+
+    it('should skip auto-registration when autoRegister is false', async () => {
+      await createSolanaClient({ ...mockOptions, autoRegister: false });
+
+      expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+    });
+
+    it('should use custom walletName for auto-registration', async () => {
+      await createSolanaClient({
+        ...mockOptions,
+        walletName: 'My Custom Wallet',
+      });
+
+      expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
+        client: mockCore.provider,
+        walletName: 'My Custom Wallet',
+      });
+    });
+  });
+
   describe('SolanaClient', () => {
     describe('getWallet', () => {
       it('should get wallet using getWalletStandard', async () => {
-        const client = await createSolanaClient(mockOptions);
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+        });
 
         const wallet = client.getWallet('CustomWallet');
 
@@ -116,14 +148,33 @@ describe('createSolanaClient', () => {
         expect(wallet).toBe(mockWallet);
       });
 
-      it('should get wallet without walletName', async () => {
-        const client = await createSolanaClient(mockOptions);
+      it('should use default walletName when none provided', async () => {
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+        });
 
         const wallet = client.getWallet();
 
         expect(getWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: undefined,
+          walletName: 'MetaMask',
+        });
+        expect(wallet).toBe(mockWallet);
+      });
+
+      it('should use custom walletName as default for getWallet', async () => {
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+          walletName: 'My Custom Wallet',
+        });
+
+        const wallet = client.getWallet();
+
+        expect(getWalletStandard).toHaveBeenCalledWith({
+          client: mockCore.provider,
+          walletName: 'My Custom Wallet',
         });
         expect(wallet).toBe(mockWallet);
       });
@@ -131,7 +182,10 @@ describe('createSolanaClient', () => {
 
     describe('registerWallet', () => {
       it('should register wallet using registerSolanaWalletStandard', async () => {
-        const client = await createSolanaClient(mockOptions);
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+        });
 
         await client.registerWallet('CustomWallet');
 
@@ -142,13 +196,31 @@ describe('createSolanaClient', () => {
       });
 
       it('should register wallet with default name when no name provided', async () => {
-        const client = await createSolanaClient(mockOptions);
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+        });
 
         await client.registerWallet();
 
         expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
+        });
+      });
+
+      it('should use custom walletName as default for registerWallet', async () => {
+        const client = await createSolanaClient({
+          ...mockOptions,
+          autoRegister: false,
+          walletName: 'My Custom Wallet',
+        });
+
+        await client.registerWallet();
+
+        expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
+          client: mockCore.provider,
+          walletName: 'My Custom Wallet',
         });
       });
     });

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -23,7 +23,6 @@ import type {
  * @param options.api - Optional API configuration with supported networks
  * @param options.api.supportedNetworks - Record mapping network names (mainnet, devnet, testnet) to RPC URLs
  * @param options.debug - Enable debug logging
- * @param options.walletName - Custom wallet name for registration (defaults to 'MetaMask Connect')
  * @param options.skipAutoRegister - Skip auto-registering the wallet during creation (defaults to false)
  * @returns A promise that resolves to the Solana client instance
  *
@@ -56,7 +55,6 @@ export async function createSolanaClient(
     mainnet: 'https://api.mainnet-beta.solana.com',
   };
 
-  const walletName = options.walletName ?? 'MetaMask';
   const skipAutoRegister = options.skipAutoRegister ?? false;
 
   const supportedNetworks = convertNetworksToCAIP(
@@ -72,22 +70,20 @@ export async function createSolanaClient(
 
   const client = core.provider;
 
+  const walletName = 'MetaMask';
+
   if (!skipAutoRegister) {
     await registerSolanaWalletStandard({ client, walletName });
   }
 
   return {
     core,
-    getWallet: (name?: string) =>
-      getWalletStandard({ client, walletName: name ?? walletName }),
-    registerWallet: async (name?: string): Promise<void> => {
+    getWallet: () => getWalletStandard({ client, walletName }),
+    registerWallet: async (): Promise<void> => {
       if (!skipAutoRegister) {
         return;
       }
-      await registerSolanaWalletStandard({
-        client,
-        walletName: name ?? walletName,
-      });
+      await registerSolanaWalletStandard({ client, walletName });
     },
     disconnect: async () => await core.disconnect(),
   };

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -24,7 +24,7 @@ import type {
  * @param options.api.supportedNetworks - Record mapping network names (mainnet, devnet, testnet) to RPC URLs
  * @param options.debug - Enable debug logging
  * @param options.walletName - Custom wallet name for registration (defaults to 'MetaMask Connect')
- * @param options.autoRegister - Auto-register the wallet during creation (defaults to true)
+ * @param options.skipAutoRegister - Skip auto-registering the wallet during creation (defaults to false)
  * @returns A promise that resolves to the Solana client instance
  *
  * @example
@@ -57,7 +57,7 @@ export async function createSolanaClient(
   };
 
   const walletName = options.walletName ?? 'MetaMask';
-  const autoRegister = options.autoRegister ?? true;
+  const skipAutoRegister = options.skipAutoRegister ?? false;
 
   const supportedNetworks = convertNetworksToCAIP(
     options.api?.supportedNetworks ?? defaultNetworks,
@@ -72,7 +72,7 @@ export async function createSolanaClient(
 
   const client = core.provider;
 
-  if (autoRegister) {
+  if (!skipAutoRegister) {
     await registerSolanaWalletStandard({ client, walletName });
   }
 
@@ -81,7 +81,7 @@ export async function createSolanaClient(
     getWallet: (name?: string) =>
       getWalletStandard({ client, walletName: name ?? walletName }),
     registerWallet: async (name?: string): Promise<void> => {
-      if (autoRegister) {
+      if (!skipAutoRegister) {
         return;
       }
       await registerSolanaWalletStandard({

--- a/packages/connect-solana/src/types.ts
+++ b/packages/connect-solana/src/types.ts
@@ -37,8 +37,6 @@ export type SolanaConnectOptions = Pick<MultichainOptions, 'dapp'> & {
   };
   /** Enable debug logging */
   debug?: boolean;
-  /** Custom wallet name for registration and getWallet. Defaults to 'MetaMask'. */
-  walletName?: string;
   /** Skip auto-registering the wallet during creation. Defaults to false. Set to true for manual control. */
   skipAutoRegister?: boolean;
 };
@@ -50,19 +48,16 @@ export type SolanaClient = {
   /** The underlying MultichainCore instance */
   core: MultichainCore;
   /**
-   * Gets a wallet-standard compatible wallet instance.
+   * Gets the wallet-standard compatible MetaMask wallet instance.
    *
-   * @param walletName - Optional custom name for the wallet
    * @returns The wallet instance
    */
-  getWallet: (walletName?: string) => Wallet;
+  getWallet: () => Wallet;
   /**
    * Registers the MetaMask wallet with the wallet-standard registry.
    * This makes MetaMask automatically discoverable by Solana dapps.
-   *
-   * @param walletName - Optional custom name for the wallet
    */
-  registerWallet: (walletName?: string) => Promise<void>;
+  registerWallet: () => Promise<void>;
   /**
    * Disconnects from the wallet and revokes the session.
    */

--- a/packages/connect-solana/src/types.ts
+++ b/packages/connect-solana/src/types.ts
@@ -39,8 +39,8 @@ export type SolanaConnectOptions = Pick<MultichainOptions, 'dapp'> & {
   debug?: boolean;
   /** Custom wallet name for registration and getWallet. Defaults to 'MetaMask'. */
   walletName?: string;
-  /** Auto-register the wallet during creation. Defaults to true. Set to false for manual control. */
-  autoRegister?: boolean;
+  /** Skip auto-registering the wallet during creation. Defaults to false. Set to true for manual control. */
+  skipAutoRegister?: boolean;
 };
 
 /**

--- a/packages/connect-solana/src/types.ts
+++ b/packages/connect-solana/src/types.ts
@@ -37,6 +37,10 @@ export type SolanaConnectOptions = Pick<MultichainOptions, 'dapp'> & {
   };
   /** Enable debug logging */
   debug?: boolean;
+  /** Custom wallet name for registration and getWallet. Defaults to 'MetaMask'. */
+  walletName?: string;
+  /** Auto-register the wallet during creation. Defaults to true. Set to false for manual control. */
+  autoRegister?: boolean;
 };
 
 /**

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove manual registration of `connect-solana` ([#178](https://github.com/MetaMask/connect-monorepo/pull/178))
+
 ## [0.2.0]
 
 ### Added

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -69,9 +69,6 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
     })
       .then((solanaClient) => {
         setClient(solanaClient);
-        return solanaClient.registerWallet();
-      })
-      .then(() => {
         setIsRegistered(true);
       })
       .catch((error) => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

- Auto-registers the MetaMask wallet with the wallet-standard registry during
   `createSolanaClient()`, removing the need for consumers to manually call
  `registerWallet()`
  - Adds `autoRegister` option (default `true`) for manual control and `walletName`
  option (default 'MetaMask') for customization
  - `registerWallet()` becomes a no-op when auto-registration is enabled to
  prevent duplicate registration

## References

Closes [WAPI-1091](https://consensyssoftware.atlassian.net/browse/WAPI-1091?atlOrigin=eyJpIjoiMzhhZTVmZDNlMGUxNDdiYmIxNjFlMTY3NTA4MGIzYjQiLCJwIjoiaiJ9)
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


[WAPI-1091]: https://consensyssoftware.atlassian.net/browse/WAPI-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ