### PR TITLE
fix: Fix JSON-RPC id generation

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `beforeunload` event listener not being properly removed on disconnect due to `.bind()` creating different function references, causing a listener leak on each connect/disconnect cycle ([#170](https://github.com/MetaMask/connect-monorepo/pull/170))
 - Rename `StoreAdapterWeb.DB_NAME` from `mmsdk` to `mmconnect` to prevent IndexedDB collisions when the legacy MetaMask SDK and MM Connect run in the same browser context ([#177](https://github.com/MetaMask/connect-monorepo/pull/177))
 - Clean up stale MWP session from KVStore on connection rejection so subsequent QR code connection attempts are not blocked ([#180](https://github.com/MetaMask/connect-monorepo/pull/180))
+- Fix bug with JSON-RPC requests where previously used `id` value could be re-used causing the wallet to ignore the request when a dapp was refreshed/reloaded. ([#183](https://github.com/MetaMask/connect-monorepo/pull/183))
 
 ## [0.5.3]
 

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -14,6 +14,7 @@ import type { ExtendedTransport, RPCAPI, Scope, SessionData } from 'src/domain';
 import {
   addValidAccounts,
   getOptionalScopes,
+  getUniqueRequestId,
   getValidAccounts,
   isSameScopesAndAccounts,
 } from '../../utils';
@@ -34,9 +35,6 @@ export class DefaultTransport implements ExtendedTransport {
   readonly #defaultRequestOptions = {
     timeout: DEFAULT_REQUEST_TIMEOUT,
   };
-
-  // Use timestamp-based ID to avoid conflicts across disconnect/reconnect cycles
-  #reqId = Date.now();
 
   readonly #pendingRequests = new Map<string, PendingRequest>();
 
@@ -148,8 +146,7 @@ export class DefaultTransport implements ExtendedTransport {
     this.#setupMessageListener();
 
     // Generate unique request ID - increment counter to ensure uniqueness
-    this.#reqId += 1;
-    const requestId = `${this.#reqId}`;
+    const requestId = String(getUniqueRequestId());
 
     // Create request with ID - MetaMask expects JSON-RPC format
     const request = {

--- a/packages/connect-multichain/src/multichain/transports/multichainApiClientWrapper/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/multichainApiClientWrapper/index.ts
@@ -15,21 +15,11 @@ import type { CaipAccountId } from '@metamask/utils';
 import type { InvokeMethodOptions, RPCAPI, Scope } from 'src/domain';
 import type { MetaMaskConnectMultichain } from 'src/multichain';
 
-// uint32 (two's complement) max
-// more conservative than Number.MAX_SAFE_INTEGER
-const MAX = 4_294_967_295;
-let idCounter = Math.floor(Math.random() * MAX);
-
-const getUniqueId = (): number => {
-  idCounter = (idCounter + 1) % MAX;
-  return idCounter;
-};
+import { getUniqueRequestId } from '../../utils';
 
 type TransportRequestWithId = TransportRequest & { id: number };
 
 export class MultichainApiClientWrapperTransport implements Transport {
-  #requestId = getUniqueId();
-
   readonly #notificationCallbacks = new Set<(data: unknown) => void>();
 
   notificationListener: (() => void) | undefined;
@@ -91,7 +81,7 @@ export class MultichainApiClientWrapperTransport implements Transport {
     params: ParamsType,
     _options: { timeout?: number } = {},
   ): Promise<ReturnType> {
-    const id = this.#requestId++;
+    const id = getUniqueRequestId();
     const requestPayload = {
       id,
       jsonrpc: '2.0',

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -40,6 +40,7 @@ import {
 import {
   addValidAccounts,
   getOptionalScopes,
+  getUniqueRequestId,
   getValidAccounts,
   isSameScopesAndAccounts,
 } from '../../utils';
@@ -80,8 +81,6 @@ const logger = createLogger('metamask-sdk:transport');
  * Bridges the MWP DappClient with the multichain API client Transport interface
  */
 export class MWPTransport implements ExtendedTransport {
-  private __reqId = 0;
-
   private __pendingRequests = new Map<string, PendingRequests>();
 
   private notificationCallbacks = new Set<(data: unknown) => void>();
@@ -383,7 +382,7 @@ export class MWPTransport implements ExtendedTransport {
   >(payload: TRequest, options?: { timeout?: number }): Promise<TResponse> {
     const request = {
       jsonrpc: '2.0',
-      id: `${this.__reqId++}`,
+      id: String(getUniqueRequestId()),
       ...payload,
     };
 
@@ -463,7 +462,7 @@ export class MWPTransport implements ExtendedTransport {
             };
             const request = {
               jsonrpc: '2.0',
-              id: `${this.__reqId++}`,
+              id: String(getUniqueRequestId()),
               method: 'wallet_createSession',
               params: sessionRequest,
             };
@@ -751,7 +750,7 @@ export class MWPTransport implements ExtendedTransport {
   >(payload: TRequest, options?: { timeout?: number }): Promise<TResponse> {
     const request = {
       jsonrpc: '2.0',
-      id: `${this.__reqId++}`,
+      id: String(getUniqueRequestId()),
       ...payload,
     };
 

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -399,3 +399,13 @@ export function addValidAccounts(
 
   return result;
 }
+
+// uint32 (two's complement) max
+// more conservative than Number.MAX_SAFE_INTEGER
+const MAX = 4_294_967_295;
+let idCounter = Math.floor(Math.random() * MAX);
+
+export const getUniqueRequestId = (): number => {
+  idCounter = (idCounter + 1) % MAX;
+  return idCounter;
+};


### PR DESCRIPTION
## Explanation

Fix bug with JSON-RPC requests where previously used `id` value could be re-used causing the wallet to ignore the request when a dapp was refreshed/reloaded
## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1120

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
