### PR TITLE
revert solana connect registration name

### DIFF
--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -108,7 +108,7 @@ describe('createSolanaClient', () => {
 
       expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
         client: mockCore.provider,
-        walletName: 'MetaMask',
+        walletName: 'MetaMask Connect',
       });
     });
 
@@ -131,7 +131,7 @@ describe('createSolanaClient', () => {
 
         expect(getWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask',
+          walletName: 'MetaMask Connect',
         });
         expect(wallet).toBe(mockWallet);
       });
@@ -148,7 +148,7 @@ describe('createSolanaClient', () => {
 
         expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask',
+          walletName: 'MetaMask Connect',
         });
       });
 

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -70,7 +70,7 @@ export async function createSolanaClient(
 
   const client = core.provider;
 
-  const walletName = 'MetaMask';
+  const walletName = 'MetaMask Connect';
 
   if (!skipAutoRegister) {
     await registerSolanaWalletStandard({ client, walletName });


### PR DESCRIPTION
We're not quite ready to deal with name collision issue