### PR TITLE
fix: make sure react native playground renders multichain card ui after connection is established

### DIFF
--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Make sure Multichain UI card is rendered after Multichain connection established, which broke after merging in [Connect Multichain Singleton PR](https://github.com/MetaMask/connect-monorepo/pull/157) ([#181](https://github.com/MetaMask/connect-monorepo/pull/181))
+
 ## [0.1.1]
 
 ### Changed

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - Make sure Multichain UI card is rendered after Multichain connection established, which broke after merging in [Connect Multichain Singleton PR](https://github.com/MetaMask/connect-monorepo/pull/157) ([#181](https://github.com/MetaMask/connect-monorepo/pull/181))
 
 ## [0.1.1]

--- a/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -77,8 +77,8 @@ export const LegacyEVMSDKProvider = ({
             };
         const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 
-        // Type assertion needed because createEVMClient's type doesn't include mobile/transport
-        // but they are passed through to createMultichainClient at runtime
+        // Type assertion needed because createEVMClient's type doesn't include mobile
+        // but it is passed through to createMultichainClient at runtime
         const clientSDK = await createEVMClient({
           dapp: {
             name: 'playground',
@@ -94,11 +94,6 @@ export const LegacyEVMSDKProvider = ({
           },
           transport: {
             extensionId: METAMASK_PROD_CHROME_ID,
-            onNotification: (notification: unknown) => {
-              const payload = notification as Record<string, unknown>;
-              // Handle any necessary notifications here
-              console.debug('Legacy EVM notification:', payload);
-            },
           },
         } as any);
         const providerInstance = await clientSDK.getProvider();


### PR DESCRIPTION
## Explanation

This PR aligns the RN `SDKProvider` with the browser playground's event-emitter pattern to make sure the multichain ui card is render after connection, which was broken after merging https://github.com/MetaMask/connect-monorepo/pull/157.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1110

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
