### PR TITLE
fix: Fix react-native-playground consumption of __PACKAGE_VERSION__ build-time constant in connect packages

### DIFF
--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1044,9 +1044,9 @@ export async function createEVMClient(
         // typeof guard needed: Metro (React Native) bundles TS source directly,
         // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
         'connect-evm':
-          typeof __PACKAGE_VERSION__ !== 'undefined'
-            ? __PACKAGE_VERSION__
-            : 'unknown',
+          typeof __PACKAGE_VERSION__ === 'undefined'
+            ? 'unknown'
+            : __PACKAGE_VERSION__,
       },
     });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -40,7 +40,8 @@ import {
   validSupportedChainsUrls,
 } from './utils/type-guards';
 
-declare const __PACKAGE_VERSION__: string;
+// Value substitued by tsup at build time
+declare const __PACKAGE_VERSION__: string | undefined;
 
 const DEFAULT_CHAIN_ID = '0x1';
 const CHAIN_STORE_KEY = 'cache_eth_chainId';
@@ -1039,7 +1040,14 @@ export async function createEVMClient(
       analytics: {
         integrationType: options.analytics?.integrationType ?? 'direct',
       },
-      versions: { 'connect-evm': __PACKAGE_VERSION__ },
+      versions: {
+        // typeof guard needed: Metro (React Native) bundles TS source directly,
+        // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
+        'connect-evm':
+          typeof __PACKAGE_VERSION__ !== 'undefined'
+            ? __PACKAGE_VERSION__
+            : 'unknown',
+      },
     });
 
     return MetamaskConnectEVM.create({

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -71,7 +71,8 @@ import {
 
 export { getInfuraRpcUrls } from '../domain/multichain/api/infura';
 
-declare const __PACKAGE_VERSION__: string;
+// Value substitued by tsup at build time
+declare const __PACKAGE_VERSION__: string | undefined;
 
 // ENFORCE NAMESPACE THAT CAN BE DISABLED
 const logger = createLogger('metamask-sdk:core');
@@ -154,7 +155,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         integrationType,
       },
       versions: {
-        'connect-multichain': __PACKAGE_VERSION__,
+        // typeof guard needed: Metro (React Native) bundles TS source directly,
+        // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
+        'connect-multichain':
+          typeof __PACKAGE_VERSION__ !== 'undefined'
+            ? __PACKAGE_VERSION__
+            : 'unknown',
         ...(options.versions ?? {}),
       },
     };

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -158,9 +158,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         // typeof guard needed: Metro (React Native) bundles TS source directly,
         // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
         'connect-multichain':
-          typeof __PACKAGE_VERSION__ !== 'undefined'
-            ? __PACKAGE_VERSION__
-            : 'unknown',
+          typeof __PACKAGE_VERSION__ === 'undefined'
+            ? 'unknown'
+            : __PACKAGE_VERSION__,
         ...(options.versions ?? {}),
       },
     };

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -15,7 +15,8 @@ import type {
   SolanaSupportedNetworks,
 } from './types';
 
-declare const __PACKAGE_VERSION__: string;
+// Value substitued by tsup at build time
+declare const __PACKAGE_VERSION__: string | undefined;
 
 /**
  * Creates a new Solana client for connecting to MetaMask via wallet-standard.
@@ -72,7 +73,14 @@ export async function createSolanaClient(
     api: {
       supportedNetworks,
     },
-    versions: { 'connect-solana': __PACKAGE_VERSION__ },
+    versions: {
+      // typeof guard needed: Metro (React Native) bundles TS source directly,
+      // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
+      'connect-solana':
+        typeof __PACKAGE_VERSION__ !== 'undefined'
+          ? __PACKAGE_VERSION__
+          : 'unknown',
+    },
   });
 
   const client = core.provider;

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -77,9 +77,9 @@ export async function createSolanaClient(
       // typeof guard needed: Metro (React Native) bundles TS source directly,
       // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
       'connect-solana':
-        typeof __PACKAGE_VERSION__ !== 'undefined'
-          ? __PACKAGE_VERSION__
-          : 'unknown',
+        typeof __PACKAGE_VERSION__ === 'undefined'
+          ? 'unknown'
+          : __PACKAGE_VERSION__,
     },
   });
 


### PR DESCRIPTION
## Explanation

The react-native-playground consumes the connect package ts files directly rather than the built `dist` files. This causes an issue where the `__PACKAGE_VERSION__` placeholder constant is still undefined when referenced later. This PR fixes that by adding a check and a default.

Note that this issue only affects expo builds.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
