### PR TITLE
fix: isolate wagmi GitHub Pages routes

### DIFF
--- a/.github/workflows/deploy-wagmi-to-gh-pages.yml
+++ b/.github/workflows/deploy-wagmi-to-gh-pages.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       destination_dir:
-        description: 'Destination directory on GitHub Pages (e.g., "latest", "5.0.0", "wagmi")'
+        description: 'Destination directory on GitHub Pages (e.g., "wagmi/latest", "wagmi/5.0.0")'
         required: true
         type: string
 
@@ -27,6 +27,10 @@ jobs:
     steps:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+
+      - name: Ensure `destination_dir` stays under `wagmi/`
+        if: ${{ !startsWith(inputs.destination_dir, 'wagmi/') }}
         run: exit 1
 
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -128,24 +128,24 @@ jobs:
           fi
 
   publish-wagmi-to-gh-pages:
-    name: Publish Wagmi Integration to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    name: Publish Wagmi Integration to `wagmi/${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     needs: get-release-version
     permissions:
       contents: write
     uses: ./.github/workflows/deploy-wagmi-to-gh-pages.yml
     with:
-      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+      destination_dir: wagmi/${{ needs.get-release-version.outputs.RELEASE_VERSION }}
     secrets:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-wagmi-to-latest-gh-pages:
-    name: Publish Wagmi Integration to `latest` directory of `gh-pages` branch
+    name: Publish Wagmi Integration to `wagmi/latest` directory of `gh-pages` branch
     needs: publish-wagmi-to-gh-pages
     permissions:
       contents: write
     uses: ./.github/workflows/deploy-wagmi-to-gh-pages.yml
     with:
-      destination_dir: latest
+      destination_dir: wagmi/latest
     secrets:
       PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 


### PR DESCRIPTION
## Summary
- move wagmi release deploys off the shared root Pages routes into the `wagmi/` namespace
- keep the browser playground as the owner of `latest` and root versioned release routes
- prevent manual wagmi deploy workflow runs from targeting non-`wagmi/` destinations

## Test plan
- [x] Run `yarn prettier --check .github/workflows/publish-release.yml .github/workflows/deploy-wagmi-to-gh-pages.yml`
- [x] Run `actionlint` against the updated workflow files

Made with [Cursor](https://cursor.com)