### PR TITLE
feat: change `getInfuraRpcUrls` to accept param object and chain ids property

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** `getInfuraRpcUrls` now accepts a single options object `{ infuraApiKey, chainIds? }` instead of a positional `infuraApiKey` string. The optional `chainIds` parameter accepts hex chain IDs to filter the output ([#211](https://github.com/MetaMask/connect-monorepo/pull/211))
+
 ### Fixed
 
 - Fix an issue where `connect` would always return the default chain id regardless of other chains being specified. This also affected `connectWith` and `connectAndSign` ([#205](https://github.com/MetaMask/connect-monorepo/pull/205))

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -506,10 +506,10 @@ Helper function to generate EVM Infura RPC URLs for common networks keyed by hex
 
 **Parameters**
 
-| Name           | Type     | Required | Description                               |
-| -------------- | -------- | -------- | ----------------------------------------- |
-| `infuraApiKey` | `string` | Yes      | Your Infura API key                       |
-| `chainIds`     | `Hex[]`  | No       | Hex chain IDs to filter the output        |
+| Name           | Type     | Required | Description                        |
+| -------------- | -------- | -------- | ---------------------------------- |
+| `infuraApiKey` | `string` | Yes      | Your Infura API key                |
+| `chainIds`     | `Hex[]`  | No       | Hex chain IDs to filter the output |
 
 **Returns**
 

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -37,7 +37,7 @@ const client = await createEVMClient({
   api: {
     supportedNetworks: {
       // use the `getInfuraRpcUrls` helper to generate a map of Infura RPC endpoints
-      ...getInfuraRpcUrls(INFURA_API_KEY),
+      ...getInfuraRpcUrls({ infuraApiKey: INFURA_API_KEY }),
       // or specify your own CAIP Chain ID to rpc endpoint mapping
       // Hex chain IDs mapped to RPC URLs
       '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY', // Ethereum Mainnet
@@ -500,15 +500,16 @@ provider.on('display_uri', (uri) => {
 
 ---
 
-### `getInfuraRpcUrls(infuraApiKey)`
+### `getInfuraRpcUrls(options)`
 
 Helper function to generate EVM Infura RPC URLs for common networks keyed by hex chain ID.
 
 **Parameters**
 
-| Name           | Type     | Required | Description         |
-| -------------- | -------- | -------- | ------------------- |
-| `infuraApiKey` | `string` | Yes      | Your Infura API key |
+| Name           | Type     | Required | Description                               |
+| -------------- | -------- | -------- | ----------------------------------------- |
+| `infuraApiKey` | `string` | Yes      | Your Infura API key                       |
+| `chainIds`     | `Hex[]`  | No       | Hex chain IDs to filter the output        |
 
 **Returns**
 
@@ -517,8 +518,16 @@ A map of hex chain IDs to Infura RPC URLs. See https://docs.metamask.io/services
 ```typescript
 import { getInfuraRpcUrls } from '@metamask/connect-evm';
 
-const rpcUrls = getInfuraRpcUrls('YOUR_INFURA_KEY');
+// Get all supported Infura RPC URLs
+const rpcUrls = getInfuraRpcUrls({ infuraApiKey: 'YOUR_INFURA_KEY' });
 // Returns: { '0x1': 'https://mainnet.infura.io/v3/KEY', ... }
+
+// Filter to specific chains
+const filtered = getInfuraRpcUrls({
+  infuraApiKey: 'YOUR_INFURA_KEY',
+  chainIds: ['0x1', '0x89'],
+});
+// Returns: { '0x1': 'https://mainnet.infura.io/v3/KEY', '0x89': 'https://polygon-mainnet.infura.io/v3/KEY' }
 ```
 
 ---

--- a/packages/connect-evm/src/utils/infura.ts
+++ b/packages/connect-evm/src/utils/infura.ts
@@ -1,15 +1,37 @@
-import type { RpcUrlsMap } from '@metamask/connect-multichain';
 import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
 import type { CaipChainId, Hex } from '@metamask/utils';
 import {
+  hexToNumber,
   KnownCaipNamespace,
   numberToHex,
   parseCaipChainId,
 } from '@metamask/utils';
 
-export const getInfuraRpcUrls = (infuraAPIKey: string): RpcUrlsMap => {
-  const caipMap = getInfuraRpcUrlsMultichain(infuraAPIKey);
-  const hexMap = Object.entries(caipMap).reduce<Record<Hex, string>>(
+/**
+ * Generates Infura RPC URLs for common EVM networks keyed by hex chain ID.
+ *
+ * @param options - The options for generating Infura RPC URLs
+ * @param options.infuraApiKey - The Infura API key
+ * @param options.chainIds - Optional hex chain IDs to filter the output
+ * @returns A map of hex chain IDs to Infura RPC URLs
+ */
+export const getInfuraRpcUrls = ({
+  infuraApiKey,
+  chainIds,
+}: {
+  infuraApiKey: string;
+  chainIds?: Hex[];
+}): Record<Hex, string> => {
+  const caipChainIds = chainIds?.map(
+    (chainId) => `eip155:${hexToNumber(chainId)}` as CaipChainId,
+  );
+
+  const caipMap = getInfuraRpcUrlsMultichain({
+    infuraApiKey,
+    caipChainIds,
+  });
+
+  return Object.entries(caipMap).reduce<Record<Hex, string>>(
     (acc, [key, url]) => {
       const { namespace, reference } = parseCaipChainId(key as CaipChainId);
       if (namespace !== KnownCaipNamespace.Eip155) {
@@ -21,5 +43,4 @@ export const getInfuraRpcUrls = (infuraAPIKey: string): RpcUrlsMap => {
     },
     {},
   );
-  return hexMap;
 };

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** `getInfuraRpcUrls` now accepts a single options object `{ infuraApiKey, caipChainIds? }` instead of a positional `infuraApiKey` string. The optional `caipChainIds` parameter filters the output to only the specified CAIP-2 chain IDs ([#211](https://github.com/MetaMask/connect-monorepo/pull/211))
+
 ### Fixed
 
 - Fix a bug where wallet_sessionChanged events were failing to propagate to the `ConnectMultichain` instance when the `DefaultTransport` is using the `WindowPostMessageTransport`. This was affecting Firefox, both iOS and Android in-app browsers ([#204](https://github.com/MetaMask/connect-monorepo/pull/204))

--- a/packages/connect-multichain/README.md
+++ b/packages/connect-multichain/README.md
@@ -343,10 +343,10 @@ Generates Infura RPC URLs for common networks keyed by CAIP Chain ID.
 
 **Parameters**
 
-| Name              | Type             | Required | Description                                          |
-| ----------------- | ---------------- | -------- | ---------------------------------------------------- |
-| `infuraApiKey`    | `string`         | Yes      | Your Infura API key                                  |
-| `caipChainIds`    | `CaipChainId[]`  | No       | CAIP-2 chain IDs to filter the output                |
+| Name           | Type            | Required | Description                           |
+| -------------- | --------------- | -------- | ------------------------------------- |
+| `infuraApiKey` | `string`        | Yes      | Your Infura API key                   |
+| `caipChainIds` | `CaipChainId[]` | No       | CAIP-2 chain IDs to filter the output |
 
 **Returns**
 

--- a/packages/connect-multichain/README.md
+++ b/packages/connect-multichain/README.md
@@ -32,7 +32,7 @@ const client = await createMultichainClient({
   api: {
     supportedNetworks: {
       // use the `getInfuraRpcUrls` helper to generate a map of Infura RPC endpoints
-      ...getInfuraRpcUrls(INFURA_API_KEY),
+      ...getInfuraRpcUrls({ infuraApiKey: INFURA_API_KEY }),
       // or specify your own CAIP Chain ID to rpc endpoint mapping
       'eip155:1': 'https://mainnet.example.io/rpc',
       'eip155:137': 'https://polygon-mainnet.example.io/rpc',
@@ -337,15 +337,16 @@ Emits an event to all registered handlers.
 
 ### Utilities
 
-#### `getInfuraRpcUrls(infuraApiKey)`
+#### `getInfuraRpcUrls(options)`
 
 Generates Infura RPC URLs for common networks keyed by CAIP Chain ID.
 
 **Parameters**
 
-| Name           | Type     | Required | Description         |
-| -------------- | -------- | -------- | ------------------- |
-| `infuraApiKey` | `string` | Yes      | Your Infura API key |
+| Name              | Type             | Required | Description                                          |
+| ----------------- | ---------------- | -------- | ---------------------------------------------------- |
+| `infuraApiKey`    | `string`         | Yes      | Your Infura API key                                  |
+| `caipChainIds`    | `CaipChainId[]`  | No       | CAIP-2 chain IDs to filter the output                |
 
 **Returns**
 
@@ -354,12 +355,23 @@ A map of [CAIP-2 chain IDs](https://chainagnostic.org/CAIPs/caip-2) to Infura RP
 ```typescript
 import { getInfuraRpcUrls } from '@metamask/connect-multichain';
 
-const rpcUrls = getInfuraRpcUrls('YOUR_INFURA_KEY');
+// Get all supported Infura RPC URLs
+const rpcUrls = getInfuraRpcUrls({ infuraApiKey: 'YOUR_INFURA_KEY' });
 // {
 //   'eip155:1': 'https://mainnet.infura.io/v3/YOUR_KEY',
 //   'eip155:137': 'https://polygon-mainnet.infura.io/v3/YOUR_KEY',
 //   'eip155:11155111': 'https://sepolia.infura.io/v3/YOUR_KEY',
 //   ...
+// }
+
+// Filter to specific chains
+const filtered = getInfuraRpcUrls({
+  infuraApiKey: 'YOUR_INFURA_KEY',
+  caipChainIds: ['eip155:1', 'eip155:137'],
+});
+// {
+//   'eip155:1': 'https://mainnet.infura.io/v3/YOUR_KEY',
+//   'eip155:137': 'https://polygon-mainnet.infura.io/v3/YOUR_KEY',
 // }
 ```
 

--- a/packages/connect-multichain/src/domain/multichain/api/infura.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/infura.ts
@@ -1,11 +1,30 @@
-/* eslint-disable jsdoc/require-jsdoc */
+import type { CaipChainId } from '@metamask/utils';
+
 import { infuraRpcUrls } from './constants';
 import type { RpcUrlsMap } from './types';
 
-export function getInfuraRpcUrls(infuraAPIKey: string): RpcUrlsMap {
-  return Object.keys(infuraRpcUrls).reduce<RpcUrlsMap>((acc, key) => {
-    const typedKey = key as keyof typeof infuraRpcUrls;
-    acc[typedKey] = `${infuraRpcUrls[typedKey]}${infuraAPIKey}`;
+/**
+ * Generates Infura RPC URLs for common networks keyed by CAIP Chain ID.
+ *
+ * @param options - The options for generating Infura RPC URLs
+ * @param options.infuraApiKey - The Infura API key
+ * @param options.caipChainIds - Optional CAIP-2 chain IDs to filter the output
+ * @returns A map of CAIP-2 chain IDs to Infura RPC URLs
+ */
+export function getInfuraRpcUrls({
+  infuraApiKey,
+  caipChainIds,
+}: {
+  infuraApiKey: string;
+  caipChainIds?: CaipChainId[];
+}): RpcUrlsMap {
+  const keys = caipChainIds && caipChainIds.length > 0 ? caipChainIds : Object.keys(infuraRpcUrls) as CaipChainId[];
+
+  return keys.reduce<RpcUrlsMap>((acc, key) => {
+    const baseUrl = infuraRpcUrls[key as keyof typeof infuraRpcUrls];
+    if (baseUrl) {
+      acc[key] = `${baseUrl}${infuraApiKey}`;
+    }
     return acc;
   }, {});
 }

--- a/packages/connect-multichain/src/domain/multichain/api/infura.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/infura.ts
@@ -18,10 +18,13 @@ export function getInfuraRpcUrls({
   infuraApiKey: string;
   caipChainIds?: CaipChainId[];
 }): RpcUrlsMap {
-  const keys = caipChainIds && caipChainIds.length > 0 ? caipChainIds : Object.keys(infuraRpcUrls) as CaipChainId[];
+  const keys =
+    caipChainIds && caipChainIds.length > 0
+      ? caipChainIds
+      : (Object.keys(infuraRpcUrls) as CaipChainId[]);
 
   return keys.reduce<RpcUrlsMap>((acc, key) => {
-    const baseUrl = infuraRpcUrls[key as keyof typeof infuraRpcUrls];
+    const baseUrl = infuraRpcUrls[key];
     if (baseUrl) {
       acc[key] = `${baseUrl}${infuraApiKey}`;
     }

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `getInfuraRpcUrls` calls to use new options object parameter ([#211](https://github.com/MetaMask/connect-monorepo/pull/211))
+
 ### Added
 
 - Add Connect button that calls legacy EVM `connectAndSign` method ([#205](https://github.com/MetaMask/connect-monorepo/pull/205))

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -68,7 +68,7 @@ export const LegacyEVMSDKProvider = ({
         const infuraApiKey = process.env.INFURA_API_KEY || '';
         // Get CAIP-keyed RPC URLs and convert to hex-keyed format
         const caipNetworks = infuraApiKey
-          ? getInfuraRpcUrls(infuraApiKey)
+          ? getInfuraRpcUrls({ infuraApiKey })
           : {
               // Fallback public RPC endpoints if no Infura key is provided
               'eip155:1': 'https://eth.llamarpc.com',

--- a/playground/browser-playground/src/sdk/SDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/SDKProvider.tsx
@@ -51,7 +51,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
           url: 'https://playground.metamask.io',
         },
         api: {
-          supportedNetworks: getInfuraRpcUrls(process.env.INFURA_API_KEY || ''),
+          supportedNetworks: getInfuraRpcUrls({ infuraApiKey: process.env.INFURA_API_KEY || '' }),
         },
         transport: {
           extensionId: METAMASK_PROD_CHROME_ID,

--- a/playground/node-playground/CHANGELOG.md
+++ b/playground/node-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `getInfuraRpcUrls` call to use new options object parameter ([#211](https://github.com/MetaMask/connect-monorepo/pull/211))
+
 ### Added
 
 - Add support for `@metamask/connect-solana` ([#169](https://github.com/MetaMask/connect-monorepo/pull/169))

--- a/playground/node-playground/src/index.ts
+++ b/playground/node-playground/src/index.ts
@@ -453,7 +453,7 @@ const main = async (): Promise<void> => {
   console.log('------------------------------------');
 
   const infuraApiKey = process.env.INFURA_API_KEY ?? 'demo';
-  const supportedNetworks = getInfuraRpcUrls(infuraApiKey);
+  const supportedNetworks = getInfuraRpcUrls({ infuraApiKey });
   // Convert CAIP-keyed RPC URLs to hex-keyed format for EVM SDK
   const hexKeyedNetworks = convertCaipToHexKeys(supportedNetworks);
 

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `getInfuraRpcUrls` calls to use new options object parameter ([#211](https://github.com/MetaMask/connect-monorepo/pull/211))
+
 ## [0.2.0]
 
 ### Changed

--- a/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -67,7 +67,7 @@ export const LegacyEVMSDKProvider = ({
         const infuraApiKey = process.env.EXPO_PUBLIC_INFURA_API_KEY || '';
         // Get CAIP-keyed RPC URLs and convert to hex-keyed format
         const caipNetworks = infuraApiKey
-          ? getInfuraRpcUrls(infuraApiKey)
+          ? getInfuraRpcUrls({ infuraApiKey })
           : {
               // Fallback public RPC endpoints if no Infura key is provided
               'eip155:1': 'https://eth.llamarpc.com',

--- a/playground/react-native-playground/src/sdk/SDKProvider.tsx
+++ b/playground/react-native-playground/src/sdk/SDKProvider.tsx
@@ -34,7 +34,7 @@ export const SDKProvider = ({ children }: { children: React.ReactNode }) => {
 					url: 'https://playground.metamask.io',
 				},
 				api: {
-					supportedNetworks: getInfuraRpcUrls(process.env.EXPO_PUBLIC_INFURA_API_KEY || ''),
+					supportedNetworks: getInfuraRpcUrls({ infuraApiKey: process.env.EXPO_PUBLIC_INFURA_API_KEY || '' }),
 				},
 				mobile: {
 					preferredOpenLink: (deeplink: string) => {


### PR DESCRIPTION
## Explanation

## @metamask/connect-multichain
- getInfuraRpcUrls(infuraApiKey) → getInfuraRpcUrls({ infuraApiKey, caipChainIds? })
- When caipChainIds is provided, only matching CAIP-2 chains are included in the output
## @metamask/connect-evm
- getInfuraRpcUrls(infuraApiKey) → getInfuraRpcUrls({ infuraApiKey, chainIds? })
- chainIds accepts hex values (e.g., ['0x1', '0x89']), converts to CAIP format internally, and delegates to the multichain helper

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1234

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
