### PR TITLE
fix: uncaught exception when rejecting solana requests due to invalid provider error code range

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix uncaught exception in `parseWalletError` when the wallet returns error codes outside the EIP-1193 provider range (1000–4999), such as standard JSON-RPC codes like `-32603` (Internal error). This prevented Solana request rejections from being handled gracefully. ([#189](https://github.com/MetaMask/connect-monorepo/pull/189))
+
 ## [0.6.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -25,7 +25,7 @@ import {
   type TransportResponse,
   TransportTimeoutError,
 } from '@metamask/multichain-api-client';
-import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
+import { JsonRpcError, providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { CaipAccountId } from '@metamask/utils';
 
 import {
@@ -192,10 +192,13 @@ export class MWPTransport implements ExtendedTransport {
       typeof errorData.code === 'number' &&
       typeof errorData.message === 'string'
     ) {
-      return providerErrors.custom({
-        code: errorData.code,
-        message: errorData.message,
-      });
+      const { code, message } = errorData;
+
+      if (code >= 1000 && code <= 4999) {
+        return providerErrors.custom({ code, message });
+      }
+
+      return new JsonRpcError(code, message);
     }
 
     const message =


### PR DESCRIPTION
## Explanation

This PR fixes `parseWalletError` in the MWP transport to gracefully handle error codes outside the EIP-1193 provider range (1000–4999), preventing uncaught exceptions when the wallet returns standard JSON-RPC error codes (e.g. `-32603`).
- Adds unit test coverage for `parseWalletError` with JSON-RPC error codes, arbitrary codes, and EIP-1193 provider codes.

### Problem

When a Solana request (e.g. `signMessage`) is rejected by the wallet, the error payload contains a standard JSON-RPC error code like `-32603` (Internal error). The `parseWalletError` method passed this code directly to `providerErrors.custom()`, which enforces a strict code range of `1000 <= code <= 4999`. This caused `providerErrors.custom()` to throw:

```
"code" must be an integer such that: 1000 <= code <= 4999
```

This resulted in an uncaught exception instead of a clean promise rejection, breaking error handling for Solana (and potentially other) requests.

### Solution

Updated `parseWalletError` to check the error code range before selecting the appropriate error constructor:

| Code range | Constructor used | Examples |
|---|---|---|
| `1000–4999` (EIP-1193 provider) | `providerErrors.custom()` | `4001` (User Rejected), `4100` (Unauthorized) |
| Any other integer | `new JsonRpcError()` | `-32603` (Internal error), `-32602` (Invalid params) |
| Malformed (missing code/message) | `rpcErrors.internal()` | Non-standard error payloads |

`JsonRpcError` from `@metamask/rpc-errors` accepts any integer code without range restriction, preserving the original error code and message from the wallet.

### Test plan

- [x] Existing test: EIP-1193 provider code `4001` (User rejected) is handled correctly
- [x] Existing test: EIP-1193 provider code `4100` (Unauthorized) preserves the custom code
- [x] Existing test: Malformed error (missing message) falls back to internal error
- [x] Existing test: Success messages resolve correctly
- [x] New test: JSON-RPC code `-32603` (Internal error) no longer throws, returns proper rejection with preserved code
- [x] New test: JSON-RPC code `-32602` (Invalid params) is handled gracefully
- [x] New test: Arbitrary code `500` outside both ranges is handled gracefully


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1109

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
