### PR TITLE
fix: derive release pages version from root package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,15 +93,11 @@ jobs:
       - id: get-release-version
         shell: bash
         run: |
-          # Get version from the latest git tag created by the release action
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$TAG" ]; then
-            # Fallback to package.json version if no tag found
-            TAG="v$(node -p "require('./package.json').version")"
-          fi
+          # Read the released root package version directly so Pages paths track
+          # the monorepo release rather than whichever workspace tag git sees last.
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_OUTPUT"
-          # Remove 'v' prefix for the version output
-          VERSION=${TAG#v}
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - id: check-rn-playground
         shell: bash


### PR DESCRIPTION
## Summary
- derive `RELEASE_VERSION` from the root monorepo `package.json` instead of `git describe`
- keep Pages release directories aligned with the monorepo release version instead of unrelated workspace tags
- leave the emitted `RELEASE_TAG` consistent with the root release version

## Test plan
- [x] Run `yarn prettier --check .github/workflows/publish-release.yml`
- [x] Run `actionlint` against the updated workflow files
- [x] Confirm `node -p "require('./package.json').version"` returns the root release version used by the workflow

Made with [Cursor](https://cursor.com)