### PR TITLE
feat: add solana getInfuraRpcUrls

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
-- `getInfuraRpcUrls` now includes Solana mainnet and devnet CAIP chain IDs in the generated RPC URL map.
+- `getInfuraRpcUrls` now includes Solana mainnet and devnet CAIP chain IDs in the generated RPC URL map ([#235](https://github.com/MetaMask/connect-monorepo/pull/235))
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DefaultTransport` now forwards all wallet notifications instead of filtering to only `metamask_chainChanged` and `metamask_accountsChanged`, matching `MWPTransport` behavior ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `stateChanged` is now emitted via the `EventEmitter` so `client.on('stateChanged', cb)` fires correctly ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
+- `getInfuraRpcUrls` now includes Solana mainnet and devnet CAIP chain IDs in the generated RPC URL map.
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/src/domain/multichain/api/constants.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/constants.ts
@@ -64,9 +64,11 @@ export const infuraRpcUrls: RpcUrlsMap = {
   'eip155:44787': 'https://celo-alfajores.infura.io/v3/',
   // ###### Solana ######
   // Mainnet
-  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'https://solana-mainnet.infura.io/v3/',
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp':
+    'https://solana-mainnet.infura.io/v3/',
   // Devnet
-  'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1': 'https://solana-devnet.infura.io/v3/',
+  'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1':
+    'https://solana-devnet.infura.io/v3/',
 };
 
 // Methods that are passed through to the RPC node

--- a/packages/connect-multichain/src/domain/multichain/api/constants.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/constants.ts
@@ -62,6 +62,11 @@ export const infuraRpcUrls: RpcUrlsMap = {
   'eip155:42220': 'https://celo-mainnet.infura.io/v3/',
   // Alfajores Testnet
   'eip155:44787': 'https://celo-alfajores.infura.io/v3/',
+  // ###### Solana ######
+  // Mainnet
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'https://solana-mainnet.infura.io/v3/',
+  // Devnet
+  'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1': 'https://solana-devnet.infura.io/v3/',
 };
 
 // Methods that are passed through to the RPC node

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -108,9 +108,9 @@ t.describe('MultichainCore', () => {
       t.expect(opts.api.supportedNetworks['eip155:11155111']).toBe(
         'https://eth.sepolia.example',
       );
-      t.expect(opts.api.supportedNetworks['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe(
-        'https://solana.example',
-      );
+      t.expect(
+        opts.api.supportedNetworks['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+      ).toBe('https://solana.example');
     });
 
     t.it(

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -96,7 +96,7 @@ t.describe('MultichainCore', () => {
         api: {
           supportedNetworks: {
             'eip155:1': 'https://overridden.example',
-            'solana:mainnet': 'https://solana.example',
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'https://solana.example',
           },
         },
       });
@@ -108,7 +108,7 @@ t.describe('MultichainCore', () => {
       t.expect(opts.api.supportedNetworks['eip155:11155111']).toBe(
         'https://eth.sepolia.example',
       );
-      t.expect(opts.api.supportedNetworks['solana:mainnet']).toBe(
+      t.expect(opts.api.supportedNetworks['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe(
         'https://solana.example',
       );
     });

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `getInfuraRpcUrls({ infuraApiKey, networks })` helper to generate Solana `supportedNetworks` entries (mainnet/devnet) for `createSolanaClient`.
+
 ## [0.6.0]
 
 ### Fixed

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `getInfuraRpcUrls({ infuraApiKey, networks })` helper to generate Solana `supportedNetworks` entries (mainnet/devnet) for `createSolanaClient`.
+- Add `getInfuraRpcUrls({ infuraApiKey, networks })` helper to generate Solana `supportedNetworks` entries (mainnet/devnet) for `createSolanaClient` ([#235](https://github.com/MetaMask/connect-monorepo/pull/235))
 
 ## [0.6.0]
 

--- a/packages/connect-solana/README.md
+++ b/packages/connect-solana/README.md
@@ -123,9 +123,9 @@ Generates Solana Infura RPC URLs keyed by Solana network name. The return value 
 
 #### Parameters
 
-| Name           | Type              | Required | Description                                                        |
-| -------------- | ----------------- | -------- | ------------------------------------------------------------------ |
-| `infuraApiKey` | `string`          | Yes      | Your Infura API key                                                |
+| Name           | Type              | Required | Description                                                       |
+| -------------- | ----------------- | -------- | ----------------------------------------------------------------- |
+| `infuraApiKey` | `string`          | Yes      | Your Infura API key                                               |
 | `networks`     | `SolanaNetwork[]` | Yes      | Solana networks to include (for example, `['mainnet', 'devnet']`) |
 
 #### Returns

--- a/packages/connect-solana/README.md
+++ b/packages/connect-solana/README.md
@@ -26,7 +26,9 @@ npm install @metamask/connect-solana
 ## Quick Start
 
 ```typescript
-import { createSolanaClient } from '@metamask/connect-solana';
+import { createSolanaClient, getInfuraRpcUrls } from '@metamask/connect-solana';
+
+const INFURA_API_KEY = 'YOUR_INFURA_API_KEY';
 
 // Create a Solana client
 // MetaMask is automatically registered with the wallet-standard registry on creation
@@ -34,6 +36,12 @@ const client = await createSolanaClient({
   dapp: {
     name: 'My Solana DApp',
     url: 'https://mydapp.com',
+  },
+  api: {
+    supportedNetworks: getInfuraRpcUrls({
+      infuraApiKey: INFURA_API_KEY,
+      networks: ['mainnet', 'devnet'],
+    }),
   },
 });
 ```
@@ -106,6 +114,37 @@ Creates a new Solana client instance. By default, the wallet is automatically re
 #### Returns
 
 `Promise<SolanaClient>`
+
+---
+
+### `getInfuraRpcUrls(options)`
+
+Generates Solana Infura RPC URLs keyed by Solana network name. The return value can be passed directly to `createSolanaClient({ api: { supportedNetworks } })`.
+
+#### Parameters
+
+| Name           | Type              | Required | Description                                                        |
+| -------------- | ----------------- | -------- | ------------------------------------------------------------------ |
+| `infuraApiKey` | `string`          | Yes      | Your Infura API key                                                |
+| `networks`     | `SolanaNetwork[]` | Yes      | Solana networks to include (for example, `['mainnet', 'devnet']`) |
+
+#### Returns
+
+`SolanaSupportedNetworks`
+
+```typescript
+import { getInfuraRpcUrls } from '@metamask/connect-solana';
+
+const supportedNetworks = getInfuraRpcUrls({
+  infuraApiKey: 'YOUR_INFURA_API_KEY',
+  networks: ['mainnet', 'devnet'],
+});
+
+// {
+//   mainnet: 'https://solana-mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
+//   devnet: 'https://solana-devnet.infura.io/v3/YOUR_INFURA_API_KEY',
+// }
+```
 
 ---
 

--- a/packages/connect-solana/src/index.ts
+++ b/packages/connect-solana/src/index.ts
@@ -1,3 +1,4 @@
+export { getInfuraRpcUrls } from './infura';
 export { createSolanaClient } from './connect';
 export type {
   SolanaClient,

--- a/packages/connect-solana/src/infura.test.ts
+++ b/packages/connect-solana/src/infura.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-shadow -- Vitest globals */
 import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 

--- a/packages/connect-solana/src/infura.test.ts
+++ b/packages/connect-solana/src/infura.test.ts
@@ -1,0 +1,49 @@
+import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { getInfuraRpcUrls } from './infura';
+
+describe('getInfuraRpcUrls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns only requested Solana networks for createSolanaClient', () => {
+    (getInfuraRpcUrlsMultichain as ReturnType<typeof vi.fn>).mockReturnValue({
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp':
+        'https://solana-mainnet.infura.io/v3/test-key',
+      'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1':
+        'https://solana-devnet.infura.io/v3/test-key',
+    });
+
+    const result = getInfuraRpcUrls({
+      infuraApiKey: 'test-key',
+      networks: ['mainnet'],
+    });
+
+    expect(getInfuraRpcUrlsMultichain).toHaveBeenCalledWith({
+      infuraApiKey: 'test-key',
+      caipChainIds: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+    });
+    expect(result).toStrictEqual({
+      mainnet: 'https://solana-mainnet.infura.io/v3/test-key',
+    });
+  });
+
+  it('omits unsupported requested networks from the returned map', () => {
+    (getInfuraRpcUrlsMultichain as ReturnType<typeof vi.fn>).mockReturnValue({
+      'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1':
+        'https://solana-devnet.infura.io/v3/test-key',
+      'eip155:1': 'https://eth.mainnet.infura.io/v3/test-key',
+    });
+
+    const result = getInfuraRpcUrls({
+      infuraApiKey: 'test-key',
+      networks: ['mainnet', 'devnet', 'testnet'],
+    });
+
+    expect(result).toStrictEqual({
+      devnet: 'https://solana-devnet.infura.io/v3/test-key',
+    });
+  });
+});

--- a/packages/connect-solana/src/infura.ts
+++ b/packages/connect-solana/src/infura.ts
@@ -1,0 +1,37 @@
+import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
+
+import { SOLANA_CAIP_IDS } from './networks';
+import type { SolanaNetwork, SolanaSupportedNetworks } from './types';
+
+/**
+ * Generates Infura RPC URLs for Solana networks keyed by Solana network name.
+ *
+ * The returned map is intended for `createSolanaClient({ api: { supportedNetworks } })`.
+ *
+ * @param options - The options for generating Solana Infura RPC URLs
+ * @param options.infuraApiKey - The Infura API key
+ * @param options.networks - Solana networks to include in the returned map
+ * @returns A map of Solana network names to Infura RPC URLs
+ */
+export const getInfuraRpcUrls = ({
+  infuraApiKey,
+  networks,
+}: {
+  infuraApiKey: string;
+  networks: SolanaNetwork[];
+}): SolanaSupportedNetworks => {
+  const caipChainIds = networks.map((network) => SOLANA_CAIP_IDS[network]);
+  const caipMap = getInfuraRpcUrlsMultichain({
+    infuraApiKey,
+    caipChainIds,
+  });
+
+  return networks.reduce<SolanaSupportedNetworks>((acc, network) => {
+    const caipId = SOLANA_CAIP_IDS[network];
+    const rpcUrl = caipMap[caipId];
+    if (rpcUrl) {
+      acc[network] = rpcUrl;
+    }
+    return acc;
+  }, {});
+};

--- a/packages/connect-solana/src/infura.ts
+++ b/packages/connect-solana/src/infura.ts
@@ -1,4 +1,5 @@
 import { getInfuraRpcUrls as getInfuraRpcUrlsMultichain } from '@metamask/connect-multichain';
+import type { CaipChainId } from '@metamask/utils';
 
 import { SOLANA_CAIP_IDS } from './networks';
 import type { SolanaNetwork, SolanaSupportedNetworks } from './types';
@@ -20,14 +21,16 @@ export const getInfuraRpcUrls = ({
   infuraApiKey: string;
   networks: SolanaNetwork[];
 }): SolanaSupportedNetworks => {
-  const caipChainIds = networks.map((network) => SOLANA_CAIP_IDS[network]);
+  const caipChainIds = networks.map(
+    (network) => SOLANA_CAIP_IDS[network] as CaipChainId,
+  );
   const caipMap = getInfuraRpcUrlsMultichain({
     infuraApiKey,
     caipChainIds,
   });
 
   return networks.reduce<SolanaSupportedNetworks>((acc, network) => {
-    const caipId = SOLANA_CAIP_IDS[network];
+    const caipId = SOLANA_CAIP_IDS[network] as CaipChainId;
     const rpcUrl = caipMap[caipId];
     if (rpcUrl) {
       acc[network] = rpcUrl;

--- a/packages/connect-solana/src/mocks/connect-multichain.ts
+++ b/packages/connect-solana/src/mocks/connect-multichain.ts
@@ -1,3 +1,4 @@
 import { vi } from 'vitest';
 
 export const createMultichainClient = vi.fn();
+export const getInfuraRpcUrls = vi.fn();


### PR DESCRIPTION
## Explanation

- `connect-multichain` `getInfuraRpcUrls()` now includes solana mainnet and devnet rpc urls
- `connect-solana` has a new `getInfuraRpcUrls()` that accepts `SolanaNetwork` string values and returns `Record<SolanaNetwork, string>` intended for usage with `createSolanaClient()`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
