### PR TITLE
chore: prevent react-native-playground from being published to npm

### DIFF
--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -2,6 +2,7 @@
   "name": "@metamask/react-native-playground",
   "version": "0.1.3",
   "description": "A React Native test dapp for multichain api",
+  "private": true,
   "keywords": [
     "MetaMask",
     "Ethereum"
@@ -16,10 +17,6 @@
   },
   "license": "MIT",
   "main": "expo-router/entry",
-  "types": "./dist/index.d.cts",
-  "files": [
-    "dist/"
-  ],
   "scripts": {
     "allow-scripts": "",
     "android": "yarn copy-wagmi-connector && expo start --android",
@@ -29,7 +26,6 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/react-native-playground",
     "copy-wagmi-connector": "node scripts/copy-wagmi-connector.js",
     "ios": "yarn copy-wagmi-connector && expo start --ios",
-    "publish:preview": "yarn npm publish --tag preview",
     "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "yarn copy-wagmi-connector && expo start --tunnel",
     "test": "echo \"No test specified\"",
@@ -99,10 +95,6 @@
   },
   "engines": {
     "node": ">=20.19.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
   },
   "lavamoat": {
     "allowScripts": {

--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@metamask/react-native-playground",
   "version": "0.1.3",
-  "description": "A React Native test dapp for multichain api",
   "private": true,
+  "description": "A React Native test dapp for multichain api",
   "keywords": [
     "MetaMask",
     "Ethereum"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

In our current deploy system, non-private packages that have version changes will be published to NPM during the release flow. However, `react-native-playground` contains a React Native application, which doesn't make sense to publish to NPM as it can't be consumed directly in JS.

This PR marks it as private so that `action-npm-publish` ignores it during release process.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
🧵 [slack discussion thread ](
https://consensys.slack.com/archives/C09H7GR7PPE/p1773072732155969?thread_ts=1773068013.410939&cid=C09H7GR7PPE)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
