### PR TITLE
feat: Update Infura RPC Url Constants

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - Mark `@react-native-async-storage/async-storage` peer dependency as optional — web/Node consumers no longer pull in the React Native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
 - `getInfuraRpcUrls` now includes Solana mainnet and devnet CAIP chain IDs in the generated RPC URL map ([#235](https://github.com/MetaMask/connect-monorepo/pull/235))
-- Updated `infuraRpcUrls` to align with Infura's currently supported networks by removing deprecated testnets (Goerli variants, Mumbai, Palm testnet, Aurora) and adding new mainnet/testnet coverage across Base, Blast, zkSync, BSC/opBNB, Scroll, Mantle, Sei, Swellchain, Unichain, Hemi, MegaETH, Monad, and Celo Sepolia
+- Updated `infuraRpcUrls` to align with Infura's currently supported networks by removing deprecated testnets (Goerli variants, Mumbai, Palm testnet, Aurora) and adding new mainnet/testnet coverage across Base, Blast, zkSync, BSC/opBNB, Scroll, Mantle, Sei, Swellchain, Unichain, Hemi, MegaETH, Monad, and Celo Sepolia ([#237](https://github.com/MetaMask/connect-monorepo/pull/237))
 
 ### Fixed
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SDKEvents` type now includes explicit entries for `metamask_accountsChanged`, `metamask_chainChanged`, and `stateChanged` ([#230](https://github.com/MetaMask/connect-monorepo/pull/230))
 - Mark `@react-native-async-storage/async-storage` peer dependency as optional — web/Node consumers no longer pull in the React Native toolchain ([#234](https://github.com/MetaMask/connect-monorepo/pull/234))
 - `getInfuraRpcUrls` now includes Solana mainnet and devnet CAIP chain IDs in the generated RPC URL map ([#235](https://github.com/MetaMask/connect-monorepo/pull/235))
+- Updated `infuraRpcUrls` to align with Infura's currently supported networks by removing deprecated testnets (Goerli variants, Mumbai, Palm testnet, Aurora) and adding new mainnet/testnet coverage across Base, Blast, zkSync, BSC/opBNB, Scroll, Mantle, Sei, Swellchain, Unichain, Hemi, MegaETH, Monad, and Celo Sepolia
 
 ## [0.10.0]
 

--- a/packages/connect-multichain/src/domain/multichain/api/constants.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/constants.ts
@@ -5,35 +5,98 @@ export const infuraRpcUrls: RpcUrlsMap = {
   // ###### Ethereum ######
   // Mainnet
   'eip155:1': 'https://mainnet.infura.io/v3/',
-  // Goerli
-  'eip155:5': 'https://goerli.infura.io/v3/',
   // Sepolia 11155111
   'eip155:11155111': 'https://sepolia.infura.io/v3/',
+  // Hoodi
+  'eip155:560048': 'https://hoodi.infura.io/v3/',
   // ###### Linea ######
   // Mainnet Alpha
   'eip155:59144': 'https://linea-mainnet.infura.io/v3/',
-  // Testnet ( linea goerli )
-  'eip155:59140': 'https://linea-goerli.infura.io/v3/',
+  // Sepolia
+  'eip155:59141': 'https://linea-sepolia.infura.io/v3/',
   // ###### Polygon ######
   // Mainnet
   'eip155:137': 'https://polygon-mainnet.infura.io/v3/',
-  // Mumbai
-  'eip155:80001': 'https://polygon-mumbai.infura.io/v3/',
+  // Amoy
+  'eip155:80002': 'https://polygon-amoy.infura.io/v3/',
   // ###### Optimism ######
   // Mainnet
   'eip155:10': 'https://optimism-mainnet.infura.io/v3/',
-  // Goerli
-  'eip155:420': 'https://optimism-goerli.infura.io/v3/',
+  // Sepolia
+  'eip155:11155420': 'https://optimism-sepolia.infura.io/v3/',
   // ###### Arbitrum ######
   // Mainnet
   'eip155:42161': 'https://arbitrum-mainnet.infura.io/v3/',
-  // Goerli
-  'eip155:421613': 'https://arbitrum-goerli.infura.io/v3/',
+  // Sepolia
+  'eip155:421614': 'https://arbitrum-sepolia.infura.io/v3/',
+  // ###### Base ######
+  // Mainnet
+  'eip155:8453': 'https://base-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:84532': 'https://base-sepolia.infura.io/v3/',
+  // ###### Blast ######
+  // Mainnet
+  'eip155:81457': 'https://blast-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:168587773': 'https://blast-sepolia.infura.io/v3/',
+  // ###### zkSync ######
+  // Mainnet
+  'eip155:324': 'https://zksync-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:300': 'https://zksync-sepolia.infura.io/v3/',
+  // ###### BSC ######
+  // Mainnet
+  'eip155:56': 'https://bsc-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:97': 'https://bsc-testnet.infura.io/v3/',
+  // ###### opBNB ######
+  // Mainnet
+  'eip155:204': 'https://opbnb-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:5611': 'https://opbnb-testnet.infura.io/v3/',
+  // ###### Scroll ######
+  // Mainnet
+  'eip155:534352': 'https://scroll-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:534351': 'https://scroll-sepolia.infura.io/v3/',
+  // ###### Mantle ######
+  // Mainnet
+  'eip155:5000': 'https://mantle-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:5003': 'https://mantle-sepolia.infura.io/v3/',
+  // ###### Sei ######
+  // Mainnet
+  'eip155:1329': 'https://sei-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:713715': 'https://sei-testnet.infura.io/v3/',
+  // ###### Swellchain ######
+  // Mainnet
+  'eip155:1923': 'https://swellchain-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:1924': 'https://swellchain-testnet.infura.io/v3/',
+  // ###### Unichain ######
+  // Mainnet
+  'eip155:130': 'https://unichain-mainnet.infura.io/v3/',
+  // Sepolia
+  'eip155:1301': 'https://unichain-sepolia.infura.io/v3/',
+  // ###### Hemi ######
+  // Mainnet
+  'eip155:43111': 'https://hemi-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:743111': 'https://hemi-testnet.infura.io/v3/',
+  // ###### MegaETH ######
+  // Mainnet
+  'eip155:6342': 'https://megaeth-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:6342001': 'https://megaeth-testnet.infura.io/v3/',
+  // ###### Monad ######
+  // Mainnet
+  'eip155:143': 'https://monad-mainnet.infura.io/v3/',
+  // Testnet
+  'eip155:10143': 'https://monad-testnet.infura.io/v3/',
   // ###### Palm ######
   // Mainnet
   'eip155:11297108109': 'https://palm-mainnet.infura.io/v3/',
-  // Testnet
-  'eip155:11297108099': 'https://palm-testnet.infura.io/v3/',
   // ###### Avalanche C-Chain ######
   // Mainnet
   'eip155:43114': 'https://avalanche-mainnet.infura.io/v3/',
@@ -44,11 +107,6 @@ export const infuraRpcUrls: RpcUrlsMap = {
   // 'near:mainnet': `https://near-mainnet.infura.io/v3/`,
   // // Testnet
   // 'near:testnet': `https://near-testnet.infura.io/v3/`,
-  // ###### Aurora ######
-  // Mainnet
-  'eip155:1313161554': 'https://aurora-mainnet.infura.io/v3/',
-  // Testnet
-  'eip155:1313161555': 'https://aurora-testnet.infura.io/v3/',
   // ###### StarkNet ######
   // Mainnet
   //
@@ -60,8 +118,8 @@ export const infuraRpcUrls: RpcUrlsMap = {
   // ###### Celo ######
   // Mainnet
   'eip155:42220': 'https://celo-mainnet.infura.io/v3/',
-  // Alfajores Testnet
-  'eip155:44787': 'https://celo-alfajores.infura.io/v3/',
+  // Sepolia
+  'eip155:44787': 'https://celo-sepolia.infura.io/v3/',
   // ###### Solana ######
   // Mainnet
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp':


### PR DESCRIPTION
## Explanation

Update the infuraRpcUrls map in connect-multichain package to align with the current networks available via Infura's dashboard. This removes deprecated testnets and adds newly supported networks.

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1282

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
