### PR TITLE
fix: Fix React Native Playground dapp url

### DIFF
--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix malformed reported dapp URL causing issues in the wallet ([#187](https://github.com/MetaMask/connect-monorepo/pull/187))
+
 ## [0.1.2]
 
 ### Changed

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - Fix malformed reported dapp URL causing issues in the wallet ([#187](https://github.com/MetaMask/connect-monorepo/pull/187))
 
 ## [0.1.2]

--- a/playground/react-native-playground/polyfills.ts
+++ b/playground/react-native-playground/polyfills.ts
@@ -27,14 +27,6 @@ if (typeof global !== 'undefined' && global.window) {
   windowObj = {};
 }
 
-// Ensure location object exists
-if (!windowObj.location) {
-  windowObj.location = {
-    hostname: 'react-native-playground',
-    href: 'react-native-playground://',
-  };
-}
-
 // Ensure addEventListener exists (even if window already exists, it might not have this method)
 if (typeof windowObj.addEventListener !== 'function') {
   windowObj.addEventListener = (event: string, listener: EventListener) => {

--- a/playground/react-native-playground/polyfills.ts
+++ b/playground/react-native-playground/polyfills.ts
@@ -27,6 +27,14 @@ if (typeof global !== 'undefined' && global.window) {
   windowObj = {};
 }
 
+// Ensure location object exists
+if (!windowObj.location) {
+  windowObj.location = {
+    hostname: 'react-native-playground',
+    href: 'https://playground.metamask.io',
+  };
+}
+
 // Ensure addEventListener exists (even if window already exists, it might not have this method)
 if (typeof windowObj.addEventListener !== 'function') {
   windowObj.addEventListener = (event: string, listener: EventListener) => {

--- a/playground/react-native-playground/src/wagmi/config.ts
+++ b/playground/react-native-playground/src/wagmi/config.ts
@@ -18,7 +18,7 @@ export const wagmiConfig = createConfig({
     metaMask({
       dapp: {
         name: 'react-native-playground',
-        url: 'https://playground.metamask.io', // verify if protocol is required
+        url: 'https://playground.metamask.io',
       },
       // React Native: use Linking.openURL for deeplinks instead of window.location.href
       mobile: {

--- a/playground/react-native-playground/src/wagmi/config.ts
+++ b/playground/react-native-playground/src/wagmi/config.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-globals -- React Native polyfills window */
-/* eslint-disable no-negated-condition -- Clearer pattern for undefined checks */
 /* eslint-disable import-x/no-unassigned-import -- Polyfill import */
 
 // Ensure polyfills are loaded first (especially window.addEventListener)

--- a/playground/react-native-playground/src/wagmi/config.ts
+++ b/playground/react-native-playground/src/wagmi/config.ts
@@ -15,8 +15,8 @@ export const wagmiConfig = createConfig({
   connectors: [
     metaMask({
       dapp: {
-        name: 'react-native-playground',
-        url: 'https://playground.metamask.io',
+        name: window.location.hostname,
+        url: window.location.href,
       },
       // React Native: use Linking.openURL for deeplinks instead of window.location.href
       mobile: {

--- a/playground/react-native-playground/src/wagmi/config.ts
+++ b/playground/react-native-playground/src/wagmi/config.ts
@@ -15,7 +15,9 @@ export const wagmiConfig = createConfig({
   connectors: [
     metaMask({
       dapp: {
+        // eslint-disable-next-line no-restricted-globals
         name: window.location.hostname,
+        // eslint-disable-next-line no-restricted-globals
         url: window.location.href,
       },
       // React Native: use Linking.openURL for deeplinks instead of window.location.href

--- a/playground/react-native-playground/src/wagmi/config.ts
+++ b/playground/react-native-playground/src/wagmi/config.ts
@@ -12,24 +12,13 @@ import { mainnet, sepolia, optimism, celo } from 'wagmi/chains';
 // Auto-generated file with @ts-nocheck - types are ignored
 import { metaMask } from './metamask-connector';
 
-// Use window polyfill for React Native
-// The polyfill is set up in polyfills.ts
-const windowHostname =
-  typeof window !== 'undefined'
-    ? window.location.hostname
-    : 'react-native-playground';
-const windowHref =
-  typeof window !== 'undefined'
-    ? window.location.href
-    : 'react-native-playground://';
-
 export const wagmiConfig = createConfig({
   chains: [mainnet, sepolia, optimism, celo],
   connectors: [
     metaMask({
       dapp: {
-        name: windowHostname,
-        url: windowHref,
+        name: 'react-native-playground',
+        url: 'https://playground.metamask.io', // verify if protocol is required
       },
       // React Native: use Linking.openURL for deeplinks instead of window.location.href
       mobile: {


### PR DESCRIPTION
## Explanation

Fixes an issue where the react native playground was unable to get Solana signMessage prompts to appear on the wallet. This was caused by an value being used for the dapp url param which fails `new URL()` on the wallet side. This is fixed by using a better url value. 

Separately, we need to investigate how we should implement better handling for malformed dapp urls.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
