### PR TITLE
fix: re-surface EIP-1193 error code on wagmi connector

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `EIP1193Provider.request()` now re-surfaces the original numeric RPC error code as `error.code` on the thrown error, matching the EIP-1193 error shape expected by dApps, wagmi, and ethers.js. Previously `error.code` was always `undefined`. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+
 ## [0.8.0]
 
 ### Changed

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `EIP1193Provider.request()` now re-surfaces the original numeric RPC error code as `error.code` on the thrown error, matching the EIP-1193 error shape expected by dApps, wagmi, and ethers.js. Previously `error.code` was always `undefined`. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
-
 ### Changed
 
 - Migrate `metamask_accountsChanged` and `metamask_chainChanged` subscriptions from `transport.onNotification()` to typed `core.on()`/`core.off()`, removing `@ts-expect-error` suppressions ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+
+### Fixed
+
+- `EIP1193Provider.request()` now re-surfaces the original numeric RPC error code as `error.code` on the thrown error, matching the EIP-1193 error shape expected by dApps, wagmi, and ethers.js. Previously `error.code` was always `undefined`. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
 
 ## [0.8.0]
 

--- a/packages/connect-evm/src/provider.test.ts
+++ b/packages/connect-evm/src/provider.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable @typescript-eslint/no-explicit-any -- mock core uses any for private options */
+import { RPCInvokeMethodErr } from '@metamask/connect-multichain';
+import { describe, it, expect, vi } from 'vitest';
+
+import { EIP1193Provider } from './provider';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createMockCore(
+  supportedNetworks: Record<string, string> = {
+    'eip155:1': 'https://rpc.example.com',
+  },
+) {
+  return {
+    invokeMethod: vi.fn(),
+    options: {
+      api: { supportedNetworks },
+    },
+  };
+}
+
+describe('EIP1193Provider', () => {
+  describe('#request', () => {
+    it('re-throws RPCInvokeMethodErr as an EIP-1193 error with the correct code', async () => {
+      const mockCore = createMockCore();
+      const provider = new EIP1193Provider(mockCore as any, vi.fn());
+      provider.selectedChainId = '0x1';
+
+      mockCore.invokeMethod.mockRejectedValue(
+        new RPCInvokeMethodErr(
+          'RPC Request failed with code 4001: User denied transaction signature.',
+          4001,
+          'User denied transaction signature.',
+        ),
+      );
+
+      await expect(
+        provider.request({ method: 'eth_sendTransaction', params: [] }),
+      ).rejects.toMatchObject({
+        message: 'User denied transaction signature.',
+        code: 4001,
+      });
+    });
+
+    it('preserves the rpcCode for internal errors (-32603)', async () => {
+      const mockCore = createMockCore();
+      const provider = new EIP1193Provider(mockCore as any, vi.fn());
+      provider.selectedChainId = '0x1';
+
+      mockCore.invokeMethod.mockRejectedValue(
+        new RPCInvokeMethodErr(
+          'RPC Request failed with code -32603: Internal error.',
+          -32603,
+          'Internal error.',
+        ),
+      );
+
+      await expect(
+        provider.request({ method: 'eth_getBalance', params: [] }),
+      ).rejects.toMatchObject({
+        message: 'Internal error.',
+        code: -32603,
+      });
+    });
+
+    it('propagates non-RPCInvokeMethodErr errors unchanged', async () => {
+      const mockCore = createMockCore();
+      const provider = new EIP1193Provider(mockCore as any, vi.fn());
+      provider.selectedChainId = '0x1';
+
+      const originalError = new Error('Something unexpected');
+      mockCore.invokeMethod.mockRejectedValue(originalError);
+
+      await expect(
+        provider.request({ method: 'eth_blockNumber', params: [] }),
+      ).rejects.toThrow('Something unexpected');
+    });
+
+    it('propagates RPCInvokeMethodErr without rpcCode unchanged', async () => {
+      const mockCore = createMockCore();
+      const provider = new EIP1193Provider(mockCore as any, vi.fn());
+      provider.selectedChainId = '0x1';
+
+      const err = new RPCInvokeMethodErr('some internal error');
+      mockCore.invokeMethod.mockRejectedValue(err);
+
+      await expect(
+        provider.request({ method: 'eth_blockNumber', params: [] }),
+      ).rejects.toBeInstanceOf(RPCInvokeMethodErr);
+    });
+  });
+});

