### PR TITLE
fix: allow MWP to accept subsequent connect requests

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `wallet_requestPermissions` now correctly re-prompts account selection on MWP (mobile) without requiring a full disconnect/reconnect cycle. The request forwards `forceRequest: true` through to `MWPTransport`, which previously ignored it and silently returned the existing session. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
+- `wallet_requestPermissions` now uses the current session's chain IDs when re-prompting, instead of hardcoding mainnet (`0x1`). This preserves scope parity with the original connection. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
+- `#onSessionChanged` now always derives accounts from session scopes via `getEthAccounts()` rather than making an `eth_accounts` RPC call when connected. On MWP, the `eth_accounts` cache may not yet reflect the updated session at the time `wallet_sessionChanged` fires, causing stale accounts to be emitted. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
+
 ## [0.9.0]
 
 ### Changed

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `wallet_requestPermissions` now correctly re-prompts account selection on MWP (mobile) without requiring a full disconnect/reconnect cycle. The request forwards `forceRequest: true` through to `MWPTransport`, which previously ignored it and silently returned the existing session. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
-- `wallet_requestPermissions` now uses the current session's chain IDs when re-prompting, instead of hardcoding mainnet (`0x1`). This preserves scope parity with the original connection. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
-- `#onSessionChanged` now always derives accounts from session scopes via `getEthAccounts()` rather than making an `eth_accounts` RPC call when connected. On MWP, the `eth_accounts` cache may not yet reflect the updated session at the time `wallet_sessionChanged` fires, causing stale accounts to be emitted. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
 
 ## [0.9.0]
 

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -195,15 +195,10 @@ describe('MetamaskConnectEVM', () => {
         );
       });
 
