### PR TITLE
fix: mark @react-native-async-storage/async-storage peer dep as optional

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Mark `@react-native-async-storage/async-storage` peer dependency as optional to prevent web/node consumers from pulling in the entire react-native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
-
 ### Changed
 
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+
+### Fixed
+
+- Mark `@react-native-async-storage/async-storage` peer dependency as optional to prevent web/node consumers from pulling in the entire react-native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Mark `@react-native-async-storage/async-storage` peer dependency as optional to prevent web/node consumers from pulling in the entire react-native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
+
 ### Changed
 
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -12,10 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
-
-### Fixed
-
-- Mark `@react-native-async-storage/async-storage` peer dependency as optional to prevent web/node consumers from pulling in the entire react-native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
+- Mark `@react-native-async-storage/async-storage` peer dependency as optional — web/Node consumers no longer pull in the React Native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -110,6 +110,11 @@
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.23"
   },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/connect-multichain/src/index.native.ts
+++ b/packages/connect-multichain/src/index.native.ts
@@ -20,7 +20,15 @@ export const createMultichainClient: CreateMultichainFN = async (options) => {
   if (options.storage) {
     storage = options.storage;
   } else {
-    const { StoreAdapterRN } = await import('./store/adapters/rn');
+    let StoreAdapterRN;
+    try {
+      ({ StoreAdapterRN } = await import('./store/adapters/rn'));
+    } catch {
+      throw new Error(
+        '@metamask/connect-multichain: @react-native-async-storage/async-storage is required for React Native. ' +
+          'Install it with: npm install @react-native-async-storage/async-storage',
+      );
+    }
     const adapter = new StoreAdapterRN();
     storage = new Store(adapter);
   }

--- a/packages/connect-multichain/src/index.native.ts
+++ b/packages/connect-multichain/src/index.native.ts
@@ -26,8 +26,8 @@ export const createMultichainClient: CreateMultichainFN = async (options) => {
     } catch (error) {
       throw new Error(
         '@metamask/connect-multichain: @react-native-async-storage/async-storage is required for React Native. ' +
-          'Install it with: npm install @react-native-async-storage/async-storage',
-        { cause: error },
+          'Install it with: npm install @react-native-async-storage/async-storage\n' +
+          `Original error: ${error instanceof Error ? error.message : error}`,
       );
     }
     const adapter = new StoreAdapterRN();

--- a/packages/connect-multichain/src/index.native.ts
+++ b/packages/connect-multichain/src/index.native.ts
@@ -23,10 +23,11 @@ export const createMultichainClient: CreateMultichainFN = async (options) => {
     let StoreAdapterRN;
     try {
       ({ StoreAdapterRN } = await import('./store/adapters/rn'));
-    } catch {
+    } catch (error) {
       throw new Error(
         '@metamask/connect-multichain: @react-native-async-storage/async-storage is required for React Native. ' +
           'Install it with: npm install @react-native-async-storage/async-storage',
+        { cause: error },
       );
     }
     const adapter = new StoreAdapterRN();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,6 +4186,9 @@ __metadata:
     ws: "npm:^8.18.3"
   peerDependencies:
     "@react-native-async-storage/async-storage": ^1.23
+  peerDependenciesMeta:
+    "@react-native-async-storage/async-storage":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Adds `peerDependenciesMeta` to `@metamask/connect-multichain` marking `@react-native-async-storage/async-storage` as `optional: true`
- The async-storage peer dependency is only used by the React Native build entry (`index.native.ts` → `store/adapters/rn.ts`). Browser and Node entry points (`index.browser.ts`, `index.node.ts`) never import it.
- Without the optional flag, package managers like pnpm eagerly resolve this peer dep, pulling in the **entire** `react-native` CLI/dev toolchain (`@react-native/debugger-frontend`, `chrome-launcher`, `chromium-edge-launcher`, `metro`, etc.) for web consumers
- This triggers 20+ false-positive security alerts from Socket on downstream PRs (e.g. [metamask-connect-examples#2](https://github.com/MetaMask/metamask-connect-examples/pull/2))

### Dependency chain causing alerts

```
@metamask/connect-evm
  → @metamask/connect-multichain
    ← @react-native-async-storage/async-storage (PEER DEP, not optional)
      → react-native@0.84.1
        → @react-native/community-cli-plugin
          → @react-native/dev-middleware
            → @react-native/debugger-frontend  ← HIGH: "obfuscated code"
            → chrome-launcher                  ← shell + network alerts
            → chromium-edge-launcher           ← shell + network alerts
```

### Why this is safe

1. The browser build entry (`src/index.browser.ts`) dynamically imports `store/adapters/web.ts` — never `rn.ts`
2. The node build entry (`src/index.node.ts`) dynamically imports `store/adapters/node.ts` — never `rn.ts`
3. Only `src/index.native.ts` imports the RN adapter
4. The tsup config already marks `@react-native-async-storage/async-storage` as external in all build targets
5. React Native consumers who actually need it will already have it installed as part of their RN project

## Test plan

- [x] Verify browser/node builds are unaffected (no import of async-storage)
- [ ] Verify React Native build still resolves async-storage when it's installed
- [ ] Regenerate lockfile in a web consumer (e.g. examples repo) and confirm react-native subtree is gone