### PR TITLE
fix(connect-multichain): clean up MWP session on connection rejection

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `beforeunload` event listener not being properly removed on disconnect due to `.bind()` creating different function references, causing a listener leak on each connect/disconnect cycle ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
 - Rename `StoreAdapterWeb.DB_NAME` from `mmsdk` to `mmconnect` to prevent IndexedDB collisions when the legacy MetaMask SDK and MM Connect run in the same browser context ([#177](https://github.com/MetaMask/connect-monorepo/pull/177))
+- Clean up stale MWP session from KVStore on connection rejection so subsequent QR code connection attempts are not blocked
 
 ## [0.5.3]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `beforeunload` event listener not being properly removed on disconnect due to `.bind()` creating different function references, causing a listener leak on each connect/disconnect cycle ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
 - Rename `StoreAdapterWeb.DB_NAME` from `mmsdk` to `mmconnect` to prevent IndexedDB collisions when the legacy MetaMask SDK and MM Connect run in the same browser context ([#177](https://github.com/MetaMask/connect-monorepo/pull/177))
-- Clean up stale MWP session from KVStore on connection rejection so subsequent QR code connection attempts are not blocked
+- Clean up stale MWP session from KVStore on connection rejection so subsequent QR code connection attempts are not blocked ([#180](https://github.com/MetaMask/connect-monorepo/pull/180))
 
 ## [0.5.3]
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -494,7 +494,10 @@ export class MWPTransport implements ExtendedTransport {
     });
 
     return connectionPromise
-      .catch((error) => {
+      .catch(async (error) => {
+        // Clean up the MWP session from the KVStore so stale sessions
+        // don't cause subsequent connect attempts to enter the resume path
+        await this.dappClient.disconnect()
         throw error;
       })
       .finally(() => {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -497,7 +497,7 @@ export class MWPTransport implements ExtendedTransport {
       .catch(async (error) => {
         // Clean up the MWP session from the KVStore so stale sessions
         // don't cause subsequent connect attempts to enter the resume path
-        await this.dappClient.disconnect()
+        await this.dappClient.disconnect();
         throw error;
       })
       .finally(() => {


### PR DESCRIPTION
## Summary

- Fix stale MWP session persisting in KVStore after user rejects a QR code connection in the wallet, which prevented subsequent connection attempts

## Problem

When connecting via QR code, the MWP handshake completes and stores a `session:{id}` entry in the KVStore **before** the wallet responds to `wallet_createSession`. If the user then rejects the connection in the wallet:

1. `rejectConnection()` is called in `initialConnectionMessageHandler`, but `dappClient.disconnect()` is never called
2. `dappClient.disconnect()` is the only method that calls `sessionstore.delete(session.id)` to remove the session from the KVStore
3. The stale session remains in storage indefinitely
4. On the next connection attempt, `getActiveSession()` finds this stale session and enters the `resume` branch — trying to resume a session the wallet already rejected
5. The resume either hangs or times out, blocking the user from connecting

## Fix

Call `dappClient.disconnect()` in `MWPTransport.connect()`'s catch handler so that any connection failure (rejection, timeout, etc.) properly cleans up the dappClient session from the KVStore. The `.catch(() => {})` on disconnect ensures cleanup errors don't mask the original connection error.

## Test plan

- [ ] Initiate a QR code connection from the dapp
- [ ] Scan the QR code with the MetaMask wallet
- [ ] Reject the connection in the wallet
- [ ] Verify the rejection error propagates to the dapp
- [ ] Initiate a new QR code connection — it should show a fresh QR code and not hang/timeout
- [ ] Accept the second connection and verify it completes successfully