### PR TITLE
fix: normalize ReactNative URLS

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Normalize non-http(s) dapp URLs to valid https URLs on React Native to prevent RPC middleware crashes ([#190](https://github.com/MetaMask/connect-monorepo/pull/190))
 - **BREAKING** `createMultichainClient()` now returns a singleton. Any incoming constructor params on subsequent calls to `createMultichainClient()` will be applied to the existing singleton instance except for the `dapp`, `storage`, and `ui.factory` param options. ([#157](https://github.com/MetaMask/connect-monorepo/pull/157))
 - **BREAKING** `ConnectMultichain.openDeeplinkIfNeeded()` is renamed to `openSimpleDeeplinkIfNeeded()` ([#176](https://github.com/MetaMask/connect-monorepo/pull/176))
 - `ConnectMultichain.connect()` now throws an `'Existing connection is pending. Please check your MetaMask Mobile app to continue.'` error if there is already an pending connection attempt. Previously it would abort that ongoing connection in favor of a new one. ([#157](https://github.com/MetaMask/connect-monorepo/pull/157))

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -28,6 +28,8 @@ export type { SessionData } from '@metamask/multichain-api-client';
 export type DappSettings = {
   name: string;
   url?: string;
+  /** The original non-http(s) URL before normalization on React Native platforms */
+  nativeScheme?: string;
 } & ({ iconUrl?: string } | { base64Icon?: string });
 
 export type ConnectionRequest = {

--- a/packages/connect-multichain/src/multichain/utils/index.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.test.ts
@@ -263,6 +263,92 @@ t.describe('Utils', () => {
         );
       },
     );
+
+    t.it(
+      'should normalize non-http URL to https on ReactNative platform',
+      () => {
+        const mockGetPlatformType = t.vi.mocked(getPlatformType);
+        mockGetPlatformType.mockReturnValue(PlatformType.ReactNative);
+        options.dapp.url = 'react-native-playground://';
+        options.dapp.name = 'playground';
+
+        const result = utils.setupDappMetadata(options);
+
+        t.expect(result.dapp.url).toBe(
+          'https://react-native-playground.rn.dapp.local',
+        );
+        t.expect(result.dapp.nativeScheme).toBe('react-native-playground://');
+      },
+    );
+
+    t.it(
+      'should normalize custom scheme URL with path on ReactNative platform',
+      () => {
+        const mockGetPlatformType = t.vi.mocked(getPlatformType);
+        mockGetPlatformType.mockReturnValue(PlatformType.ReactNative);
+        options.dapp.url = 'myapp://path';
+        options.dapp.name = 'myapp';
+
+        const result = utils.setupDappMetadata(options);
+
+        t.expect(result.dapp.url).toBe('https://myapp.rn.dapp.local');
+        t.expect(result.dapp.nativeScheme).toBe('myapp://path');
+      },
+    );
+
+    t.it(
+      'should sanitize scheme with dots and uppercase on ReactNative platform',
+      () => {
+        const mockGetPlatformType = t.vi.mocked(getPlatformType);
+        mockGetPlatformType.mockReturnValue(PlatformType.ReactNative);
+        options.dapp.url = 'My.App://';
+        options.dapp.name = 'myapp';
+
+        const result = utils.setupDappMetadata(options);
+
+        t.expect(result.dapp.url).toBe('https://my-app.rn.dapp.local');
+        t.expect(result.dapp.nativeScheme).toBe('My.App://');
+      },
+    );
+
+    t.it(
+      'should use "unknown" subdomain when scheme sanitizes to empty string on ReactNative platform',
+      () => {
+        const mockGetPlatformType = t.vi.mocked(getPlatformType);
+        mockGetPlatformType.mockReturnValue(PlatformType.ReactNative);
+        options.dapp.url = '://';
+        options.dapp.name = 'test';
+
+        const result = utils.setupDappMetadata(options);
+
+        t.expect(result.dapp.url).toBe('https://unknown.rn.dapp.local');
+        t.expect(result.dapp.nativeScheme).toBe('://');
+      },
+    );
+
+    t.it('should not normalize http(s) URLs on ReactNative platform', () => {
+      const mockGetPlatformType = t.vi.mocked(getPlatformType);
+      mockGetPlatformType.mockReturnValue(PlatformType.ReactNative);
+      options.dapp.url = 'https://example.com';
+      options.dapp.name = 'test';
+
+      const result = utils.setupDappMetadata(options);
+
+      t.expect(result.dapp.url).toBe('https://example.com');
+      t.expect(result.dapp.nativeScheme).toBeUndefined();
+    });
+
+    t.it('should not normalize URLs on non-ReactNative platforms', () => {
+      const mockGetPlatformType = t.vi.mocked(getPlatformType);
+      mockGetPlatformType.mockReturnValue(PlatformType.NonBrowser);
+      options.dapp.url = 'custom-scheme://';
+      options.dapp.name = 'test';
+
+      const result = utils.setupDappMetadata(options);
+
+      t.expect(result.dapp.url).toBe('custom-scheme://');
+      t.expect(result.dapp.nativeScheme).toBeUndefined();
+    });
   });
 
   t.describe('isSameScopesAndAccounts', () => {

--- a/packages/connect-multichain/src/multichain/utils/index.ts
+++ b/packages/connect-multichain/src/multichain/utils/index.ts
@@ -222,7 +222,7 @@ function normalizeNativeUrl(
 
   // Captures the scheme before "://" — e.g. "myapp" from "myapp://path"
   const schemeMatch = url.match(/^([^:]*):\/\//u);
-  const rawScheme = schemeMatch?.[1] ?? '';
+  const rawScheme = schemeMatch?.[1] ?? url;
   const sanitized = rawScheme
     .toLowerCase()
     // Replace non-DNS chars with hyphens — e.g. "My.App" -> "my-app"


### PR DESCRIPTION
## Explanation
- React Native apps can provide custom-scheme URLs (e.g. `react-native-playground://`) as `dapp.url`, which breaks downstream wallet RPC middleware that calls `new URL()` expecting http(s) schemes
- Adds `normalizeNativeUrl()` helper in `setupDappMetadata()` that converts non-http(s) URLs to `https://<sanitized-scheme>.rn.dapp.local` on RN platforms
- Preserves the original URL in a new `nativeScheme` field on `DappSettings`

## Testing

### Unit tests
```bash
cd packages/connect-multichain && yarn vitest run src/multichain/utils/index.test.ts
```

### Manual (React Native playground)
1. `cd playground/react-native-playground && cp .env.example .env` (add Infura key)
2. `yarn ios` or `yarn android`
3. Use the **Wagmi tab** to connect — it passes `react-native-playground://` as `dapp.url`
4. Verify console log: `Normalizing dapp URL for React Native: "react-native-playground://" -> "https://react-native-playground.rn.dapp.local"`
5. Connection should succeed without RPC middleware crash

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes [WAPI-1134](https://consensyssoftware.atlassian.net/browse/WAPI-1134)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


[WAPI-1134]: https://consensyssoftware.atlassian.net/browse/WAPI-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