-      it('connects using accounts from a eth_accounts response when the MultichainClient is connected', async () => {
+      it('connects using accounts from session scopes when the MultichainClient is connected', async () => {
         const mockCore = createMockCore();
         mockCore._status = 'connected';
         mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
-        mockCore.transport.sendEip1193Message.mockResolvedValue({
-          result: ['0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'],
-          id: 1,
-          jsonrpc: '2.0',
-        });
 
         const client = await MetamaskConnectEVM.create({ core: mockCore });
 
@@ -228,9 +223,9 @@ describe('MetamaskConnectEVM', () => {
         const connectData = await connectPromise;
         expect(connectData.chainId).toBe('0x1');
         expect(connectData.accounts).toContain(
-          '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          '0x1234567890123456789012345678901234567890',
         );
-        expect(mockCore.transport.sendEip1193Message).toHaveBeenCalledWith({
+        expect(mockCore.transport.sendEip1193Message).not.toHaveBeenCalledWith({
           method: 'eth_accounts',
           params: [],
         });
@@ -473,6 +468,53 @@ describe('MetamaskConnectEVM', () => {
       expect(mockCore.invokeMethod).toHaveBeenCalledWith(
         expect.objectContaining({ scope: 'eip155:137' }),
       );
+    });
+  });
+
+  describe('#requestInterceptor', () => {
+    it('wallet_requestPermissions uses session chain IDs when session exists', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x89'));
+
+      // First establish a session with multiple chains
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0xabc0000000000000000000000000000000000001'],
+            },
+            'eip155:137': {
+              methods: [],
+              notifications: [],
+              accounts: [
+                'eip155:137:0xabc0000000000000000000000000000000000001',
+              ],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      // Initial connect to establish session scopes
+      await client.connect({ chainIds: ['0x89', '0x1'] });
+
+      // Now call wallet_requestPermissions — should use session chain IDs
+      await client.getProvider().request({
+        method: 'wallet_requestPermissions',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
+      });
+
+      // The second connect call (from requestInterceptor) should include
+      // the session chain IDs, not just DEFAULT_CHAIN_ID
+      const secondConnectCall = mockCore.connect.mock.calls[1];
+      const scopes = secondConnectCall[0] as string[];
+      expect(scopes).toContain('eip155:1');
+      expect(scopes).toContain('eip155:137');
     });
   });
 

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -512,6 +512,46 @@ describe('MetamaskConnectEVM', () => {
       const forceRequestArg = secondConnectCall[3];
       expect(forceRequestArg).toBe(true);
     });
+
+    it('wallet_requestPermissions keeps cached chain first in chainIds when still permitted', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x89'));
+
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0xabc0000000000000000000000000000000000001'],
+            },
+            'eip155:137': {
+              methods: [],
+              notifications: [],
+              accounts: [
+                'eip155:137:0xabc0000000000000000000000000000000000001',
+              ],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await client.connect({ chainIds: ['0x89', '0x1'] });
+
+      await client.getProvider().request({
+        method: 'wallet_requestPermissions',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
+      });
+
+      const secondConnectCall = mockCore.connect.mock.calls[1];
+      const scopes = secondConnectCall[0] as string[];
+      expect(scopes[0]).toBe('eip155:137');
+      expect(scopes).toContain('eip155:1');
+    });
   });
 
   describe('disconnect', () => {

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -195,10 +195,15 @@ describe('MetamaskConnectEVM', () => {
         );
       });
 
-      it('connects using accounts from session scopes when the MultichainClient is connected', async () => {
+      it('connects using accounts from a eth_accounts response when the MultichainClient is connected', async () => {
         const mockCore = createMockCore();
         mockCore._status = 'connected';
         mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+        mockCore.transport.sendEip1193Message.mockResolvedValue({
+          result: ['0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'],
+          id: 1,
+          jsonrpc: '2.0',
+        });
 
         const client = await MetamaskConnectEVM.create({ core: mockCore });
 
@@ -223,9 +228,9 @@ describe('MetamaskConnectEVM', () => {
         const connectData = await connectPromise;
         expect(connectData.chainId).toBe('0x1');
         expect(connectData.accounts).toContain(
-          '0x1234567890123456789012345678901234567890',
+          '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
         );
-        expect(mockCore.transport.sendEip1193Message).not.toHaveBeenCalledWith({
+        expect(mockCore.transport.sendEip1193Message).toHaveBeenCalledWith({
           method: 'eth_accounts',
           params: [],
         });
@@ -472,11 +477,11 @@ describe('MetamaskConnectEVM', () => {
   });
 
   describe('#requestInterceptor', () => {
-    it('wallet_requestPermissions uses session chain IDs when session exists', async () => {
+    it('wallet_requestPermissions passes forceRequest: true to core.connect', async () => {
       const mockCore = createMockCore();
-      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x89'));
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
 
-      // First establish a session with multiple chains
+      // Establish a session on connect
       mockCore.connect.mockImplementation(async (): Promise<void> => {
         const session: SessionData = {
           sessionScopes: {
@@ -485,13 +490,6 @@ describe('MetamaskConnectEVM', () => {
               notifications: [],
               accounts: ['eip155:1:0xabc0000000000000000000000000000000000001'],
             },
-            'eip155:137': {
-              methods: [],
-              notifications: [],
-              accounts: [
-                'eip155:137:0xabc0000000000000000000000000000000000001',
-              ],
-            },
           },
         };
         mockCore.emit('wallet_sessionChanged', session);
@@ -499,22 +497,20 @@ describe('MetamaskConnectEVM', () => {
 
       const client = await MetamaskConnectEVM.create({ core: mockCore });
 
-      // Initial connect to establish session scopes
-      await client.connect({ chainIds: ['0x89', '0x1'] });
+      // Initial connect
+      await client.connect({ chainIds: ['0x1'] });
 
-      // Now call wallet_requestPermissions — should use session chain IDs
+      // Call wallet_requestPermissions — should force a new request
       await client.getProvider().request({
         method: 'wallet_requestPermissions',
         // eslint-disable-next-line @typescript-eslint/naming-convention
         params: [{ eth_accounts: {} }],
       });
 
-      // The second connect call (from requestInterceptor) should include
-      // the session chain IDs, not just DEFAULT_CHAIN_ID
+      // The second connect call (from requestInterceptor) should pass forceRequest=true
       const secondConnectCall = mockCore.connect.mock.calls[1];
-      const scopes = secondConnectCall[0] as string[];
-      expect(scopes).toContain('eip155:1');
-      expect(scopes).toContain('eip155:137');
+      const forceRequestArg = secondConnectCall[3];
+      expect(forceRequestArg).toBe(true);
     });
   });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -617,14 +617,27 @@ export class MetamaskConnectEVM {
         request.method === 'wallet_requestPermissions';
 
       const { method, params } = request;
-      const initiallySelectedChainId = DEFAULT_CHAIN_ID;
-      const scope: Scope = `eip155:${initiallySelectedChainId}`;
+      const permitted = getPermittedEthChainIds(this.#sessionScopes);
+      if (permitted.length === 0) {
+        permitted.push(DEFAULT_CHAIN_ID);
+      }
+
+      const selected = this.#provider.selectedChainId;
+      const preferred =
+        selected && permitted.includes(selected) ? selected : permitted[0];
+
+      const chainIds = [
+        preferred,
+        ...permitted.filter((id) => id !== preferred),
+      ];
+
+      const scope: Scope = `eip155:${hexToNumber(preferred)}`;
 
       await this.#trackWalletActionRequested(method, scope, params);
 
       try {
         const result = await this.connect({
-          chainIds: [initiallySelectedChainId],
+          chainIds,
           forceRequest: shouldForceConnectionRequest,
         });
         await this.#trackWalletActionSucceeded(method, scope, params);

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -617,16 +617,14 @@ export class MetamaskConnectEVM {
         request.method === 'wallet_requestPermissions';
 
       const { method, params } = request;
-      const sessionChainIds = getPermittedEthChainIds(this.#sessionScopes);
-      const chainIds: Hex[] =
-        sessionChainIds.length > 0 ? sessionChainIds : [DEFAULT_CHAIN_ID];
-      const scope: Scope = `eip155:${chainIds[0]}`;
+      const initiallySelectedChainId = DEFAULT_CHAIN_ID;
+      const scope: Scope = `eip155:${initiallySelectedChainId}`;
 
       await this.#trackWalletActionRequested(method, scope, params);
 
       try {
         const result = await this.connect({
-          chainIds,
+          chainIds: [initiallySelectedChainId],
           forceRequest: shouldForceConnectionRequest,
         });
         await this.#trackWalletActionSucceeded(method, scope, params);
@@ -759,7 +757,17 @@ export class MetamaskConnectEVM {
     if (hexPermittedChainIds.length === 0) {
       this.#onDisconnect();
     } else {
-      const initialAccounts = getEthAccounts(this.#sessionScopes);
+      let initialAccounts: Address[] = [];
+      if (this.#core.status === 'connected') {
+        const ethAccountsResponse =
+          await this.#core.transport.sendEip1193Message({
+            method: 'eth_accounts',
+            params: [],
+          });
+        initialAccounts = ethAccountsResponse.result as Address[];
+      } else {
+        initialAccounts = getEthAccounts(this.#sessionScopes);
+      }
 
       const chainId = await this.#getSelectedChainId(hexPermittedChainIds);
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -617,14 +617,16 @@ export class MetamaskConnectEVM {
         request.method === 'wallet_requestPermissions';
 
       const { method, params } = request;
-      const initiallySelectedChainId = DEFAULT_CHAIN_ID;
-      const scope: Scope = `eip155:${initiallySelectedChainId}`;
+      const sessionChainIds = getPermittedEthChainIds(this.#sessionScopes);
+      const chainIds: Hex[] =
+        sessionChainIds.length > 0 ? sessionChainIds : [DEFAULT_CHAIN_ID];
+      const scope: Scope = `eip155:${chainIds[0]}`;
 
       await this.#trackWalletActionRequested(method, scope, params);
 
       try {
         const result = await this.connect({
-          chainIds: [initiallySelectedChainId],
+          chainIds,
           forceRequest: shouldForceConnectionRequest,
         });
         await this.#trackWalletActionSucceeded(method, scope, params);
@@ -757,17 +759,7 @@ export class MetamaskConnectEVM {
     if (hexPermittedChainIds.length === 0) {
       this.#onDisconnect();
     } else {
-      let initialAccounts: Address[] = [];
-      if (this.#core.status === 'connected') {
-        const ethAccountsResponse =
-          await this.#core.transport.sendEip1193Message({
-            method: 'eth_accounts',
-            params: [],
-          });
-        initialAccounts = ethAccountsResponse.result as Address[];
-      } else {
-        initialAccounts = getEthAccounts(this.#sessionScopes);
-      }
+      const initialAccounts = getEthAccounts(this.#sessionScopes);
 
       const chainId = await this.#getSelectedChainId(hexPermittedChainIds);
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MWPTransport.connect()` now accepts and forwards a `forceRequest` option. When `true`, `onResumeSuccess` skips the `isSameScopesAndAccounts` check and unconditionally sends `wallet_createSession`, allowing consumers to re-prompt account selection on an existing MWP session. Previously `forceRequest` was silently ignored, causing `wallet_requestPermissions` to no-op on mobile. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
 - Fix platform detection for Hermes-based React Native apps: `isReactNative()` now checks `global.navigator.product` before `window.navigator.product`, so modern RN environments where `window` is undefined correctly resolve to `PlatformType.ReactNative` instead of `PlatformType.NonBrowser`. This restores analytics for all React Native consumers — analytics were silently disabled because `#setupAnalytics()` only calls `analytics.enable()` for browser and `ReactNative` platforms ([#238](https://github.com/MetaMask/connect-monorepo/pull/238))
 
 ## [0.11.0]

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -306,7 +306,11 @@ export class MWPTransport implements ExtendedTransport {
   private async onResumeSuccess(
     resumeResolve: () => void,
     resumeReject: (err: Error) => void,
-    options?: { scopes: Scope[]; caipAccountIds: CaipAccountId[] },
+    options?: {
+      scopes: Scope[];
+      caipAccountIds: CaipAccountId[];
+      forceRequest?: boolean;
+    },
   ): Promise<void> {
     try {
       await this.waitForWalletSessionIfNotCached();
@@ -330,7 +334,7 @@ export class MWPTransport implements ExtendedTransport {
           walletSession,
           proposedCaipAccountIds,
         );
-        if (!hasSameScopesAndAccounts) {
+        if (options.forceRequest || !hasSameScopesAndAccounts) {
           const optionalScopes = addValidAccounts(
             getOptionalScopes(options?.scopes ?? []),
             getValidAccounts(options?.caipAccountIds ?? []),
@@ -427,6 +431,7 @@ export class MWPTransport implements ExtendedTransport {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
     sessionProperties?: SessionProperties;
+    forceRequest?: boolean;
   }): Promise<void> {
     const { dappClient } = this;
 


### PR DESCRIPTION
## Explanation

When a user wants to add or change accounts after an initial connection, consumers like Portfolio currently have to `disconnectAsync()` + `connectAsync()` through wagmi. This forces the user through a full reconnection flow — bad UX, especially on mobile where it means scanning a QR code again.

The `wallet_requestPermissions` flow in `connect-evm` is designed to handle this by calling `connect({ forceRequest: true })`, which should bypass the "already connected" short-circuit and re-prompt the user for account selection. The `forceRequest` plumbing already exists at every layer — `connect-evm`, `MetaMaskConnectMultichain`, `DefaultTransport` — except the final one: **`MWPTransport` ignores `forceRequest`**, so the re-prompt silently no-ops on mobile.

### Changes

**1. `MWPTransport.connect()` — accept `forceRequest`** (`connect-multichain`)

Added `forceRequest?: boolean` to the `connect()` options type so it's forwarded to `onResumeSuccess`.

**2. `MWPTransport.onResumeSuccess()` — bypass scope check when forced** (`connect-multichain`)

When `forceRequest` is true, skip the `isSameScopesAndAccounts` check and unconditionally send `wallet_createSession`. This mirrors `DefaultTransport`'s existing behavior.

**3. Test: `forceRequest` is forwarded on `wallet_requestPermissions`** (`connect-evm`)

Added a test verifying that `wallet_requestPermissions` calls `core.connect` with `forceRequest: true`.

### Flow after fix

```
wallet_requestPermissions
  → connect-evm interceptor: connect({ chainIds: [DEFAULT_CHAIN_ID], forceRequest: true })
  → MetaMaskConnectMultichain.connect() forwards forceRequest to transport
  → MWPTransport.onResumeSuccess() skips scope check, sends wallet_createSession
  → MetaMask Mobile presents account selection UI
  → wallet responds with updated session
  → wallet_sessionChanged fires
  → accountsChanged emitted → wagmi state updates
```

## References

Needed to fix [WAPI-1349](https://consensyssoftware.atlassian.net/browse/WAPI-1349)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes