### PR TITLE
feat: remove eth_accounts analytics events

### DIFF
--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -640,16 +640,6 @@ export class MetamaskConnectEVM {
     }
 
     if (isAccountsRequest(request)) {
-      const { method } = request;
-      const decimalChainId = hexToNumber(
-        this.#provider.selectedChainId ?? '0x1',
-      );
-      const scope: Scope = `eip155:${decimalChainId}`;
-      const params: unknown[] = [];
-
-      await this.#trackWalletActionRequested(method, scope, params);
-      await this.#trackWalletActionSucceeded(method, scope, params);
-
       return this.#provider.accounts;
     }
 


### PR DESCRIPTION
## Explanation

Stops the mmconnect_wallet_action_ events from being fired when `eth_accounts` is requested

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1224

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
