### PR TITLE
fix: skip Solana wallet standard registration when Metamask extension exists

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip Solana wallet-standard registration when MetaMask extension is already present to avoid double-registration ([#231](https://github.com/MetaMask/connect-monorepo/pull/231))
+
 ## [0.6.0]
 
 ### Fixed

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@metamask/connect-multichain": "workspace:^",
     "@metamask/solana-wallet-standard": "^0.6.0",
+    "@wallet-standard/app": "~1.1.0",
     "@wallet-standard/base": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { createSolanaClient } from './connect';
+import { setMockWallets } from './mocks/wallet-standard-app';
 import type { SolanaConnectOptions } from './types';
 
 describe('createSolanaClient', () => {
@@ -37,6 +38,7 @@ describe('createSolanaClient', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    setMockWallets([]);
     (createMultichainClient as ReturnType<typeof vi.fn>).mockResolvedValue(
       mockCore,
     );
@@ -110,12 +112,20 @@ describe('createSolanaClient', () => {
 
       expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
         client: mockCore.provider,
-        walletName: 'MetaMask Connect',
+        walletName: 'MetaMask',
       });
     });
 
     it('should skip auto-registration when skipAutoRegister is true', async () => {
       await createSolanaClient({ ...mockOptions, skipAutoRegister: true });
+
+      expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+    });
+
+    it('should skip auto-registration when MetaMask extension is already registered', async () => {
+      setMockWallets([{ name: 'MetaMask' }]);
+
+      await createSolanaClient(mockOptions);
 
       expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
     });
@@ -133,7 +143,7 @@ describe('createSolanaClient', () => {
 
         expect(getWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
         });
         expect(wallet).toBe(mockWallet);
       });
@@ -150,7 +160,7 @@ describe('createSolanaClient', () => {
 
         expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
         });
       });
 
