### PR TITLE
fix: explicitly disconnect only Solana scopes

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Explicitly disconnect Solana scopes ([#193](https://github.com/MetaMask/connect-monorepo/pull/193))
+- Explicitly disconnect only Solana scopes when calling `SolanaClient.disconnect()`. Previously calling this function would result in the wallet connection being terminated entirely even if other ecosystems (evm, bitcoin, etc) were still connected  ([#193](https://github.com/MetaMask/connect-monorepo/pull/193))
 
 ## [0.2.0]
 

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Explicitly disconnect only Solana scopes when calling `SolanaClient.disconnect()`. Previously calling this function would result in the wallet connection being terminated entirely even if other ecosystems (evm, bitcoin, etc) were still connected  ([#193](https://github.com/MetaMask/connect-monorepo/pull/193))
+- Explicitly disconnect only Solana scopes when calling `SolanaClient.disconnect()`. Previously calling this function would result in the wallet connection being terminated entirely even if other ecosystems (evm, bitcoin, etc) were still connected ([#193](https://github.com/MetaMask/connect-monorepo/pull/193))
 
 ## [0.2.0]
 

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Explicitly disconnect Solana scopes ([#193](https://github.com/MetaMask/connect-monorepo/pull/193))
+
 ## [0.2.0]
 
 ### Added

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -163,12 +163,16 @@ describe('createSolanaClient', () => {
     });
 
     describe('disconnect', () => {
-      it('should disconnect using core.disconnect', async () => {
+      it('should disconnect only Solana scopes', async () => {
         const client = await createSolanaClient(mockOptions);
 
         await client.disconnect();
 
-        expect(mockCore.disconnect).toHaveBeenCalled();
+        expect(mockCore.disconnect).toHaveBeenCalledWith([
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+          'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z',
+        ]);
       });
     });
   });

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -1,10 +1,13 @@
-import { createMultichainClient } from '@metamask/connect-multichain';
+import {
+  createMultichainClient,
+  type Scope,
+} from '@metamask/connect-multichain';
 import {
   getWalletStandard,
   registerSolanaWalletStandard,
 } from '@metamask/solana-wallet-standard';
 
-import { convertNetworksToCAIP } from './networks';
+import { convertNetworksToCAIP, SOLANA_CAIP_IDS } from './networks';
 import type {
   SolanaClient,
   SolanaConnectOptions,
@@ -85,6 +88,7 @@ export async function createSolanaClient(
       }
       await registerSolanaWalletStandard({ client, walletName });
     },
-    disconnect: async () => await core.disconnect(),
+    disconnect: async () =>
+      await core.disconnect(Object.values(SOLANA_CAIP_IDS) as Scope[]),
   };
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Specify Solana scopes when calling `core.disconnect` from `connect-solana` package to avoid disconnecting all packages. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

[Relevant slack thread](https://consensys.slack.com/archives/C0A0FA061UY/p1772467852876579?thread_ts=1772454971.015589&cid=C0A0FA061UY)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
