### PR TITLE
refactor: unify connect notification flow and establish typed sdk event baseline

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate `metamask_accountsChanged` and `metamask_chainChanged` subscriptions from `transport.onNotification()` to typed `core.on()`/`core.off()`, removing `@ts-expect-error` suppressions ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+
 ## [0.8.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -70,6 +70,11 @@ function createMockCore(): MockCore {
       }
       handlers[event].push(handler);
     },
+    off(event: string, handler: (...args: unknown[]) => void): void {
+      if (handlers[event]) {
+        handlers[event] = handlers[event].filter((fn) => fn !== handler);
+      }
+    },
     emit(event: string, ...args: unknown[]): void {
       handlers[event]?.forEach((handler) => handler(...args));
     },
@@ -504,6 +509,82 @@ describe('MetamaskConnectEVM', () => {
         expect.arrayContaining(['eip155:1', 'eip155:137']),
       );
       expect(scopes).toHaveLength(2);
+    });
+  });
+
+  describe('core event subscriptions', () => {
+    let mockCore: MockCore;
+    let client: Awaited<ReturnType<typeof MetamaskConnectEVM.create>>;
+
+    beforeEach(async () => {
+      mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+    });
+
+    it('handles metamask_accountsChanged via core.on()', async () => {
+      const accountsChangedPromise = new Promise<string[]>((resolve) => {
+        client.getProvider().once('accountsChanged', resolve);
+      });
+
+      mockCore.emit('metamask_accountsChanged', [
+        '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      ]);
+
+      const accounts = await accountsChangedPromise;
+      expect(accounts).toEqual(['0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef']);
+    });
+
+    it('handles metamask_chainChanged via core.on()', async () => {
+      const chainChangedPromise = new Promise<string>((resolve) => {
+        client.getProvider().once('chainChanged', resolve);
+      });
+
+      mockCore.emit('metamask_chainChanged', { chainId: '0x89' });
+
+      const chainId = await chainChangedPromise;
+      expect(chainId).toBe('0x89');
+    });
+
+    it('caches the chainId when metamask_chainChanged fires', async () => {
+      const chainChangedPromise = new Promise<string>((resolve) => {
+        client.getProvider().once('chainChanged', resolve);
+      });
+
+      mockCore.emit('metamask_chainChanged', { chainId: '0x89' });
+
+      await chainChangedPromise;
+      expect(mockCore.storage.adapter.set).toHaveBeenCalledWith(
+        'cache_eth_chainId',
+        JSON.stringify('0x89'),
+      );
+    });
+
+    it('stops receiving events after removeNotificationHandler is called via disconnect', async () => {
+      await client.disconnect();
+
+      const accountsChangedSpy = vi.fn();
+      client.getProvider().on('accountsChanged', accountsChangedSpy);
+
+      mockCore.emit('metamask_accountsChanged', [
+        '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      ]);
+
+      expect(accountsChangedSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -834,32 +834,26 @@ export class MetamaskConnectEVM {
 
       this.#removeNotificationHandler?.();
 
-      // TODO: Verify if #core.on('metamask_accountsChanged') and #core.on('metamask_chainChanged')
-      // would work here instead
-      this.#removeNotificationHandler = this.#core.transport.onNotification(
-        (notification) => {
-          // @ts-expect-error TODO: address this
-          if (notification?.method === 'metamask_accountsChanged') {
-            // @ts-expect-error TODO: address this
-            const notificationAccounts = notification?.params;
-            logger('transport-event: accountsChanged', notificationAccounts);
-            // why are we not caching the accounts here?
-            this.#onAccountsChanged(notificationAccounts);
-          }
+      const onAccountsChanged = (accs: string[]): void => {
+        logger('core-event: accountsChanged', accs);
+        this.#onAccountsChanged(accs as Address[]);
+      };
 
-          // @ts-expect-error TODO: address this
-          if (notification?.method === 'metamask_chainChanged') {
-            // @ts-expect-error TODO: address this
-            const notificationChainId = notification?.params?.chainId;
-            logger('transport-event: chainChanged', notificationChainId);
-            // Cache the chainId for persistence across page refreshes
-            this.#cacheChainId(notificationChainId).catch((error) => {
-              logger('Error caching chainId in notification handler', error);
-            });
-            this.#onChainChanged(notificationChainId);
-          }
-        },
-      );
+      const onChainChanged = (chainChanged: { chainId: string }): void => {
+        logger('core-event: chainChanged', chainChanged.chainId);
+        this.#cacheChainId(chainChanged.chainId as Hex).catch((error) => {
+          logger('Error caching chainId in notification handler', error);
+        });
+        this.#onChainChanged(chainChanged.chainId as Hex);
+      };
+
+      this.#core.on('metamask_accountsChanged', onAccountsChanged);
+      this.#core.on('metamask_chainChanged', onChainChanged);
+
+      this.#removeNotificationHandler = (): void => {
+        this.#core.off('metamask_accountsChanged', onAccountsChanged);
+        this.#core.off('metamask_chainChanged', onChainChanged);
+      };
     }
 
     this.#onChainChanged(chainId);

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+- `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+- `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/connect-multichain/src/domain/events/types/index.ts
+++ b/packages/connect-multichain/src/domain/events/types/index.ts
@@ -4,6 +4,12 @@ import type { SessionData } from '@metamask/multichain-api-client';
 export type SDKEvents = {
   display_uri: [evt: string];
   wallet_sessionChanged: [evt: SessionData | undefined];
+  metamask_accountsChanged: [evt: string[]];
+  metamask_chainChanged: [evt: { chainId: string }];
+  // Inlined to avoid circular import with domain/multichain (ConnectionStatus)
+  stateChanged: [
+    evt: 'pending' | 'loaded' | 'disconnected' | 'connected' | 'connecting',
+  ];
   [key: string]: [evt: unknown];
 };
 

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -15,7 +15,19 @@ import type { StoreClient } from '../store/client';
 class MockMultichainCore extends MultichainCore {
   storage = {} as StoreClient;
 
-  status: ConnectionStatus = 'loaded';
+  _status: ConnectionStatus = 'loaded';
+
+  get status(): ConnectionStatus {
+    return this._status;
+  }
+
+  set status(value: ConnectionStatus) {
+    if (this._status === value) {
+      return;
+    }
+    this._status = value;
+    this.emit('stateChanged', value);
+  }
 
   provider = {} as MultichainApiClient<RPCAPI>;
 
@@ -303,6 +315,51 @@ t.describe('MultichainCore', () => {
       t.expect(opts.mobile).toEqual({ useDeeplink: true });
       t.expect(opts.transport?.extensionId).toBe('merged-ext');
       t.expect(opts.debug).toBe(true);
+    });
+  });
+
+  t.describe('stateChanged event', () => {
+    t.it('fires stateChanged when status is set to a new value', () => {
+      const base = createBaseOptions();
+      const core = new MockMultichainCore(base);
+      const handler = t.vi.fn();
+
+      core.on('stateChanged', handler);
+      core.status = 'connected';
+
+      t.expect(handler).toHaveBeenCalledTimes(1);
+      t.expect(handler).toHaveBeenCalledWith('connected');
+    });
+
+    t.it(
+      'does not fire stateChanged when status is set to the same value',
+      () => {
+        const base = createBaseOptions();
+        const core = new MockMultichainCore(base);
+        core.status = 'connected';
+
+        const handler = t.vi.fn();
+        core.on('stateChanged', handler);
+        core.status = 'connected';
+
+        t.expect(handler).not.toHaveBeenCalled();
+      },
+    );
+
+    t.it('fires stateChanged for each distinct status transition', () => {
+      const base = createBaseOptions();
+      const core = new MockMultichainCore(base);
+      const handler = t.vi.fn();
+
+      core.on('stateChanged', handler);
+      core.status = 'connecting';
+      core.status = 'connected';
+      core.status = 'disconnected';
+
+      t.expect(handler).toHaveBeenCalledTimes(3);
+      t.expect(handler).toHaveBeenNthCalledWith(1, 'connecting');
+      t.expect(handler).toHaveBeenNthCalledWith(2, 'connected');
+      t.expect(handler).toHaveBeenNthCalledWith(3, 'disconnected');
     });
   });
 });

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -100,10 +100,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       return;
     }
     this._status = value;
