### PR TITLE
feat: remove rpc method analytics. remove MWP optimistic chain switch analytics

### DIFF
--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -527,7 +527,6 @@ export class MetamaskConnectEVM {
     const scope: Scope = `eip155:${hexToNumber(chainId)}`;
     const params = [{ chainId }];
 
-    await this.#trackWalletActionRequested(method, scope, params);
 
     // TODO (wenfix): better way to return here other than resolving.
     if (this.selectedChainId === chainId) {
@@ -542,9 +541,10 @@ export class MetamaskConnectEVM {
     ) {
       await this.#cacheChainId(chainId);
       this.#onChainChanged(chainId);
-      await this.#trackWalletActionSucceeded(method, scope, params);
       return Promise.resolve();
     }
+
+    await this.#trackWalletActionRequested(method, scope, params);
 
     try {
       const result = await this.#request({

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -527,7 +527,6 @@ export class MetamaskConnectEVM {
     const scope: Scope = `eip155:${hexToNumber(chainId)}`;
     const params = [{ chainId }];
 
-
     // TODO (wenfix): better way to return here other than resolving.
     if (this.selectedChainId === chainId) {
       return Promise.resolve();

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -211,16 +211,14 @@ export class RequestRouter {
    * @param options
    */
   private async handleWithRpcNode(options: InvokeMethodOptions): Promise<Json> {
-    return this.#withAnalyticsTracking(options, async () => {
-      try {
-        return await this.rpcClient.request(options);
-      } catch (error) {
-        if (error instanceof MissingRpcEndpointErr) {
-          return this.handleWithWallet(options);
-        }
-        throw error;
+    try {
+      return await this.rpcClient.request(options);
+    } catch (error) {
+      if (error instanceof MissingRpcEndpointErr) {
+        return this.handleWithWallet(options);
       }
-    });
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Explanation

* Stops the mmconnect_wallet_action_ events from being fired when requests are routed to an rpc node
* Stops mmconnect_wallet_action_ events from being fired when wallet_switchEthereumChain requests are resolved locally without hitting the wallet
 
## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1224

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
