### PR TITLE
fix: use merged integration types in analytics

### DIFF
--- a/packages/analytics/src/analytics.test.ts
+++ b/packages/analytics/src/analytics.test.ts
@@ -103,7 +103,7 @@ t.describe('Analytics Integration', () => {
     scope.done();
   });
 
-  t.it('should merge repeated integration_types global updates', async () => {
+  t.it('should merge multiple integration_types global updates', async () => {
     let captured: EventV2[] = [];
     scope = nock('http://127.0.0.3')
       .post('/v2/events', (body) => {

--- a/packages/analytics/src/analytics.test.ts
+++ b/packages/analytics/src/analytics.test.ts
@@ -23,7 +23,7 @@ t.describe('Analytics Integration', () => {
     dapp_id: 'aave.com',
     anon_id: 'bbbc1727-8b85-433a-a26a-e9df70ddc81c',
     platform: 'web-desktop',
-    integration_type: 'direct',
+    integration_types: ['direct'],
   };
 
   t.afterAll(() => {
@@ -79,8 +79,8 @@ t.describe('Analytics Integration', () => {
     analytics.setGlobalProperty('anon_id', eventProperties.anon_id);
     analytics.setGlobalProperty('platform', eventProperties.platform);
     analytics.setGlobalProperty(
-      'integration_type',
-      eventProperties.integration_type,
+      'integration_types',
+      eventProperties.integration_types,
     );
     analytics.track('mmconnect_initialized', {
       dapp_id: 'dapp_id',
@@ -99,6 +99,44 @@ t.describe('Analytics Integration', () => {
       },
     };
     t.expect(captured).toEqual([expectedEvent]);
+
+    scope.done();
+  });
+
+  t.it('should merge repeated integration_types global updates', async () => {
+    let captured: EventV2[] = [];
+    scope = nock('http://127.0.0.3')
+      .post('/v2/events', (body) => {
+        captured = body;
+        return true;
+      })
+      .reply(
+        200,
+        { status: 'success' },
+        { 'Content-Type': 'application/json' },
+      );
+
+    analytics = new Analytics('http://127.0.0.3');
+    analytics.enable();
+    analytics.setGlobalProperty(
+      'mmconnect_versions',
+      eventProperties.mmconnect_versions,
+    );
+    analytics.setGlobalProperty('anon_id', eventProperties.anon_id);
+    analytics.setGlobalProperty('platform', eventProperties.platform);
+    analytics.setGlobalProperty('dapp_id', eventProperties.dapp_id);
+    analytics.setGlobalProperty('integration_types', ['wagmi']);
+    analytics.setGlobalProperty('integration_types', ['direct']);
+
+    analytics.track('mmconnect_initialized', {});
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const event = captured[0] as MMConnectPayload | undefined;
+    t.expect(event?.properties).toMatchObject({
+      dapp_id: eventProperties.dapp_id,
+      integration_types: ['wagmi', 'direct'],
+    });
 
     scope.done();
   });

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -38,6 +38,18 @@ class Analytics {
     key: K,
     value: MMConnectProperties[K],
   ): void {
+    if (key === 'integration_types') {
+      const existing = Array.isArray(this.properties.integration_types)
+        ? this.properties.integration_types
+        : [];
+      const incoming = Array.isArray(value) ? value : [];
+
+      this.properties.integration_types = [
+        ...new Set([...existing, ...incoming]),
+      ];
+      return;
+    }
+
     this.properties[key] = value;
   }
 

--- a/packages/analytics/src/schema.ts
+++ b/packages/analytics/src/schema.ts
@@ -151,8 +151,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkUsedChainEvent: {
       /**
@@ -180,8 +180,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkConnectionInitiatedEvent: {
       /**
@@ -211,8 +211,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkConnectionEstablishedEvent: {
       /**
@@ -242,8 +242,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkConnectionRejectedEvent: {
       /**
@@ -273,8 +273,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkConnectionFailedEvent: {
       /**
@@ -304,8 +304,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     WalletConnectionRequestReceivedEvent: {
       /**
@@ -381,8 +381,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkActionSucceededEvent: {
       /**
@@ -410,8 +410,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkActionFailedEvent: {
       /**
@@ -439,8 +439,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     SdkActionRejectedEvent: {
       /**
@@ -468,8 +468,8 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      /** @description Type of integration used by the SDK. */
-      integration_type: string;
+      /** @description Types of integrations used by the SDK. */
+      integration_types: string[];
     };
     WalletActionReceivedEvent: {
       /**
@@ -566,7 +566,7 @@ export type components = {
         | 'nodejs'
         | 'in-app-browser'
         | 'react-native';
-      integration_type: string;
+      integration_types: string[];
       transport_type?: 'browser' | 'mwp' | 'unknown';
       method?: string;
       caip_chain_id?: string;

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1037,6 +1037,7 @@ export async function createEVMClient(
         supportedNetworks: supportedNetworksCaipChainId,
       },
       analytics: {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         integrationType: options.analytics?.integrationType || 'direct',
       },
       versions: { 'connect-evm': __PACKAGE_VERSION__ },

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1037,7 +1037,7 @@ export async function createEVMClient(
         supportedNetworks: supportedNetworksCaipChainId,
       },
       analytics: {
-        integrationType: options.analytics?.integrationType ?? 'direct',
+        integrationType: options.analytics?.integrationType || 'direct',
       },
       versions: { 'connect-evm': __PACKAGE_VERSION__ },
     });

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -247,10 +247,9 @@ function testSuite<T extends MultichainOptions>({
         } as any);
 
         if (platform === 'web' || platform === 'web-mobile') {
-          t.expect(setGlobalSpy).toHaveBeenCalledWith(
-            'integration_types',
-            ['wagmi'],
-          );
+          t.expect(setGlobalSpy).toHaveBeenCalledWith('integration_types', [
+            'wagmi',
+          ]);
         }
 
         setGlobalSpy.mockRestore();
@@ -271,14 +270,12 @@ function testSuite<T extends MultichainOptions>({
         } as any);
 
         if (platform === 'web' || platform === 'web-mobile') {
-          t.expect(setGlobalSpy).toHaveBeenCalledWith(
-            'integration_types',
-            ['direct'],
-          );
-          t.expect(setGlobalSpy).not.toHaveBeenCalledWith(
-            'integration_types',
-            [''],
-          );
+          t.expect(setGlobalSpy).toHaveBeenCalledWith('integration_types', [
+            'direct',
+          ]);
+          t.expect(setGlobalSpy).not.toHaveBeenCalledWith('integration_types', [
+            '',
+          ]);
         }
 
         setGlobalSpy.mockRestore();

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -231,6 +231,61 @@ function testSuite<T extends MultichainOptions>({
     );
 
     t.it(
+      `${platform} should update integration_types analytics global when singleton sees a new integration`,
+      async () => {
+        const setGlobalSpy = t.vi.spyOn(analytics, 'setGlobalProperty');
+
+        sdk = await createSDK(testOptions);
+        setGlobalSpy.mockClear();
+
+        await createSDK({
+          ...testOptions,
+          analytics: {
+            ...testOptions.analytics,
+            integrationType: 'wagmi',
+          },
+        } as any);
+
+        if (platform === 'web' || platform === 'web-mobile') {
+          t.expect(setGlobalSpy).toHaveBeenCalledWith(
+            'integration_types',
+            ['wagmi'],
+          );
+        }
+
+        setGlobalSpy.mockRestore();
+      },
+    );
+
+    t.it(
+      `${platform} should normalize empty integrationType to direct for analytics globals`,
+      async () => {
+        const setGlobalSpy = t.vi.spyOn(analytics, 'setGlobalProperty');
+
+        await createSDK({
+          ...testOptions,
+          analytics: {
+            ...testOptions.analytics,
+            integrationType: '',
+          },
+        } as any);
+
+        if (platform === 'web' || platform === 'web-mobile') {
+          t.expect(setGlobalSpy).toHaveBeenCalledWith(
+            'integration_types',
+            ['direct'],
+          );
+          t.expect(setGlobalSpy).not.toHaveBeenCalledWith(
+            'integration_types',
+            [''],
+          );
+        }
+
+        setGlobalSpy.mockRestore();
+      },
+    );
+
+    t.it(
       `${platform} Should gracefully handle init errors by just logging them and return non initialized sdk`,
       async () => {
         const testError = new Error('Test error');

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -140,7 +140,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   constructor(options: MultichainOptions) {
     const withDappMetadata = setupDappMetadata(options);
-    const integrationType = options.analytics?.integrationType ?? 'direct';
+    const integrationType = options.analytics?.integrationType || 'direct';
     const allOptions = {
       ...withDappMetadata,
       ui: {
@@ -189,6 +189,11 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         'mmconnect_versions',
         instance.options.versions ?? {},
       );
+      if (options.analytics?.integrationType) {
+        analytics.setGlobalProperty('integration_types', [
+          options.analytics.integrationType,
+        ]);
+      }
       if (options.debug) {
         enableDebug('metamask-sdk:*');
       }
@@ -244,7 +249,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     analytics.setGlobalProperty('dapp_id', dappId);
     analytics.setGlobalProperty('anon_id', anonId);
     analytics.setGlobalProperty('platform', platform);
-    analytics.setGlobalProperty('integration_type', integrationType);
+    if (integrationType) {
+      analytics.setGlobalProperty('integration_types', [integrationType]);
+    }
     analytics.enable();
   }
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -140,6 +140,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   constructor(options: MultichainOptions) {
     const withDappMetadata = setupDappMetadata(options);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const integrationType = options.analytics?.integrationType || 'direct';
     const allOptions = {
       ...withDappMetadata,

--- a/packages/connect-multichain/src/multichain/utils/analytics.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.ts
@@ -49,21 +49,16 @@ export async function getBaseAnalyticsProperties(
   mmconnect_versions: Record<string, string>;
   dapp_id: string;
   platform: PlatformType;
-  integration_type: string;
   anon_id: string;
 }> {
   const dappId = getDappId(options.dapp);
   const platform = getPlatformType();
   const anonId = await storage.getAnonId();
-  const integrationType =
-    (options.analytics as { enabled: true; integrationType: string })
-      ?.integrationType ?? TransportType.UNKNOWN;
 
   return {
     mmconnect_versions: options.versions ?? {},
     dapp_id: dappId,
     platform,
-    integration_type: integrationType,
     anon_id: anonId,
   };
 }
@@ -86,22 +81,17 @@ export async function getWalletActionAnalyticsProperties(
   mmconnect_versions: Record<string, string>;
   dapp_id: string;
   method: string;
-  integration_type: string;
   caip_chain_id: string;
   anon_id: string;
   transport_type: TransportType;
 }> {
   const dappId = getDappId(options.dapp);
   const anonId = await storage.getAnonId();
-  const integrationType =
-    (options.analytics as { enabled: true; integrationType: string })
-      ?.integrationType ?? 'unknown';
 
   return {
     mmconnect_versions: options.versions ?? {},
     dapp_id: dappId,
     method: invokeOptions.request.method,
-    integration_type: integrationType,
     caip_chain_id: invokeOptions.scope,
     anon_id: anonId,
     transport_type: transportType,

--- a/packages/connect-multichain/src/multichain/utils/analytics.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.ts
@@ -7,8 +7,9 @@ import type {
   PlatformType,
   Scope,
   StoreClient,
+  TransportType,
 } from '../../domain';
-import { getPlatformType, TransportType } from '../../domain';
+import { getPlatformType } from '../../domain';
 
 /**
  * Checks if an error represents a user rejection.


### PR DESCRIPTION
## Summary
- replace the singular analytics integration field with a merged global `integration_types` array so mixed SDK integrations are preserved in shared analytics context
- normalize empty `integrationType` inputs to the `direct` default to avoid invalid analytics payloads
- add regression coverage for integration type merging and empty integration type normalization

## Test plan
- [x] `yarn vitest run \"src/analytics.test.ts\"`
- [x] `yarn workspace @metamask/analytics run build`
- [x] `yarn workspace @metamask/connect-multichain run build`
- [x] `yarn workspace @metamask/connect-evm run build`