### PR TITLE
Release/21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-monorepo",
-  "version": "20.0.0",
+  "version": "21.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2]
+
 ### Added
 
 - Add `integrationType: wagmi` to wagmi metamask connector([#215](https://github.com/MetaMask/connect-monorepo/pull/215/))
@@ -96,7 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.4.1...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.4.2...HEAD
+[0.4.2]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.4.1...@metamask/browser-playground@0.4.2
 [0.4.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.4.0...@metamask/browser-playground@0.4.1
 [0.4.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.3.1...@metamask/browser-playground@0.4.0
 [0.3.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.3.0...@metamask/browser-playground@0.3.1

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browser-playground",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A browser test dapp for multichain api",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## @metamask/browser-playground

## [0.4.2]

### Added

- Add `integrationType: wagmi` to wagmi metamask connector([#215](https://github.com/MetaMask/connect-monorepo/pull/215/))