-    this.options.transport?.onNotification?.({
-      method: 'stateChanged',
-      params: value,
-    });
+    this.emit('stateChanged', value);
   }
 
   get provider(): MultichainApiClient<RPCAPI> {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -114,8 +114,7 @@ export class DefaultTransport implements ExtendedTransport {
     if (
       typeof responseData === 'object' &&
       responseData !== null &&
-      (responseData.method === 'metamask_chainChanged' ||
-        responseData.method === 'metamask_accountsChanged')
+      'method' in responseData
     ) {
       this.#notifyCallbacks(responseData);
     }


### PR DESCRIPTION
## Explanation

- Remove the notification method filter in `DefaultTransport` so all wallet notifications are forwarded (matching MWP transport behavior)
- Add explicit `SDKEvents` entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged`
- Route `stateChanged` through `emit()` so `client.on('stateChanged', cb)` works correctly
- Migrate `ConnectEvm` from `transport.onNotification()` to typed `core.on()`/`core.off()`, removing all `@ts-expect-error` suppressions

## Motivation

The SDK had two parallel notification delivery paths — `core.on(...)` and `transport.onNotification()` — for what should be a single concern. This caused:

1. **Asymmetric transport behavior** — `DefaultTransport` silently dropped any notification that wasn't `metamask_chainChanged` or `metamask_accountsChanged`, while MWP forwarded everything.
2. **Ecosystem clients coupled to transport internals** — `ConnectEvm` subscribed directly to `transport.onNotification()` for chain/account events (with `@ts-expect-error` on every access) instead of using the core event bus.
3. **`stateChanged` silently failing** — The status setter emitted only via `options.transport?.onNotification?.(...)`, never via `super.emit()`, so `client.on('stateChanged', cb)` never fired.
4. **Unmodeled notification types** — `SDKEvents` had no explicit entries for key notification events; the catch-all index signature hid this gap.

## Changes

### `packages/connect-multichain/src/multichain/transports/default/index.ts`
Removed the `metamask_chainChanged || metamask_accountsChanged` guard in `#handleNotification`. The transport now forwards any notification with a `method` property, with a generalized null/type guard.

### `packages/connect-multichain/src/domain/events/types/index.ts`
Added typed entries for `metamask_accountsChanged` (`string[]`), `metamask_chainChanged` (`{ chainId: string }`), and `stateChanged` (connection status union). The `ConnectionStatus` type is inlined to avoid a circular import. The catch-all index signature is retained for backward compatibility.

### `packages/connect-multichain/src/multichain/index.ts`
Changed the `status` setter to call `this.emit('stateChanged', value)` instead of `this.options.transport?.onNotification?.(...)`. The existing `emit` override already calls both `onNotification` and `super.emit`, so both paths are covered without duplication.

### `packages/connect-evm/src/connect.ts`
Replaced `this.#core.transport.onNotification(...)` with typed `this.#core.on('metamask_accountsChanged', ...)` and `this.#core.on('metamask_chainChanged', ...)`. Cleanup uses `this.#core.off(...)`. All four `@ts-expect-error` suppressions are removed.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1141

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
