### PR TITLE
feat: remove mmconnect_init analytics

### DIFF
--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -101,17 +101,7 @@ function testSuite<T extends MultichainOptions>({
           t.expect(enableSpy).not.toHaveBeenCalled();
         } else {
           // For web and web-mobile platforms, analytics should be enabled
-          t.expect(enableSpy.mock.calls.length).toBeGreaterThan(0);
-          t.expect(trackSpy.mock.calls.length).toBeGreaterThan(0);
-          t.expect(trackSpy).toHaveBeenCalledWith(
-            'mmconnect_initialized',
-            t.expect.objectContaining({
-              mmconnect_version: t.expect.any(String),
-              dapp_id: t.expect.any(String),
-              platform: t.expect.any(String),
-              integration_type: t.expect.any(String),
-            }),
-          );
+          t.expect(enableSpy).toHaveBeenCalled();
         }
 
         enableSpy.mockRestore();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -329,15 +329,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     try {
       await this.#setupAnalytics();
       await this.#setupTransport();
-      try {
-        const baseProps = await getBaseAnalyticsProperties(
-          this.options,
-          this.storage,
-        );
-        analytics.track('mmconnect_initialized', baseProps);
-      } catch (error) {
-        logger('Error tracking initialized event', error);
-      }
     } catch (error) {
       await this.storage.removeTransport();
       this.status = 'pending';


### PR DESCRIPTION
## Explanation

Stops the mmconnect_initialized event from being fired

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1224

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