@@ -158,6 +168,18 @@ describe('createSolanaClient', () => {
         const client = await createSolanaClient(mockOptions);
 
         vi.clearAllMocks();
+        await client.registerWallet();
+
+        expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+      });
+
+      it('should skip registration when MetaMask extension is already registered', async () => {
+        const client = await createSolanaClient({
+          ...mockOptions,
+          skipAutoRegister: true,
+        });
+
+        setMockWallets([{ name: 'MetaMask' }]);
         await client.registerWallet();
 
         expect(registerSolanaWalletStandard).not.toHaveBeenCalled();

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -14,6 +14,7 @@ import type {
   SolanaConnectOptions,
   SolanaSupportedNetworks,
 } from './types';
+import { isMetamaskExtensionRegistered, logger, enableDebug } from './utils';
 
 // Value substitued by tsup at build time
 declare const __PACKAGE_VERSION__: string | undefined;
@@ -58,6 +59,10 @@ declare const __PACKAGE_VERSION__: string | undefined;
 export async function createSolanaClient(
   options: SolanaConnectOptions,
 ): Promise<SolanaClient> {
+  if (options.debug) {
+    enableDebug();
+  }
+
   const defaultNetworks: SolanaSupportedNetworks = {
     mainnet: 'https://api.mainnet-beta.solana.com',
   };
@@ -85,10 +90,14 @@ export async function createSolanaClient(
 
   const client = core.provider;
 
-  const walletName = 'MetaMask Connect';
+  const walletName = 'MetaMask';
 
   if (!skipAutoRegister) {
-    await registerSolanaWalletStandard({ client, walletName });
+    if (isMetamaskExtensionRegistered()) {
+      logger('MetaMask extension is already registered. Skipping...');
+    } else {
+      await registerSolanaWalletStandard({ client, walletName });
+    }
   }
 
   return {
@@ -96,6 +105,10 @@ export async function createSolanaClient(
     getWallet: () => getWalletStandard({ client, walletName }),
     registerWallet: async (): Promise<void> => {
       if (!skipAutoRegister) {
+        return;
+      }
+      if (isMetamaskExtensionRegistered()) {
+        logger('MetaMask extension is already registered. Skipping...');
         return;
       }
       await registerSolanaWalletStandard({ client, walletName });

--- a/packages/connect-solana/src/mocks/connect-multichain.ts
+++ b/packages/connect-solana/src/mocks/connect-multichain.ts
@@ -1,3 +1,5 @@
 import { vi } from 'vitest';
 
 export const createMultichainClient = vi.fn();
+export const enableDebug = vi.fn();
+export const createLogger = vi.fn();

--- a/packages/connect-solana/src/mocks/wallet-standard-app.ts
+++ b/packages/connect-solana/src/mocks/wallet-standard-app.ts
@@ -1,0 +1,12 @@
+import { vi } from 'vitest';
+
+const mockWallets: { name: string }[] = [];
+
+export const getWallets = vi.fn().mockReturnValue({
+  get: () => mockWallets,
+});
+
+export const setMockWallets = (wallets: { name: string }[]) => {
+  mockWallets.length = 0;
+  mockWallets.push(...wallets);
+};

--- a/packages/connect-solana/src/utils.ts
+++ b/packages/connect-solana/src/utils.ts
@@ -1,0 +1,28 @@
+import {
+  createLogger,
+  enableDebug as debug,
+} from '@metamask/connect-multichain';
+import { getWallets } from '@wallet-standard/app';
+
+const namespace = 'metamask-connect:solana';
+
+// @ts-expect-error logger needs to be typed properly
+export const logger = createLogger(namespace, '93');
+
+export const enableDebug = (): void => {
+  // @ts-expect-error logger needs to be typed properly
+  debug(namespace);
+};
+
+/**
+ * Check if MetaMask extension is registered on Solana wallet-standard registry
+ *
+ * @returns True if extension is registered, false otherwise
+ */
+export const isMetamaskExtensionRegistered = (): boolean => {
+  const wallets = getWallets();
+
+  return wallets
+    .get()
+    .some((wallet) => wallet.name.toLowerCase().includes('metamask'));
+};

--- a/packages/connect-solana/vitest.config.ts
+++ b/packages/connect-solana/vitest.config.ts
@@ -32,6 +32,11 @@ export default defineConfig({
         __dirname,
         './src/mocks/solana-wallet-standard.ts',
       ),
+      '@wallet-standard/app': resolve(
+        // eslint-disable-next-line no-restricted-globals
+        __dirname,
+        './src/mocks/wallet-standard-app.ts',
+      ),
     },
   },
 });

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change Solana Wallet Standard filter to find wallet name 'MetaMask' rather than 'MetaMask Connect' ([#231](https://github.com/MetaMask/connect-monorepo/pull/231))
+
 ## [0.5.0]
 
 ### Changed

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -170,7 +170,7 @@ function App() {
 
     // Find the MetaMask wallet in registered wallets
     const metamaskWallet = wallets.find((w) =>
-      w.adapter.name.toLowerCase().includes('metamask connect'),
+      w.adapter.name.toLowerCase().includes('metamask'),
     );
     if (metamaskWallet) {
       // Just select the wallet - autoConnect in WalletProvider will handle connection

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -1,4 +1,7 @@
-import { createSolanaClient, type SolanaClient } from '@metamask/connect-solana';
+import {
+  createSolanaClient,
+  type SolanaClient,
+} from '@metamask/connect-solana';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
 import {
   ConnectionProvider,
@@ -56,6 +59,7 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
     initRef.current = true;
 
     createSolanaClient({
+      debug: true,
       dapp: {
         name: 'MetaMask Connect Playground',
         url: window.location.origin,
@@ -77,7 +81,14 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const contextValue = useMemo(
-    () => ({ client, isRegistered, endpoint, setEndpoint, walletError, clearWalletError }),
+    () => ({
+      client,
+      isRegistered,
+      endpoint,
+      setEndpoint,
+      walletError,
+      clearWalletError,
+    }),
     [client, isRegistered, endpoint, walletError, clearWalletError],
   );
 
@@ -93,7 +104,10 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <SolanaSDKContext.Provider value={contextValue}>
-      <ConnectionProvider endpoint={endpoint} config={{ commitment: 'confirmed' }}>
+      <ConnectionProvider
+        endpoint={endpoint}
+        config={{ commitment: 'confirmed' }}
+      >
         <WalletProvider wallets={[]} autoConnect onError={onWalletError}>
           <WalletModalProvider>{children}</WalletModalProvider>
         </WalletProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,6 +4198,7 @@ __metadata:
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@types/jsdom": "npm:^21.1.7"
     "@vitest/coverage-v8": "npm:^3.2.4"
+    "@wallet-standard/app": "npm:~1.1.0"
     "@wallet-standard/base": "npm:^1.1.0"
     jsdom: "npm:^26.1.0"
     prettier: "npm:^3.3.3"
@@ -9643,7 +9644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-standard/app@npm:^1.1.0":
+"@wallet-standard/app@npm:^1.1.0, @wallet-standard/app@npm:~1.1.0":
   version: 1.1.0
   resolution: "@wallet-standard/app@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
## Explanation

When both the MetaMask extension and SDK are present, registering the SDK wallet would create a duplicate "MetaMask" entry in wallet adapters, confusing users. This change ensures only one MetaMask wallet appears in the wallet selection UI.

This PR brings back the change from https://github.com/MetaMask/connect-monorepo/pull/164 to prevent duplicate wallet registration when the MetaMask browser extension is already installed and registered in the Solana wallet-standard registry. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1083

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
