### PR TITLE
chore: pin eciesjs to exact version 0.4.17

### DIFF
--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -82,7 +82,7 @@
     "bowser": "^2.11.0",
     "buffer": "^6.0.3",
     "cross-fetch": "^4.1.0",
-    "eciesjs": "^0.4.15",
+    "eciesjs": "0.4.17",
     "eventemitter3": "^5.0.1",
     "pako": "^2.1.0",
     "uuid": "^11.1.0",

--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -56,7 +56,7 @@
     "@tanstack/react-query-persist-client": "5.0.5",
     "@wagmi/core": "^2.22.1",
     "buffer": "^6.0.3",
-    "eciesjs": "^0.4.15",
+    "eciesjs": "0.4.17",
     "expo": "^54.0.0",
     "expo-camera": "~17.0.8",
     "expo-constants": "~18.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2036,6 +2036,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ecies/ciphers@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@ecies/ciphers@npm:0.2.5"
+  peerDependencies:
+    "@noble/ciphers": ^1.0.0
+  checksum: 10/af90636ee51812c9ead6e2c4be006f334bd6e12c5840de9c673b974b1ff3f79776747059257da3cb1731fcbc2d435a67b86dfb18fa90e07a6962c8816e6ab596
+  languageName: node
+  linkType: hard
+
 "@egjs/hammerjs@npm:^2.0.17":
   version: 2.0.17
   resolution: "@egjs/hammerjs@npm:2.0.17"
@@ -4169,7 +4178,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     cross-fetch: "npm:^4.1.0"
     deepmerge: "npm:^4.2.2"
-    eciesjs: "npm:^0.4.15"
+    eciesjs: "npm:0.4.17"
     esbuild-plugin-umd-wrapper: "npm:^3.0.0"
     eventemitter3: "npm:^5.0.1"
     fake-indexeddb: "npm:^6.0.1"
@@ -4745,7 +4754,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     cross-env: "npm:^10.1.0"
     dotenv: "npm:^17.2.3"
-    eciesjs: "npm:^0.4.15"
+    eciesjs: "npm:0.4.17"
     eslint: "npm:^9.25.0"
     eslint-config-expo: "npm:~10.0.0"
     expo: "npm:^54.0.0"
@@ -14164,7 +14173,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eciesjs@npm:^0.4.11, eciesjs@npm:^0.4.15":
+"eciesjs@npm:0.4.17":
+  version: 0.4.17
+  resolution: "eciesjs@npm:0.4.17"
+  dependencies:
+    "@ecies/ciphers": "npm:^0.2.5"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/curves": "npm:^1.9.7"
+    "@noble/hashes": "npm:^1.8.0"
+  checksum: 10/89e3db5d916e9b4badb516f0a89514300ce7bbc4e1a8a0b8f1e0ef4ac1d88c5aef622a65cb277b6a020e423c3b04f981398eeb349d5bd7e3e42a35132e871e7f
+  languageName: node
+  linkType: hard
+
+"eciesjs@npm:^0.4.11":
   version: 0.4.16
   resolution: "eciesjs@npm:0.4.16"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,15 +2027,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ecies/ciphers@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "@ecies/ciphers@npm:0.2.4"
-  peerDependencies:
-    "@noble/ciphers": ^1.0.0
-  checksum: 10/6300075ffce01765ad0ddcc26ed6150301cd448bc79b7a046cbd659c4bd6e3a05f207df2a09396cdf529bcc6ab921b26cb50483703c57f80f2d8898c369284f3
-  languageName: node
-  linkType: hard
-
 "@ecies/ciphers@npm:^0.2.5":
   version: 0.2.5
   resolution: "@ecies/ciphers@npm:0.2.5"
@@ -14173,7 +14164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eciesjs@npm:0.4.17":
+"eciesjs@npm:0.4.17, eciesjs@npm:^0.4.11":
   version: 0.4.17
   resolution: "eciesjs@npm:0.4.17"
   dependencies:
@@ -14182,18 +14173,6 @@ __metadata:
     "@noble/curves": "npm:^1.9.7"
     "@noble/hashes": "npm:^1.8.0"
   checksum: 10/89e3db5d916e9b4badb516f0a89514300ce7bbc4e1a8a0b8f1e0ef4ac1d88c5aef622a65cb277b6a020e423c3b04f981398eeb349d5bd7e3e42a35132e871e7f
-  languageName: node
-  linkType: hard
-
-"eciesjs@npm:^0.4.11":
-  version: 0.4.16
-  resolution: "eciesjs@npm:0.4.16"
-  dependencies:
-    "@ecies/ciphers": "npm:^0.2.4"
-    "@noble/ciphers": "npm:^1.3.0"
-    "@noble/curves": "npm:^1.9.7"
-    "@noble/hashes": "npm:^1.8.0"
-  checksum: 10/0b179dc8ad470b976edb1c7f59770c934a36854d22ccab979fea32ae559f017d843c468f8a551523877251e7340df1babef0777acebcf6518341337d8ed7bb94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Pin eciesjs from `^0.4.15` (resolved 0.4.16) to exact `0.4.17` in `connect-multichain` and `react-native-playground`.

No source code changes needed - `KeyManager.ts` already uses the 0.4.x API (`.toBytes(true)`, `Buffer.from(decryptedBuffer).toString('utf8')`).


https://github.com/user-attachments/assets/8b6c76d6-46c5-416b-a559-4c559e36213c



## Why

Cross-repo eciesjs version alignment effort. All three repos that share the ECIES encryption channel (metamask-mobile, connect-monorepo, mobile-wallet-protocol) should use the identical eciesjs version to eliminate any possibility of version-related surprises.

Companion PRs:
- metamask-mobile: upgrading from 0.3.x to exact 0.4.17
- mobile-wallet-protocol: pinning from ^0.4.15 to exact 0.4.17

## Changes

- `packages/connect-multichain/package.json`: `"^0.4.15"` -> `"0.4.17"`
- `playground/react-native-playground/package.json`: `"^0.4.15"` -> `"0.4.17"`

## Test plan

- [ ] `yarn workspace @metamask/connect-multichain test:unit` passes (185 tests)
- [ ] TypeScript compilation clean
- [ ] No source code changes needed