### PR TITLE
feat: passive wallet_sessionChanged listening for extension

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enable `ConnectMultichain` to handle `wallet_sessionChanged` events when MetaMask extension is detected and `preferExtension: true` without needing the user to explicitly connect via `ConnectMultichain.connect()` ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
+- Enable `ConnectMultichain` to automatically handle `wallet_sessionChanged` events when MetaMask extension is detected (Desktop Chrome/Firefox, or Mobile In-App Browser) and `preferExtension: true` without needing the user to explicitly connect via `ConnectMultichain.connect()` ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
 
 ### Changed
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix uncaught exception in `parseWalletError` when the wallet returns error codes outside the EIP-1193 provider range (1000–4999), such as standard JSON-RPC codes like `-32603` (Internal error). This prevented Solana request rejections from being handled gracefully. ([#189](https://github.com/MetaMask/connect-monorepo/pull/189))
 
+### Added
+
+- Enable `ConnectMultichain` to handle `wallet_sessionChanged` events when MetaMask extension is detected and `preferExtension: true` without needing the user to explicitly connect via `ConnectMultichain.connect()` ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
+
 ## [0.6.0]
 
 ### Added

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable `ConnectMultichain` to handle `wallet_sessionChanged` events when MetaMask extension is detected and `preferExtension: true` without needing the user to explicitly connect via `ConnectMultichain.connect()` ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
+
 ### Changed
 
 - Redact logs ([#191](https://github.com/MetaMask/connect-monorepo/pull/191]))
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix uncaught exception in `parseWalletError` when the wallet returns error codes outside the EIP-1193 provider range (1000–4999), such as standard JSON-RPC codes like `-32603` (Internal error). This prevented Solana request rejections from being handled gracefully. ([#189](https://github.com/MetaMask/connect-monorepo/pull/189))
-
-### Added
-
-- Enable `ConnectMultichain` to handle `wallet_sessionChanged` events when MetaMask extension is detected and `preferExtension: true` without needing the user to explicitly connect via `ConnectMultichain.connect()` ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
 
 ## [0.6.0]
 

--- a/packages/connect-multichain/src/connect.test.ts
+++ b/packages/connect-multichain/src/connect.test.ts
@@ -170,7 +170,12 @@ function testSuite<T extends MultichainOptions>({
       t.expect(sdk.status).toBe('loaded');
       // Provider is always available via wrapper transport (handles connection state internally)
       t.expect(sdk.provider).toBeDefined();
-      t.expect(() => sdk.transport).toThrow();
+      if (platform === 'web') {
+        // Web with extension sets up a DefaultTransport for passive listening
+        t.expect(sdk.transport).toBeDefined();
+      } else {
+        t.expect(() => sdk.transport).toThrow();
+      }
 
       // Expect sdk.connect to reject if transport cannot connect
       // Add timeout wrapper for web-mobile platform to prevent hanging
@@ -250,7 +255,7 @@ function testSuite<T extends MultichainOptions>({
 
         // Empty initial session
         mockedData.mockWalletGetSession.mockImplementation(
-          async () => undefined as any,
+          async () => ({sessionScopes: {}}),
         );
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
@@ -264,7 +269,11 @@ function testSuite<T extends MultichainOptions>({
         t.expect(sdk.status).toBe('loaded');
         // Provider is always available via wrapper transport (handles connection state internally)
         t.expect(sdk.provider).toBeDefined();
-        t.expect(() => sdk.transport).toThrow();
+        if (platform === 'web') {
+          t.expect(sdk.transport).toBeDefined();
+        } else {
+          t.expect(() => sdk.transport).toThrow();
+        }
 
         await sdk.connect(scopes, caipAccountIds);
 
@@ -294,7 +303,7 @@ function testSuite<T extends MultichainOptions>({
           async () => mockSessionRequestData,
         );
         mockedData.mockWalletGetSession.mockImplementation(
-          async () => undefined as any,
+          async () => ({sessionScopes: {}}),
         );
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
@@ -371,7 +380,7 @@ function testSuite<T extends MultichainOptions>({
           async () => mockSessionRequestData,
         );
         mockedData.mockWalletGetSession.mockImplementation(
-          async () => undefined as any,
+          async () => ({sessionScopes: {}}),
         );
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
@@ -381,7 +390,11 @@ function testSuite<T extends MultichainOptions>({
         unloadSpy = t.vi.spyOn((sdk as any).options.ui.factory, 'unload');
 
         t.expect(sdk.status).toBe('loaded');
-        t.expect(() => sdk.transport).toThrow();
+        if (platform === 'web') {
+          t.expect(sdk.transport).toBeDefined();
+        } else {
+          t.expect(() => sdk.transport).toThrow();
+        }
 
         if (platform !== 'web' && platform !== 'web-mobile') {
           showModalPromise = waitForInstallModal(sdk).catch(() => {
@@ -440,7 +453,7 @@ function testSuite<T extends MultichainOptions>({
       ] as any;
 
       mockedData.mockWalletGetSession.mockImplementation(
-        async () => undefined as any,
+        async () => ({sessionScopes: {}}),
       );
       mockedData.mockSessionRequest.mockImplementation(
         async () => mockSessionRequestData,
@@ -450,7 +463,11 @@ function testSuite<T extends MultichainOptions>({
       sdk = await createSDK(testOptions);
 
       t.expect(sdk.status).toBe('loaded');
-      t.expect(() => sdk.transport).toThrow();
+      if (platform === 'web') {
+        t.expect(sdk.transport).toBeDefined();
+      } else {
+        t.expect(() => sdk.transport).toThrow();
+      }
 
       // Add timeout wrapper for web-mobile platform to prevent hanging
       let timeoutId: NodeJS.Timeout;
@@ -522,19 +539,14 @@ function testSuite<T extends MultichainOptions>({
       );
 
       sdk = await createSDK(testOptions);
-
-      if (platform === 'web') {
-        mockedData.mockWalletRevokeSession.mockImplementation(async () => {
-          mockedData.mockWalletGetSession.mockResolvedValue({
-            sessionScopes: {},
-          });
-        });
-      }
-
       await sdk.disconnect();
 
       if (platform === 'web') {
-        t.expect(mockedData.mockDefaultTransport.disconnect).toHaveBeenCalled();
+        // DefaultTransport.disconnect() sends wallet_revokeSession via the inner transport's request()
+        t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
+          t.expect.objectContaining({ method: 'wallet_revokeSession' }),
+          t.expect.anything(),
+        );
       } else {
         t.expect(mockedData.mockDappClient.disconnect).toHaveBeenCalled();
       }
@@ -556,11 +568,7 @@ function testSuite<T extends MultichainOptions>({
       mockedData.mockWalletCreateSession.mockResolvedValue(mockSessionData);
       mockedData.mockWalletRevokeSession.mockResolvedValue(undefined);
 
-      if (platform === 'web') {
-        mockedData.mockDefaultTransport.disconnect.mockRejectedValue(
-          disconnectError,
-        );
-      } else {
+      if (platform !== 'web') {
         mockedData.mockDappClient.disconnect.mockRejectedValue(disconnectError);
       }
 
@@ -571,11 +579,9 @@ function testSuite<T extends MultichainOptions>({
       t.expect(sdk.transport).toBeDefined();
 
       if (platform === 'web') {
-        mockedData.mockWalletRevokeSession.mockImplementation(async () => {
-          mockedData.mockWalletGetSession.mockResolvedValue({
-            sessionScopes: {},
-          });
-        });
+        // DefaultTransport.disconnect() sends wallet_revokeSession via the inner transport's request(),
+        // so we mock the RPC handler to reject
+        mockedData.mockWalletRevokeSession.mockRejectedValue(disconnectError);
       }
 
       await t

--- a/packages/connect-multichain/src/connect.test.ts
+++ b/packages/connect-multichain/src/connect.test.ts
@@ -254,9 +254,9 @@ function testSuite<T extends MultichainOptions>({
         ] as any;
 
         // Empty initial session
-        mockedData.mockWalletGetSession.mockImplementation(
-          async () => ({sessionScopes: {}}),
-        );
+        mockedData.mockWalletGetSession.mockImplementation(async () => ({
+          sessionScopes: {},
+        }));
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
         );
@@ -302,9 +302,9 @@ function testSuite<T extends MultichainOptions>({
         mockedData.mockSessionRequest.mockImplementation(
           async () => mockSessionRequestData,
         );
-        mockedData.mockWalletGetSession.mockImplementation(
-          async () => ({sessionScopes: {}}),
-        );
+        mockedData.mockWalletGetSession.mockImplementation(async () => ({
+          sessionScopes: {},
+        }));
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
         );
@@ -379,9 +379,9 @@ function testSuite<T extends MultichainOptions>({
         mockedData.mockSessionRequest.mockImplementation(
           async () => mockSessionRequestData,
         );
-        mockedData.mockWalletGetSession.mockImplementation(
-          async () => ({sessionScopes: {}}),
-        );
+        mockedData.mockWalletGetSession.mockImplementation(async () => ({
+          sessionScopes: {},
+        }));
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
         );
@@ -452,9 +452,9 @@ function testSuite<T extends MultichainOptions>({
         'eip155:1:0x1234567890abcdef1234567890abcdef12345678',
       ] as any;
 
-      mockedData.mockWalletGetSession.mockImplementation(
-        async () => ({sessionScopes: {}}),
-      );
+      mockedData.mockWalletGetSession.mockImplementation(async () => ({
+        sessionScopes: {},
+      }));
       mockedData.mockSessionRequest.mockImplementation(
         async () => mockSessionRequestData,
       );

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -117,6 +117,8 @@ export type CreateMultichainFN = (
 ) => Promise<MultichainCore>;
 
 export type ExtendedTransport = Omit<Transport, 'connect'> & {
+  init: () => Promise<void>;
+
   connect: (props?: {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -147,7 +147,7 @@ function testSuite<T extends MultichainOptions>({
         } else {
           t.expect(() => sdk.transport).toThrow();
         }
-      }
+      },
     );
 
     t.it(

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -141,8 +141,13 @@ function testSuite<T extends MultichainOptions>({
       async () => {
         sdk = await createSDK(testOptions);
         t.expect(sdk.status).toBe('loaded');
-        t.expect(() => sdk.transport).toThrow();
-      },
+        if (platform === 'web') {
+          // Web with extension sets up a DefaultTransport for passive listening
+          t.expect(sdk.transport).toBeDefined();
+        } else {
+          t.expect(() => sdk.transport).toThrow();
+        }
+      }
     );
 
     t.it(

--- a/packages/connect-multichain/src/invoke.test.ts
+++ b/packages/connect-multichain/src/invoke.test.ts
@@ -160,7 +160,7 @@ function testSuite<T extends MultichainOptions>({
           async () => mockSessionRequestData,
         );
         mockedData.mockWalletGetSession.mockImplementation(
-          async () => undefined as any,
+          async () => ({sessionScopes: {}}),
         );
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
@@ -178,7 +178,12 @@ function testSuite<T extends MultichainOptions>({
         t.expect(sdk.status).toBe('loaded');
         // Provider is always available via wrapper transport (handles connection state internally)
         t.expect(sdk.provider).toBeDefined();
-        t.expect(() => sdk.transport).toThrow();
+        if (platform === 'web') {
+          // Web with extension sets up a DefaultTransport for passive listening
+          t.expect(sdk.transport).toBeDefined();
+        } else {
+          t.expect(() => sdk.transport).toThrow();
+        }
 
         await sdk.connect(scopes, caipAccountIds);
 

--- a/packages/connect-multichain/src/invoke.test.ts
+++ b/packages/connect-multichain/src/invoke.test.ts
@@ -159,9 +159,9 @@ function testSuite<T extends MultichainOptions>({
         mockedData.mockSessionRequest.mockImplementation(
           async () => mockSessionRequestData,
         );
-        mockedData.mockWalletGetSession.mockImplementation(
-          async () => ({sessionScopes: {}}),
-        );
+        mockedData.mockWalletGetSession.mockImplementation(async () => ({
+          sessionScopes: {},
+        }));
         mockedData.mockWalletCreateSession.mockImplementation(
           async () => mockSessionData,
         );

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -258,7 +258,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (transportType) {
       if (transportType === TransportType.Browser) {
         if (hasExtensionInstalled) {
-          // Why does this not use setupDefaultTransport?..
           const apiTransport = new DefaultTransport();
           this.#transport = apiTransport;
           this.#providerTransportWrapper.setupTransportNotificationListener();
@@ -268,7 +267,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           return apiTransport;
         }
       } else if (transportType === TransportType.MWP) {
-        // Why does this not use setupMWP?..
         const { adapter: kvstore } = this.options.storage;
         const dappClient = await this.#createDappClient();
         const apiTransport = new MWPTransport(dappClient, kvstore);
@@ -281,7 +279,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         return apiTransport;
       }
 
-      await this.storage.removeTransport(); // why do we remove the transport here?..
+      await this.storage.removeTransport();
     }
 
     return undefined;
@@ -295,7 +293,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.transport.connect();
       }
       this.status = 'connected';
-      // Why do do we this?..
       if (this.transport instanceof MWPTransport) {
         await this.storage.setTransport(TransportType.MWP);
       } else {
@@ -307,7 +304,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       if (hasExtensionInstalled && preferExtension) {
         await this.#setupDefaultTransport();
         // We don't actually want getStoredTransport to return this transport
-        // since we aren't connecting to it
+        // since we aren't connecting it to the wallet with a CAIP session, only
+        // listening for wallet_sessionChanged events.
         await this.storage.removeTransport();
         // Normally calling DefaultTransport.connect() ensures that the transport is initialized
         // and that wallet_sessionChanged (faked) is emitted. But because we are not

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -313,7 +313,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         // and that wallet_sessionChanged (faked) is emitted. But because we are not
         // calling transport.connect(), we need to initialize DefaultTransport manually.
         await this.transport.init();
-        await this.emitSessionChanged();
       }
       this.status = 'loaded';
     }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -96,6 +96,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   set status(value: ConnectionStatus) {
+    if (this._status === value) {
+      return;
+    }
     this._status = value;
     this.options.transport?.onNotification?.({
       method: 'stateChanged',
@@ -243,6 +246,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         const sessionScopes =
           (payload.params as SessionData | undefined)?.sessionScopes ?? {};
         const hasScopes = Object.keys(sessionScopes).length > 0;
+        // We don't want to set the status to disconnected if this is the first wallet_sessionChanged event
+        // triggered during #setupTransport() initialization for passive extension wallet_sessionChanged listening.
+        if (this.status === 'pending' && !hasScopes) {
+          this.status = 'loaded';
+          return;
+        }
         this.status = hasScopes ? 'connected' : 'disconnected';
       }
 
@@ -301,6 +310,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     } else {
       const hasExtensionInstalled = await hasExtension();
       const preferExtension = this.options.ui.preferExtension ?? true;
+      // Setup passive listening for extension wallet_sessionChanged events
       if (hasExtensionInstalled && preferExtension) {
         await this.#setupDefaultTransport();
         // We don't actually want getStoredTransport to return this transport
@@ -316,7 +326,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           // Passive init may fail if extension transport isn't ready
         }
       }
-      this.status = 'loaded';
     }
   }
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -261,6 +261,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (transportType) {
       if (transportType === TransportType.Browser) {
         if (hasExtensionInstalled) {
+          // Why does this not use setupDefaultTransport?..
           const apiTransport = new DefaultTransport();
           this.#transport = apiTransport;
           this.#providerTransportWrapper.setupTransportNotificationListener();
@@ -270,6 +271,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           return apiTransport;
         }
       } else if (transportType === TransportType.MWP) {
+          // Why does this not use setupMWP?..
         const { adapter: kvstore } = this.options.storage;
         const dappClient = await this.#createDappClient();
         const apiTransport = new MWPTransport(dappClient, kvstore);
@@ -310,6 +312,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         // We don't actually want getStoredTransport to return this transport
         // since we aren't connecting to it
         this.storage.removeTransport();
+        // Normally calling DefaultTransport.connect() ensures that the transport is initialized
+        // and that wallet_sessionChanged (faked) is emitted. But because we are not
+        // calling transport.connect(), we need to do this ourselves
+        await this.transport.init()
+        await this.emitSessionChanged();
+
       }
       this.status = 'loaded';
     }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -283,15 +283,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       }
 
       await this.storage.removeTransport(); // why do we remove the transport here?..
-    } else if (hasExtensionInstalled) {
-          const apiTransport = new DefaultTransport();
-          this.#transport = apiTransport;
-          this.#providerTransportWrapper.setupTransportNotificationListener();
-          this.#listener = apiTransport.onNotification(
-            this.#onTransportNotification.bind(this),
-          );
-          return apiTransport;
-      }
+    }
 
     return undefined;
   }
@@ -310,6 +302,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.storage.setTransport(TransportType.Browser);
       }
     } else {
+      const hasExtensionInstalled = await hasExtension();
+      if (hasExtensionInstalled) {
+        await this.#setupDefaultTransport();
+      }
       this.status = 'loaded';
     }
   }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -272,8 +272,16 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         return apiTransport;
       }
 
-      await this.storage.removeTransport();
-    }
+      await this.storage.removeTransport(); // why do we remove the transport here?..
+    } else if (hasExtensionInstalled) {
+          const apiTransport = new DefaultTransport();
+          this.#transport = apiTransport;
+          this.#providerTransportWrapper.setupTransportNotificationListener();
+          this.#listener = apiTransport.onNotification(
+            this.#onTransportNotification.bind(this),
+          );
+          return apiTransport;
+      }
 
     return undefined;
   }
@@ -899,11 +907,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
       await this.storage.removeTransport();
 
-      this.#listener = undefined;
-      this.#beforeUnloadListener = undefined;
-      this.#transport = undefined;
-      this.#providerTransportWrapper.clearTransportNotificationListener();
-      this.#dappClient = undefined;
+      if (this.transportType !== TransportType.Browser) {
+        this.#listener = undefined;
+        this.#beforeUnloadListener = undefined;
+        this.#transport = undefined;
+        this.#providerTransportWrapper.clearTransportNotificationListener();
+        this.#dappClient = undefined;
+      }
       this.status = 'disconnected';
     }
   }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -1017,7 +1017,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async emitSessionChanged(): Promise<void> {
     const emptySession = { sessionScopes: {} };
 
-    if (this.status !== 'connected' && this.status !== 'connecting') {
+    // Unsure if this change is okay for MWP. May need to adjust or undo
+    if (!this.transport?.isConnected()) {
       // If we aren't connected or connecting, there definitely is no active CAIP session
       // so we optimistically emit an empty session to signify that to the ecosystem client consumers (EVM, Solana, etc.)
       this.emit('wallet_sessionChanged', emptySession);

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -312,11 +312,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       const preferExtension = this.options.ui.preferExtension ?? true;
       // Setup passive listening for extension wallet_sessionChanged events
       if (hasExtensionInstalled && preferExtension) {
-        await this.#setupDefaultTransport();
-        // We don't actually want getStoredTransport to return this transport
-        // since we aren't connecting it to the wallet with a CAIP session, only
-        // listening for wallet_sessionChanged events.
-        await this.storage.removeTransport();
+        await this.#setupDefaultTransport({ persist: false });
         // Normally calling DefaultTransport.connect() ensures that the transport is initialized
         // and that wallet_sessionChanged (faked) is emitted. But because we are not
         // calling transport.connect(), we need to initialize DefaultTransport manually.
@@ -589,12 +585,16 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     });
   }
 
-  async #setupDefaultTransport(): Promise<DefaultTransport> {
+  async #setupDefaultTransport(
+    options: { persist?: boolean } = { persist: true },
+  ): Promise<DefaultTransport> {
     if (this.#transport instanceof DefaultTransport) {
       return this.#transport;
     }
 
-    await this.storage.setTransport(TransportType.Browser);
+    if (options?.persist) {
+      await this.storage.setTransport(TransportType.Browser);
+    }
     const transport = new DefaultTransport();
     this.#listener = transport.onNotification(
       this.#onTransportNotification.bind(this),

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -310,7 +310,11 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         // Normally calling DefaultTransport.connect() ensures that the transport is initialized
         // and that wallet_sessionChanged (faked) is emitted. But because we are not
         // calling transport.connect(), we need to initialize DefaultTransport manually.
-        await this.transport.init();
+        try {
+          await this.transport.init();
+        } catch {
+          // Passive init may fail if extension transport isn't ready
+        }
       }
       this.status = 'loaded';
     }
@@ -894,11 +898,15 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       sessionProperties: {},
     };
     if (this.#transport?.isConnected()) {
-      const response = await this.transport.request({
-        method: 'wallet_getSession',
-      });
-      if (response.result) {
-        sessionData = response.result as SessionData;
+      try {
+        const response = await this.transport.request({
+          method: 'wallet_getSession',
+        });
+        if (response.result) {
+          sessionData = response.result as SessionData;
+        }
+      } catch {
+        // If session retrieval fails, return empty session
       }
     }
     return sessionData;

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -303,7 +303,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       }
     } else {
       const hasExtensionInstalled = await hasExtension();
-      if (hasExtensionInstalled) {
+      const preferExtension = this.options.ui.preferExtension ?? true;
+      if (hasExtensionInstalled && preferExtension) {
         await this.#setupDefaultTransport();
       }
       this.status = 'loaded';

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -246,10 +246,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         const sessionScopes =
           (payload.params as SessionData | undefined)?.sessionScopes ?? {};
         const hasScopes = Object.keys(sessionScopes).length > 0;
-        // We don't want to set the status to disconnected if this is the first wallet_sessionChanged event
-        // triggered during #setupTransport() initialization for passive extension wallet_sessionChanged listening.
-        if (this.status === 'pending' && !hasScopes) {
-          this.status = 'loaded';
+        // During passive init, status is already 'loaded' — don't downgrade to 'disconnected'
+        // just because the extension has no active session yet.
+        if (this.status === 'loaded' && !hasScopes) {
           return;
         }
         this.status = hasScopes ? 'connected' : 'disconnected';
@@ -308,6 +307,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.storage.setTransport(TransportType.Browser);
       }
     } else {
+      this.status = 'loaded';
       const hasExtensionInstalled = await hasExtension();
       const preferExtension = this.options.ui.preferExtension ?? true;
       // Setup passive listening for extension wallet_sessionChanged events
@@ -318,8 +318,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         // calling transport.connect(), we need to initialize DefaultTransport manually.
         try {
           await this.transport.init();
-        } catch {
-          // Passive init may fail if extension transport isn't ready
+        } catch (error) {
+          console.error('Passive init failed:', error);
         }
       }
     }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -296,6 +296,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.transport.connect();
       }
       this.status = 'connected';
+      // Why do do we this?..
       if (this.transport instanceof MWPTransport) {
         await this.storage.setTransport(TransportType.MWP);
       } else {
@@ -306,6 +307,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       const preferExtension = this.options.ui.preferExtension ?? true;
       if (hasExtensionInstalled && preferExtension) {
         await this.#setupDefaultTransport();
+        // We don't actually want getStoredTransport to return this transport
+        // since we aren't connecting to it
+        this.storage.removeTransport();
       }
       this.status = 'loaded';
     }
@@ -912,18 +916,20 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     await this.#transport?.disconnect(scopes);
 
     if (remainingScopes.length === 0) {
-      await this.#listener?.();
-      this.#beforeUnloadListener?.();
-
       await this.storage.removeTransport();
 
+      // We want to leave the DefaultTransport instance connected so that we can
+      // still listen for wallet_sessionChanged events.
       if (this.transportType !== TransportType.Browser) {
+        await this.#listener?.();
+        this.#beforeUnloadListener?.();
         this.#listener = undefined;
         this.#beforeUnloadListener = undefined;
         this.#transport = undefined;
         this.#providerTransportWrapper.clearTransportNotificationListener();
         this.#dappClient = undefined;
       }
+
       this.status = 'disconnected';
     }
   }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -239,6 +239,16 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       payload !== null &&
       'method' in payload
     ) {
+      if (payload.method === 'wallet_sessionChanged') {
+        const sessionScopes = (payload.params as SessionData | undefined)
+          ?.sessionScopes ?? {};
+        const hasScopes = Object.keys(sessionScopes).length > 0;
+        this.status =
+          hasScopes
+            ? 'connected'
+            : 'disconnected';
+      }
+
       this.emit(payload.method as string, payload.params ?? payload.result);
     }
   }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -240,13 +240,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       'method' in payload
     ) {
       if (payload.method === 'wallet_sessionChanged') {
-        const sessionScopes = (payload.params as SessionData | undefined)
-          ?.sessionScopes ?? {};
+        const sessionScopes =
+          (payload.params as SessionData | undefined)?.sessionScopes ?? {};
         const hasScopes = Object.keys(sessionScopes).length > 0;
-        this.status =
-          hasScopes
-            ? 'connected'
-            : 'disconnected';
+        this.status = hasScopes ? 'connected' : 'disconnected';
       }
 
       this.emit(payload.method as string, payload.params ?? payload.result);
@@ -271,7 +268,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           return apiTransport;
         }
       } else if (transportType === TransportType.MWP) {
-          // Why does this not use setupMWP?..
+        // Why does this not use setupMWP?..
         const { adapter: kvstore } = this.options.storage;
         const dappClient = await this.#createDappClient();
         const apiTransport = new MWPTransport(dappClient, kvstore);
@@ -311,13 +308,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.#setupDefaultTransport();
         // We don't actually want getStoredTransport to return this transport
         // since we aren't connecting to it
-        this.storage.removeTransport();
+        await this.storage.removeTransport();
         // Normally calling DefaultTransport.connect() ensures that the transport is initialized
         // and that wallet_sessionChanged (faked) is emitted. But because we are not
-        // calling transport.connect(), we need to do this ourselves
-        await this.transport.init()
+        // calling transport.connect(), we need to initialize DefaultTransport manually.
+        await this.transport.init();
         await this.emitSessionChanged();
-
       }
       this.status = 'loaded';
     }
@@ -586,7 +582,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async #setupDefaultTransport(): Promise<DefaultTransport> {
     if (this.#transport instanceof DefaultTransport) {
       return this.#transport;
-    };
+    }
 
     await this.storage.setTransport(TransportType.Browser);
     const transport = new DefaultTransport();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -572,7 +572,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   async #setupDefaultTransport(): Promise<DefaultTransport> {
-    this.status = 'connecting';
+    if (this.#transport instanceof DefaultTransport) {
+      return this.#transport;
+    };
+
     await this.storage.setTransport(TransportType.Browser);
     const transport = new DefaultTransport();
     this.#listener = transport.onNotification(

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -895,7 +895,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       sessionScopes: {},
       sessionProperties: {},
     };
-    if (this.status === 'connected') {
+    if (this.#transport?.isConnected()) {
       const response = await this.transport.request({
         method: 'wallet_getSession',
       });
@@ -1012,8 +1012,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async emitSessionChanged(): Promise<void> {
     const emptySession = { sessionScopes: {} };
 
-    // Unsure if this change is okay for MWP. May need to adjust or undo
-    if (!this.transport?.isConnected()) {
+    if (!this.#transport?.isConnected()) {
       // If we aren't connected or connecting, there definitely is no active CAIP session
       // so we optimistically emit an empty session to signify that to the ecosystem client consumers (EVM, Solana, etc.)
       this.emit('wallet_sessionChanged', emptySession);

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -185,9 +185,13 @@ export class DefaultTransport implements ExtendedTransport {
     });
   }
 
-  async init(): Promise<void> {
+  async #init(): Promise<void> {
     this.#setupMessageListener();
     await this.#transport.connect();
+  }
+
+  constructor() {
+    this.#init().catch(console.error);
   }
 
   async destroy(): Promise<void> {
@@ -223,7 +227,7 @@ export class DefaultTransport implements ExtendedTransport {
     sessionProperties?: SessionProperties;
     forceRequest?: boolean;
   }): Promise<void> {
-    await this.init();
+    await this.#init();
 
     // Get wallet session
     const sessionRequest = await this.request(
@@ -276,6 +280,7 @@ export class DefaultTransport implements ExtendedTransport {
       }
       walletSession = response.result as SessionData;
     }
+    // this shouldn't be needed?...
     this.#notifyCallbacks({
       method: 'wallet_sessionChanged',
       params: walletSession,

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -192,7 +192,7 @@ export class DefaultTransport implements ExtendedTransport {
 
   async init(): Promise<void> {
     await this.#init();
-    let walletSession: SessionData = {sessionScopes: {}} ;
+    let walletSession: SessionData = { sessionScopes: {} };
     try {
       const sessionRequest = await this.request(
         { method: 'wallet_getSession' },

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -192,13 +192,15 @@ export class DefaultTransport implements ExtendedTransport {
 
   async init(): Promise<void> {
     await this.#init();
-    const sessionRequest = await this.request(
-      { method: 'wallet_getSession' },
-      this.#defaultRequestOptions,
-    );
-    const walletSession = sessionRequest.result as SessionData;
-    if (walletSession) {
-      return;
+    let walletSession: SessionData = {sessionScopes: {}} ;
+    try {
+      const sessionRequest = await this.request(
+        { method: 'wallet_getSession' },
+        this.#defaultRequestOptions,
+      );
+      walletSession = sessionRequest.result as SessionData;
+    } catch {
+      // wallet_getSession may fail if extension is not ready; treat as no session
     }
     this.#notifyCallbacks({
       method: 'wallet_sessionChanged',

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -200,7 +200,9 @@ export class DefaultTransport implements ExtendedTransport {
       );
       walletSession = sessionRequest.result as SessionData;
     } catch {
-      // wallet_getSession may fail if extension is not ready; treat as no session
+      console.error(
+        'Failed to get wallet session during DefaultTransport init',
+      );
     }
     this.#notifyCallbacks({
       method: 'wallet_sessionChanged',

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -206,33 +206,6 @@ export class DefaultTransport implements ExtendedTransport {
     });
   }
 
-  async destroy(): Promise<void> {
-    this.#notificationCallbacks.clear();
-
-    // Remove the message listener when disconnecting
-    if (this.#handleResponseListener) {
-      // eslint-disable-next-line no-restricted-globals
-      window.removeEventListener('message', this.#handleResponseListener);
-      this.#handleResponseListener = undefined;
-    }
-
-    // Remove the notification listener when disconnecting
-    if (this.#handleNotificationListener) {
-      // eslint-disable-next-line no-restricted-globals
-      window.removeEventListener('message', this.#handleNotificationListener);
-      this.#handleNotificationListener = undefined;
-    }
-
-    // Reject all pending requests
-    for (const [, request] of this.#pendingRequests) {
-      clearTimeout(request.timeout);
-      request.reject(new Error('Transport disconnected'));
-    }
-    this.#pendingRequests.clear();
-
-    await this.#transport.disconnect();
-  }
-
   async connect(options?: {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -185,13 +185,9 @@ export class DefaultTransport implements ExtendedTransport {
     });
   }
 
-  async #init(): Promise<void> {
+  async init(): Promise<void> {
     this.#setupMessageListener();
     await this.#transport.connect();
-  }
-
-  constructor() {
-    this.#init().catch(console.error);
   }
 
   async destroy(): Promise<void> {
@@ -227,7 +223,7 @@ export class DefaultTransport implements ExtendedTransport {
     sessionProperties?: SessionProperties;
     forceRequest?: boolean;
   }): Promise<void> {
-    await this.#init();
+    await this.init();
 
     // Get wallet session
     const sessionRequest = await this.request(
@@ -280,7 +276,9 @@ export class DefaultTransport implements ExtendedTransport {
       }
       walletSession = response.result as SessionData;
     }
-    // this shouldn't be needed?...
+    // I see... this is needed because we don't have listeners setup before we connect.
+    // but even if we had listeners setup, we may have missed the session changed event already.
+    // so we fake it here.
     this.#notifyCallbacks({
       method: 'wallet_sessionChanged',
       params: walletSession,

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -112,9 +112,10 @@ export class DefaultTransport implements ExtendedTransport {
     const responseData = event?.data?.data?.data;
 
     if (
-      (typeof responseData === 'object' &&
-        responseData.method === 'metamask_chainChanged') ||
-      responseData.method === 'metamask_accountsChanged'
+      typeof responseData === 'object' &&
+      responseData !== null &&
+      (responseData.method === 'metamask_chainChanged' ||
+        responseData.method === 'metamask_accountsChanged')
     ) {
       this.#notifyCallbacks(responseData);
     }

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -262,21 +262,21 @@ export class DefaultTransport implements ExtendedTransport {
       return;
     }
 
-    this.#notificationCallbacks.clear();
+    // this.#notificationCallbacks.clear();
 
-    // Remove the message listener when disconnecting
-    if (this.#handleResponseListener) {
-      // eslint-disable-next-line no-restricted-globals
-      window.removeEventListener('message', this.#handleResponseListener);
-      this.#handleResponseListener = undefined;
-    }
+    // // Remove the message listener when disconnecting
+    // if (this.#handleResponseListener) {
+    //   // eslint-disable-next-line no-restricted-globals
+    //   window.removeEventListener('message', this.#handleResponseListener);
+    //   this.#handleResponseListener = undefined;
+    // }
 
-    // Remove the notification listener when disconnecting
-    if (this.#handleNotificationListener) {
-      // eslint-disable-next-line no-restricted-globals
-      window.removeEventListener('message', this.#handleNotificationListener);
-      this.#handleNotificationListener = undefined;
-    }
+    // // Remove the notification listener when disconnecting
+    // if (this.#handleNotificationListener) {
+    //   // eslint-disable-next-line no-restricted-globals
+    //   window.removeEventListener('message', this.#handleNotificationListener);
+    //   this.#handleNotificationListener = undefined;
+    // }
 
     // Reject all pending requests
     for (const [, request] of this.#pendingRequests) {
@@ -285,7 +285,7 @@ export class DefaultTransport implements ExtendedTransport {
     }
     this.#pendingRequests.clear();
 
-    await this.#transport.disconnect();
+    // await this.#transport.disconnect();
   }
 
   isConnected(): boolean {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -269,6 +269,10 @@ export class DefaultTransport implements ExtendedTransport {
       }
       walletSession = response.result as SessionData;
     }
+    this.#notifyCallbacks({
+      method: 'wallet_sessionChanged',
+      params: walletSession,
+    });
   }
 
   async disconnect(scopes: Scope[] = []): Promise<void> {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -184,16 +184,45 @@ export class DefaultTransport implements ExtendedTransport {
     });
   }
 
+  async init(): Promise<void> {
+    this.#setupMessageListener();
+    await this.#transport.connect();
+  }
+
+  async destroy(): Promise<void> {
+    this.#notificationCallbacks.clear();
+
+    // Remove the message listener when disconnecting
+    if (this.#handleResponseListener) {
+      // eslint-disable-next-line no-restricted-globals
+      window.removeEventListener('message', this.#handleResponseListener);
+      this.#handleResponseListener = undefined;
+    }
+
+    // Remove the notification listener when disconnecting
+    if (this.#handleNotificationListener) {
+      // eslint-disable-next-line no-restricted-globals
+      window.removeEventListener('message', this.#handleNotificationListener);
+      this.#handleNotificationListener = undefined;
+    }
+
+    // Reject all pending requests
+    for (const [, request] of this.#pendingRequests) {
+      clearTimeout(request.timeout);
+      request.reject(new Error('Transport disconnected'));
+    }
+    this.#pendingRequests.clear();
+
+    await this.#transport.disconnect();
+  }
+
   async connect(options?: {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
     sessionProperties?: SessionProperties;
     forceRequest?: boolean;
   }): Promise<void> {
-    // Ensure message listener is set up before connecting
-    this.#setupMessageListener();
-
-    await this.#transport.connect();
+    await this.init();
 
     // Get wallet session
     const sessionRequest = await this.request(
@@ -261,31 +290,6 @@ export class DefaultTransport implements ExtendedTransport {
     if (Object.keys(sessionScopes).length > 0) {
       return;
     }
-
-    // this.#notificationCallbacks.clear();
-
-    // // Remove the message listener when disconnecting
-    // if (this.#handleResponseListener) {
-    //   // eslint-disable-next-line no-restricted-globals
-    //   window.removeEventListener('message', this.#handleResponseListener);
-    //   this.#handleResponseListener = undefined;
-    // }
-
-    // // Remove the notification listener when disconnecting
-    // if (this.#handleNotificationListener) {
-    //   // eslint-disable-next-line no-restricted-globals
-    //   window.removeEventListener('message', this.#handleNotificationListener);
-    //   this.#handleNotificationListener = undefined;
-    // }
-
-    // Reject all pending requests
-    for (const [, request] of this.#pendingRequests) {
-      clearTimeout(request.timeout);
-      request.reject(new Error('Transport disconnected'));
-    }
-    this.#pendingRequests.clear();
-
-    // await this.#transport.disconnect();
   }
 
   isConnected(): boolean {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -287,13 +287,6 @@ export class DefaultTransport implements ExtendedTransport {
 
   async disconnect(scopes: Scope[] = []): Promise<void> {
     await this.request({ method: 'wallet_revokeSession', params: { scopes } });
-
-    const response = await this.request({ method: 'wallet_getSession' });
-    const { sessionScopes } = response.result as SessionData;
-
-    if (Object.keys(sessionScopes).length > 0) {
-      return;
-    }
   }
 
   isConnected(): boolean {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -139,6 +139,11 @@ export class DefaultTransport implements ExtendedTransport {
     window.addEventListener('message', this.#handleNotificationListener);
   }
 
+  async #init(): Promise<void> {
+    this.#setupMessageListener();
+    await this.#transport.connect();
+  }
+
   async sendEip1193Message<
     TRequest extends TransportRequest,
     TResponse extends TransportResponse,
@@ -186,8 +191,19 @@ export class DefaultTransport implements ExtendedTransport {
   }
 
   async init(): Promise<void> {
-    this.#setupMessageListener();
-    await this.#transport.connect();
+    await this.#init();
+    const sessionRequest = await this.request(
+      { method: 'wallet_getSession' },
+      this.#defaultRequestOptions,
+    );
+    const walletSession = sessionRequest.result as SessionData;
+    if (walletSession) {
+      return;
+    }
+    this.#notifyCallbacks({
+      method: 'wallet_sessionChanged',
+      params: walletSession,
+    });
   }
 
   async destroy(): Promise<void> {
@@ -223,7 +239,7 @@ export class DefaultTransport implements ExtendedTransport {
     sessionProperties?: SessionProperties;
     forceRequest?: boolean;
   }): Promise<void> {
-    await this.init();
+    await this.#init();
 
     // Get wallet session
     const sessionRequest = await this.request(
@@ -276,13 +292,6 @@ export class DefaultTransport implements ExtendedTransport {
       }
       walletSession = response.result as SessionData;
     }
-    // I see... this is needed because we don't have listeners setup before we connect.
-    // but even if we had listeners setup, we may have missed the session changed event already.
-    // so we fake it here.
-    this.#notifyCallbacks({
-      method: 'wallet_sessionChanged',
-      params: walletSession,
-    });
   }
 
   async disconnect(scopes: Scope[] = []): Promise<void> {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -377,6 +377,10 @@ export class MWPTransport implements ExtendedTransport {
     }
   }
 
+  async init(): Promise<void> {
+    // no-op for MWP — passive init is only relevant for DefaultTransport
+  }
+
   // TODO: Rename this
   async sendEip1193Message<
     TRequest extends TransportRequest,

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Connect (window.ethereum)` button ([#198](https://github.com/MetaMask/connect-monorepo/pull/198/))
+
 ## [0.3.0]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -166,6 +166,17 @@ function App() {
     }
   }, [wallets, select, clearSolanaError]);
 
+  const windowEthereumRequestAccounts = useCallback(async () => {
+    try {
+      const result = await (window as any).ethereum?.request({
+        method: 'eth_requestAccounts',
+      });
+      console.log('eth_requestAccounts result:', result);
+    } catch (err) {
+      console.error('eth_requestAccounts error:', err);
+    }
+  }, []);
+
   const isConnected = status === 'connected';
   const isConnecting = status === 'connecting';
   const isDisconnected =
@@ -266,6 +277,14 @@ function App() {
                 Connect (Solana)
               </button>
             )}
+
+            <button
+              type="button"
+              onClick={windowEthereumRequestAccounts}
+              className="bg-orange-500 text-white px-5 py-2 rounded text-base hover:bg-orange-600 transition-colors"
+            >
+              Connect (window.ethereum)
+            </button>
 
             {isConnected && scopesHaveChanged() && (
               <button

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -166,15 +166,11 @@ function App() {
     }
   }, [wallets, select, clearSolanaError]);
 
-  const windowEthereumRequestAccounts = useCallback(async () => {
-    try {
-      const result = await (window as any).ethereum?.request({
-        method: 'eth_requestAccounts',
-      });
-      console.log('eth_requestAccounts result:', result);
-    } catch (err) {
-      console.error('eth_requestAccounts error:', err);
-    }
+  const connectWindowEthereum = useCallback(() => {
+    (window as any).ethereum?.request({
+      method: 'wallet_requestPermissions',
+      params: [{ eth_accounts: {} }],
+    });
   }, []);
 
   const isConnected = status === 'connected';
@@ -280,7 +276,7 @@ function App() {
 
             <button
               type="button"
-              onClick={windowEthereumRequestAccounts}
+              onClick={connectWindowEthereum}
               className="bg-orange-500 text-white px-5 py-2 rounded text-base hover:bg-orange-600 transition-colors"
             >
               Connect (window.ethereum)

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -276,6 +276,7 @@ function App() {
 
             <button
               type="button"
+              data-testid={TEST_IDS.app.btnConnectWindowEthereum}
               onClick={connectWindowEthereum}
               className="bg-orange-500 text-white px-5 py-2 rounded text-base hover:bg-orange-600 transition-colors"
             >

--- a/playground/playground-ui/src/testIds/index.ts
+++ b/playground/playground-ui/src/testIds/index.ts
@@ -42,6 +42,7 @@ export const TEST_IDS = {
     btnDisconnect: 'app-btn-disconnect',
     btnReconnect: 'app-btn-reconnect',
     btnCancel: 'app-btn-cancel',
+    btnConnectWindowEthereum: 'app-btn-connect-window-ethereum',
 
     // Sections
     sectionScopes: 'app-section-scopes',

--- a/yarn.lock
+++ b/yarn.lock
@@ -28225,11 +28225,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28225,11 +28225,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Uses the DefaultTransport on init if no existing transport is stored, extension is found, and extensionIsPreferred. Ensures that wallet_sessionChanged events are listened to and MultichainClient.status is correctly updated.

To test, use `window.ethereum.request({method: 'eth_requestAccounts})` in console to trigger the permission flow outside of the MMC lifecycle 

## References


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