--- a/packages/connect-evm/src/provider.test.ts
+++ b/packages/connect-evm/src/provider.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable @typescript-eslint/no-explicit-any -- mock core uses any for private options */
+/* eslint-disable @typescript-eslint/no-shadow -- Vitest globals */
 import { RPCInvokeMethodErr } from '@metamask/connect-multichain';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -81,8 +81,8 @@ describe('EIP1193Provider', () => {
       const provider = new EIP1193Provider(mockCore as any, vi.fn());
       provider.selectedChainId = '0x1';
 
-      const err = new RPCInvokeMethodErr('some internal error');
-      mockCore.invokeMethod.mockRejectedValue(err);
+      const rpcError = new RPCInvokeMethodErr('some internal error');
+      mockCore.invokeMethod.mockRejectedValue(rpcError);
 
       await expect(
         provider.request({ method: 'eth_blockNumber', params: [] }),

--- a/packages/connect-evm/src/provider.ts
+++ b/packages/connect-evm/src/provider.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises -- Legacy fire-and-forget pattern */
 /* eslint-disable jsdoc/require-returns -- Inherited from abstract class */
 import type { MultichainCore, Scope } from '@metamask/connect-multichain';
-import { EventEmitter } from '@metamask/connect-multichain';
+import { EventEmitter, RPCInvokeMethodErr } from '@metamask/connect-multichain';
 import { hexToNumber } from '@metamask/utils';
 
 import { INTERCEPTABLE_METHODS } from './constants';
@@ -94,13 +94,24 @@ export class EIP1193Provider extends EventEmitter<EIP1193ProviderEvents> {
       );
     }
 
-    return this.#core.invokeMethod({
-      scope,
-      request: {
-        method: request.method,
-        params: request.params,
-      },
-    });
+    try {
+      return await this.#core.invokeMethod({
+        scope,
+        request: {
+          method: request.method,
+          params: request.params,
+        },
+      });
+    } catch (error) {
+      if (error instanceof RPCInvokeMethodErr && error.rpcCode !== undefined) {
+        const rpcError = new Error(
+          error.rpcMessage ?? error.reason,
+        ) as Error & { code: number };
+        rpcError.code = error.rpcCode;
+        throw rpcError;
+      }
+      throw error;
+    }
   }
 
   // Getters and setters

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `RPCInvokeMethodErr` now carries the original numeric RPC code from the wallet (`rpcCode`) and the original wallet-facing message (`rpcMessage`) as separate fields, so higher layers can re-surface them without losing them inside internal error formatting. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
-- `RequestRouter` now propagates the numeric RPC error code from wallet response errors and transport exceptions into `RPCInvokeMethodErr`, ensuring the code is not dropped during error wrapping. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
-- `DefaultTransport` now attaches the numeric RPC code to errors produced from `window.postMessage` responses, so it survives the transport boundary. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
-
 ### Changed
 
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - Mark `@react-native-async-storage/async-storage` peer dependency as optional — web/Node consumers no longer pull in the React Native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
+
+### Fixed
+
+- `RPCInvokeMethodErr` now carries the original numeric RPC code from the wallet (`rpcCode`) and the original wallet-facing message (`rpcMessage`) as separate fields, so higher layers can re-surface them without losing them inside internal error formatting. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+- `RequestRouter` now propagates the numeric RPC error code from wallet response errors and transport exceptions into `RPCInvokeMethodErr`, ensuring the code is not dropped during error wrapping. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+- `DefaultTransport` now attaches the numeric RPC code to errors produced from `window.postMessage` responses, so it survives the transport boundary. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `RPCInvokeMethodErr` now carries the original numeric RPC code from the wallet (`rpcCode`) and the original wallet-facing message (`rpcMessage`) as separate fields, so higher layers can re-surface them without losing them inside internal error formatting. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+- `RequestRouter` now propagates the numeric RPC error code from wallet response errors and transport exceptions into `RPCInvokeMethodErr`, ensuring the code is not dropped during error wrapping. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+- `DefaultTransport` now attaches the numeric RPC code to errors produced from `window.postMessage` responses, so it survives the transport boundary. ([#232](https://github.com/MetaMask/connect-monorepo/pull/232))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/connect-multichain/src/domain/errors/rpc.ts
+++ b/packages/connect-multichain/src/domain/errors/rpc.ts
@@ -42,7 +42,11 @@ export class RPCReadonlyRequestErr extends BaseErr<'RPC', RPCErrorCodes> {
 export class RPCInvokeMethodErr extends BaseErr<'RPC', RPCErrorCodes> {
   static readonly code = 53;
 
-  constructor(public readonly reason: string) {
+  constructor(
+    public readonly reason: string,
+    public readonly rpcCode?: number,
+    public readonly rpcMessage?: string,
+  ) {
     super(
       `RPCErr${RPCInvokeMethodErr.code}: RPC Client invoke method reason (${reason})`,
       RPCInvokeMethodErr.code,

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -141,6 +141,46 @@ t.describe('RequestRouter', () => {
               );
           },
         );
+
+        t.it(
+          'should preserve the original RPC error code on RPCInvokeMethodErr when response contains an error',
+          async () => {
+            mockTransport.request.mockResolvedValue({
+              error: {
+                code: 4001,
+                message:
+                  'MetaMask Tx Signature: User denied transaction signature.',
+              },
+            });
+
+            await t
+              .expect(requestRouter.invokeMethod(baseOptions))
+              .rejects.toSatisfy((error: RPCInvokeMethodErr) => {
+                return (
+                  error instanceof RPCInvokeMethodErr && error.rpcCode === 4001
+                );
+              });
+          },
+        );
+
+        t.it(
+          'should preserve the original RPC error code when transport rejects with a coded error',
+          async () => {
+            const codedError = new Error(
+              'MetaMask Tx Signature: User denied transaction signature.',
+            ) as Error & { code: number };
+            codedError.code = 4001;
+            mockTransport.request.mockRejectedValue(codedError);
+
+            await t
+              .expect(requestRouter.invokeMethod(baseOptions))
+              .rejects.toSatisfy((error: RPCInvokeMethodErr) => {
+                return (
+                  error instanceof RPCInvokeMethodErr && error.rpcCode === 4001
+                );
+              });
+          },
+        );
       },
     );
   });

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -104,6 +104,8 @@ export class RequestRouter {
         const { error } = response;
         throw new RPCInvokeMethodErr(
           `RPC Request failed with code ${error.code}: ${error.message}`,
+          error.code,
+          error.message,
         );
       }
 
@@ -141,7 +143,8 @@ export class RequestRouter {
       if (error instanceof RPCInvokeMethodErr) {
         throw error;
       }
-      throw new RPCInvokeMethodErr(error.message);
+      const err = error as { message?: string; code?: number };
+      throw new RPCInvokeMethodErr(err.message ?? 'Unknown error', err.code);
     }
   }
 

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -143,8 +143,11 @@ export class RequestRouter {
       if (error instanceof RPCInvokeMethodErr) {
         throw error;
       }
-      const err = error as { message?: string; code?: number };
-      throw new RPCInvokeMethodErr(err.message ?? 'Unknown error', err.code);
+      const castError = error as { message?: string; code?: number };
+      throw new RPCInvokeMethodErr(
+        castError.message ?? 'Unknown error',
+        castError.code,
+      );
     }
   }
 

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -94,9 +94,16 @@ export class DefaultTransport implements ExtendedTransport {
 
         const response = responseData as TransportResponse;
         if ('error' in response && response.error) {
-          pendingRequest.reject(
-            new Error(response.error.message || 'Request failed'),
-          );
+          // Attach the numeric RPC code so it survives the transport boundary
+          // and can be re-surfaced as an EIP-1193 error by higher layers.
+          // This path is exercised by sendEip1193Message callers.
+          const error = new Error(
+            response.error.message || 'Request failed',
+          ) as Error & { code?: number };
+          if (typeof response.error.code === 'number') {
+            error.code = response.error.code;
+          }
+          pendingRequest.reject(error);
         } else {
           pendingRequest.resolve(response);
         }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When a wallet RPC call fails (e.g. the user rejects a transaction with code `4001`), the numeric error code was being swallowed inside the internal `RPCInvokeMethodErr` class and never made it back to the EIP-1193 `provider.request()` caller. dApps and connectors (wagmi, ethers.js, etc.) rely on `error.code` to distinguish user rejections from network failures and internal errors.

This fix threads the original numeric RPC code through every layer — transport → router → provider boundary — and re-surfaces it as a proper EIP-1193 error shape (`{ message, code }`) at `EIP1193Provider.request()`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: [WAPI-1265](https://consensyssoftware.atlassian.net/browse/WAPI-1265)

## Testing steps

- Install and build: `yarn && yarn build`
- Start playground: `yarn workspace @metamask/browser-playground start`
- Select Ethereum
- Click Connect Wagmi
- Fill the Send Transaction inputs and click it
- Reject the transaction
- Should see the correct error message instead of `Unknown RPC error`

## After


https://github.com/user-attachments/assets/36df4e48-9292-407e-b108-56e02a5f271d



## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
