### PR TITLE
refactor: Lazy-load MWP packages + eciesjs/KeyManager behind dynamic `import()`

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lazy-load MWP transport dependencies: `@metamask/mobile-wallet-protocol-core`, `@metamask/mobile-wallet-protocol-dapp-client`, and `eciesjs` are now dynamically imported only when MWP transport is actually used, allowing bundlers to code-split the entire MWP + crypto dependency tree for consumers who only use the browser extension flow ([#244](https://github.com/MetaMask/connect-monorepo/pull/244))
+
 ### Fixed
 
 - Fix platform detection for Hermes-based React Native apps: `isReactNative()` now checks `global.navigator.product` before `window.navigator.product`, so modern RN environments where `window` is undefined correctly resolve to `PlatformType.ReactNative` instead of `PlatformType.NonBrowser`. This restores analytics for all React Native consumers — analytics were silently disabled because `#setupAnalytics()` only calls `analytics.enable()` for browser and `ReactNative` platforms ([#238](https://github.com/MetaMask/connect-monorepo/pull/238))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lazy-load MWP transport dependencies: `@metamask/mobile-wallet-protocol-core`, `@metamask/mobile-wallet-protocol-dapp-client`, and `eciesjs` are now dynamically imported only when MWP transport is actually used, allowing bundlers to code-split the entire MWP + crypto dependency tree for consumers who only use the browser extension flow ([#244](https://github.com/MetaMask/connect-monorepo/pull/244))
+
 ## [0.12.1]
 
 ### Fixed
@@ -18,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Include `analytics.remote_session_id` in V2 connection metadata so the wallet can correlate dapp-side and wallet-side analytics events ([#256](https://github.com/MetaMask/connect-monorepo/pull/256))
-
-### Changed
-
-- Lazy-load MWP transport dependencies: `@metamask/mobile-wallet-protocol-core`, `@metamask/mobile-wallet-protocol-dapp-client`, and `eciesjs` are now dynamically imported only when MWP transport is actually used, allowing bundlers to code-split the entire MWP + crypto dependency tree for consumers who only use the browser extension flow ([#244](https://github.com/MetaMask/connect-monorepo/pull/244))
 
 ## [0.11.1]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -15,17 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy-load MWP transport dependencies: `@metamask/mobile-wallet-protocol-core`, `@metamask/mobile-wallet-protocol-dapp-client`, and `eciesjs` are now dynamically imported only when MWP transport is actually used, allowing bundlers to code-split the entire MWP + crypto dependency tree for consumers who only use the browser extension flow ([#244](https://github.com/MetaMask/connect-monorepo/pull/244))
 
-### Fixed
-
-- `MWPTransport.connect()` now accepts and forwards a `forceRequest` option. When `true`, `onResumeSuccess` skips the `isSameScopesAndAccounts` check and unconditionally sends `wallet_createSession`, allowing consumers to re-prompt account selection on an existing MWP session. Previously `forceRequest` was silently ignored, causing `wallet_requestPermissions` to no-op on mobile. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
-- Fix platform detection for Hermes-based React Native apps: `isReactNative()` now checks `global.navigator.product` before `window.navigator.product`, so modern RN environments where `window` is undefined correctly resolve to `PlatformType.ReactNative` instead of `PlatformType.NonBrowser`. This restores analytics for all React Native consumers — analytics were silently disabled because `#setupAnalytics()` only calls `analytics.enable()` for browser and `ReactNative` platforms ([#238](https://github.com/MetaMask/connect-monorepo/pull/238))
-
 ## [0.11.1]
 
 ### Changed
 
 - chore: align sub-package licenses with root ConsenSys 2022 license ([#241](https://github.com/MetaMask/connect-monorepo/pull/241))
 - chore: turborepo ([#239](https://github.com/MetaMask/connect-monorepo/pull/239))
+
+### Fixed
+
+- `MWPTransport.connect()` now accepts and forwards a `forceRequest` option. When `true`, `onResumeSuccess` skips the `isSameScopesAndAccounts` check and unconditionally sends `wallet_createSession`, allowing consumers to re-prompt account selection on an existing MWP session. Previously `forceRequest` was silently ignored, causing `wallet_requestPermissions` to no-op on mobile. ([#243](https://github.com/MetaMask/connect-monorepo/pull/243))
+- Fix platform detection for Hermes-based React Native apps: `isReactNative()` now checks `global.navigator.product` before `window.navigator.product`, so modern RN environments where `window` is undefined correctly resolve to `PlatformType.ReactNative` instead of `PlatformType.NonBrowser`. This restores analytics for all React Native consumers — analytics were silently disabled because `#setupAnalytics()` only calls `analytics.enable()` for browser and `ReactNative` platforms ([#238](https://github.com/MetaMask/connect-monorepo/pull/238))
 
 ## [0.11.0]
 

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -7,13 +7,13 @@ import type {
 import type { CaipAccountId, Json } from '@metamask/utils';
 
 import { EventEmitter, type SDKEvents } from '../events';
-import type { StoreClient } from '../store/client';
 import type { InvokeMethodOptions, RPCAPI, Scope } from './api/types';
 import type {
   ExtendedTransport,
   MergeableMultichainOptions,
   MultichainOptions,
 } from './types';
+import type { StoreClient } from '../store/client';
 
 export type ConnectionStatus =
   | 'pending'

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -82,12 +82,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   #beforeUnloadListener: (() => void) | undefined;
 
-  #mwpModules?: Pick<
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    typeof import('@metamask/mobile-wallet-protocol-core'),
-    'ProtocolError' | 'ErrorCode'
-  >;
-
   #transportType?: TransportType;
 
   public _status: ConnectionStatus = 'pending';
@@ -300,10 +294,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       } else if (transportType === TransportType.MWP) {
         const { adapter: kvstore } = this.options.storage;
         const dappClient = await this.#createDappClient();
-        const { MWPTransport: MWPTransportClass } = await import(
-          './transports/mwp'
-        );
-        const apiTransport = new MWPTransportClass(dappClient, kvstore);
+        const { MWPTransport } = await import('./transports/mwp');
+        const apiTransport = new MWPTransport(dappClient, kvstore);
         this.#dappClient = dappClient;
         this.#transport = apiTransport;
         this.#transportType = TransportType.MWP;
@@ -383,11 +375,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       ]);
     const keymanager = await createKeyManager();
 
-    this.#mwpModules = {
-      ProtocolError: mwpCore.ProtocolError,
-      ErrorCode: mwpCore.ErrorCode,
-    };
-
     const { adapter: kvstore } = this.options.storage;
     const sessionstore = await mwpCore.SessionStore.create(kvstore);
     const websocket =
@@ -415,10 +402,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     const { adapter: kvstore } = this.options.storage;
     const dappClient = await this.#createDappClient();
     this.#dappClient = dappClient;
-    const { MWPTransport: MWPTransportClass } = await import(
-      './transports/mwp'
-    );
-    const apiTransport = new MWPTransportClass(dappClient, kvstore);
+    const { MWPTransport } = await import('./transports/mwp');
+    const apiTransport = new MWPTransport(dappClient, kvstore);
     this.#transport = apiTransport;
     this.#transportType = TransportType.MWP;
     this.#providerTransportWrapper.setupTransportNotificationListener();
@@ -495,13 +480,11 @@ export class MetaMaskConnectMultichain extends MultichainCore {
                   this.status = 'connected';
                   await this.storage.setTransport(TransportType.MWP);
                 } catch (error) {
-                  if (
-                    this.#mwpModules &&
-                    error instanceof this.#mwpModules.ProtocolError
-                  ) {
-                    if (
-                      error.code !== this.#mwpModules.ErrorCode.REQUEST_EXPIRED
-                    ) {
+                  const { ProtocolError, ErrorCode } = await import(
+                    '@metamask/mobile-wallet-protocol-core'
+                  );
+                  if (error instanceof ProtocolError) {
+                    if (error.code !== ErrorCode.REQUEST_EXPIRED) {
                       this.status = 'disconnected';
                       // Close the modal on error
                       await this.options.ui.factory.unload(error);
@@ -611,10 +594,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           resolve();
         })
         .catch(async (error) => {
-          if (
-            this.#mwpModules &&
-            error instanceof this.#mwpModules.ProtocolError
-          ) {
+          const { ProtocolError } = await import(
+            '@metamask/mobile-wallet-protocol-core'
+          );
+          if (error instanceof ProtocolError) {
             // In headless mode, we don't auto-regenerate QR codes
             // since there's no modal to display them
             this.status = 'disconnected';

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -615,10 +615,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async #setupDefaultTransport(
     options: { persist?: boolean } = { persist: true },
   ): Promise<DefaultTransport> {
-    if (
-      this.#transportType === TransportType.Browser &&
-      this.#transport instanceof DefaultTransport
-    ) {
+    if (this.#transport instanceof DefaultTransport) {
       return this.#transport;
     }
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -125,7 +125,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   get transportType(): TransportType {
-    return this.#transportType ?? TransportType.Browser;
+    if (this.#transport instanceof DefaultTransport) {
+      return TransportType.Browser;
+    }
+    if (this.#transport) {
+      return TransportType.MWP;
+    }
+    return TransportType.UNKNOWN;
   }
 
   readonly #sdkInfo = `Sdk/Javascript SdkVersion/${getVersion()} Platform/${getPlatformType()} dApp/${this.options.dapp.url ?? this.options.dapp.name} dAppTitle/${this.options.dapp.name}`;
@@ -615,8 +621,8 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async #setupDefaultTransport(
     options: { persist?: boolean } = { persist: true },
   ): Promise<DefaultTransport> {
-    if (this.#transport instanceof DefaultTransport) {
-      return this.#transport;
+    if (this.#transportType === TransportType.Browser) {
+      return this.#transport as DefaultTransport;
     }
 
     if (options?.persist) {

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -4,14 +4,8 @@
 /* eslint-disable promise/always-return -- Event handlers */
 /* eslint-disable no-async-promise-executor -- Async promise executor needed for complex flow */
 import { analytics } from '@metamask/analytics';
-import {
-  ErrorCode,
-  ProtocolError,
-  type SessionRequest,
-  SessionStore,
-  WebSocketTransport,
-} from '@metamask/mobile-wallet-protocol-core';
-import { DappClient } from '@metamask/mobile-wallet-protocol-dapp-client';
+import type { SessionRequest } from '@metamask/mobile-wallet-protocol-core';
+import type { DappClient } from '@metamask/mobile-wallet-protocol-dapp-client';
 import {
   type SessionProperties,
   getMultichainClient,
@@ -59,8 +53,6 @@ import { RpcClient } from './rpc/handlers/rpcClient';
 import { RequestRouter } from './rpc/requestRouter';
 import { DefaultTransport } from './transports/default';
 import { MultichainApiClientWrapperTransport } from './transports/multichainApiClientWrapper';
-import { MWPTransport } from './transports/mwp';
-import { keymanager } from './transports/mwp/KeyManager';
 import {
   getDappId,
   getGlobalObject,
@@ -89,6 +81,14 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   #dappClient: DappClient | undefined = undefined;
 
   #beforeUnloadListener: (() => void) | undefined;
+
+  #mwpModules?: Pick<
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    typeof import('@metamask/mobile-wallet-protocol-core'),
+    'ProtocolError' | 'ErrorCode'
+  >;
+
+  #transportType?: TransportType;
 
   public _status: ConnectionStatus = 'pending';
 
@@ -129,9 +129,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   get transportType(): TransportType {
-    return this.#transport instanceof MWPTransport
-      ? TransportType.MWP
-      : TransportType.Browser;
+    return this.#transportType ?? TransportType.Browser;
   }
 
   readonly #sdkInfo = `Sdk/Javascript SdkVersion/${getVersion()} Platform/${getPlatformType()} dApp/${this.options.dapp.url ?? this.options.dapp.name} dAppTitle/${this.options.dapp.name}`;
@@ -281,9 +279,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     }
   }
 
-  async #getStoredTransport(): Promise<
-    DefaultTransport | MWPTransport | undefined
-  > {
+  async #getStoredTransport(): Promise<ExtendedTransport | undefined> {
     const transportType = await this.storage.getTransport();
     const hasExtensionInstalled = await hasExtension();
     if (transportType) {
@@ -291,6 +287,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         if (hasExtensionInstalled) {
           const apiTransport = new DefaultTransport();
           this.#transport = apiTransport;
+          this.#transportType = TransportType.Browser;
           this.#providerTransportWrapper.setupTransportNotificationListener();
           this.#listener = apiTransport.onNotification(
             this.#onTransportNotification.bind(this),
@@ -300,9 +297,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       } else if (transportType === TransportType.MWP) {
         const { adapter: kvstore } = this.options.storage;
         const dappClient = await this.#createDappClient();
-        const apiTransport = new MWPTransport(dappClient, kvstore);
+        const { MWPTransport: MWPTransportClass } = await import(
+          './transports/mwp'
+        );
+        const apiTransport = new MWPTransportClass(dappClient, kvstore);
         this.#dappClient = dappClient;
         this.#transport = apiTransport;
+        this.#transportType = TransportType.MWP;
         this.#providerTransportWrapper.setupTransportNotificationListener();
         this.#listener = apiTransport.onNotification(
           this.#onTransportNotification.bind(this),
@@ -324,7 +325,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         await this.transport.connect();
       }
       this.status = 'connected';
-      if (this.transport instanceof MWPTransport) {
+      if (this.#transportType === TransportType.MWP) {
         await this.storage.setTransport(TransportType.MWP);
       } else {
         await this.storage.setTransport(TransportType.Browser);
@@ -360,32 +361,52 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   async #createDappClient(): Promise<DappClient> {
+    const [mwpCore, { DappClient: DappClientClass }, { createKeyManager }] =
+      await Promise.all([
+        import('@metamask/mobile-wallet-protocol-core'),
+        import('@metamask/mobile-wallet-protocol-dapp-client'),
+        import('./transports/mwp/KeyManager'),
+      ]);
+    const keymanager = await createKeyManager();
+
+    this.#mwpModules = {
+      ProtocolError: mwpCore.ProtocolError,
+      ErrorCode: mwpCore.ErrorCode,
+    };
+
     const { adapter: kvstore } = this.options.storage;
-    const sessionstore = await SessionStore.create(kvstore);
+    const sessionstore = await mwpCore.SessionStore.create(kvstore);
     const websocket =
       // eslint-disable-next-line no-negated-condition
       typeof window !== 'undefined'
         ? WebSocket
         : (await import('ws')).WebSocket;
-    const transport = await WebSocketTransport.create({
+    const transport = await mwpCore.WebSocketTransport.create({
       url: MWP_RELAY_URL,
       kvstore,
       websocket,
     });
-    const dappClient = new DappClient({ transport, sessionstore, keymanager });
+    const dappClient = new DappClientClass({
+      transport,
+      sessionstore,
+      keymanager,
+    });
     return dappClient;
   }
 
   async #setupMWP(): Promise<void> {
-    if (this.#transport instanceof MWPTransport) {
+    if (this.#transportType === TransportType.MWP) {
       return;
     }
-    // Only setup MWP if it is not already mwp
     const { adapter: kvstore } = this.options.storage;
     const dappClient = await this.#createDappClient();
     this.#dappClient = dappClient;
-    const apiTransport = new MWPTransport(dappClient, kvstore);
+    const { MWPTransport: MWPTransportClass } = await import(
+      './transports/mwp'
+    );
+    const apiTransport = new MWPTransportClass(dappClient, kvstore);
     this.#transport = apiTransport;
+    this.#transportType = TransportType.MWP;
     this.#providerTransportWrapper.setupTransportNotificationListener();
     this.#listener = this.transport.onNotification(
       this.#onTransportNotification.bind(this),
@@ -466,9 +487,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
                   this.status = 'connected';
                   await this.storage.setTransport(TransportType.MWP);
                 } catch (error) {
-                  if (error instanceof ProtocolError) {
-                    // Ignore Request expired errors to allow modal to regenerate expired qr codes
-                    if (error.code !== ErrorCode.REQUEST_EXPIRED) {
+                  if (
+                    this.#mwpModules &&
+                    error instanceof this.#mwpModules.ProtocolError
+                  ) {
+                    if (
+                      error.code !== this.#mwpModules.ErrorCode.REQUEST_EXPIRED
+                    ) {
                       this.status = 'disconnected';
                       // Close the modal on error
                       await this.options.ui.factory.unload(error);
@@ -584,7 +609,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           resolve();
         })
         .catch(async (error) => {
-          if (error instanceof ProtocolError) {
+          if (
+            this.#mwpModules &&
+            error instanceof this.#mwpModules.ProtocolError
+          ) {
             // In headless mode, we don't auto-regenerate QR codes
             // since there's no modal to display them
             this.status = 'disconnected';
@@ -602,7 +630,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   async #setupDefaultTransport(
     options: { persist?: boolean } = { persist: true },
   ): Promise<DefaultTransport> {
-    if (this.#transport instanceof DefaultTransport) {
+    if (
+      this.#transportType === TransportType.Browser &&
+      this.#transport instanceof DefaultTransport
+    ) {
       return this.#transport;
     }
 
@@ -614,6 +645,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       this.#onTransportNotification.bind(this),
     );
     this.#transport = transport;
+    this.#transportType = TransportType.Browser;
     this.#providerTransportWrapper.setupTransportNotificationListener();
     return transport;
   }
@@ -835,7 +867,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
             forceRequest,
           })
           .then(async () => {
-            if (this.#transport instanceof MWPTransport) {
+            if (this.#transportType === TransportType.MWP) {
               return this.storage.setTransport(TransportType.MWP);
             }
             return this.storage.setTransport(TransportType.Browser);
@@ -958,6 +990,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         this.#listener = undefined;
         this.#beforeUnloadListener = undefined;
         this.#transport = undefined;
+        this.#transportType = undefined;
         this.#providerTransportWrapper.clearTransportNotificationListener();
         this.#dappClient = undefined;
       }

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -120,18 +120,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     return this.#dappClient;
   }
 
-  get storage(): StoreClient {
-    return this.options.storage;
+  get transportType(): TransportType {
+    return this.#transportType ?? TransportType.UNKNOWN;
   }
 
-  get transportType(): TransportType {
-    if (this.#transport instanceof DefaultTransport) {
-      return TransportType.Browser;
-    }
-    if (this.#transport) {
-      return TransportType.MWP;
-    }
-    return TransportType.UNKNOWN;
+  get storage(): StoreClient {
+    return this.options.storage;
   }
 
   readonly #sdkInfo = `Sdk/Javascript SdkVersion/${getVersion()} Platform/${getPlatformType()} dApp/${this.options.dapp.url ?? this.options.dapp.name} dAppTitle/${this.options.dapp.name}`;
@@ -781,7 +775,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   ): Promise<void> {
     if (
       this.status === 'connecting' &&
-      this.transportType === TransportType.MWP
+      this.#transportType === TransportType.MWP
     ) {
       await this.#openConnectDeeplinkIfNeeded();
       throw new Error(
@@ -969,7 +963,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
       // We want to leave the DefaultTransport instance connected so that we can
       // still listen for wallet_sessionChanged events.
-      if (this.transportType !== TransportType.Browser) {
+      if (this.#transportType !== TransportType.Browser) {
         await this.#listener?.();
         this.#beforeUnloadListener?.();
         this.#listener = undefined;
@@ -992,7 +986,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       transport,
       rpcClient,
       options,
-      this.transportType,
+      this.#transportType ?? TransportType.UNKNOWN,
     );
     // TODO: need read only method support for solana
     return requestRouter.invokeMethod(request);

--- a/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
@@ -4,38 +4,49 @@ import type {
   IKeyManager,
   KeyPair,
 } from '@metamask/mobile-wallet-protocol-core';
-import { decrypt, encrypt, PrivateKey, PublicKey } from 'eciesjs';
 
-class KeyManager implements IKeyManager {
-  generateKeyPair(): KeyPair {
-    const privateKey = new PrivateKey();
-    return {
-      privateKey: new Uint8Array(privateKey.secret),
-      publicKey: privateKey.publicKey.toBytes(true),
-    };
-  }
+/**
+ * Creates an {@link IKeyManager} backed by the `eciesjs` library.
+ *
+ * The factory dynamically imports `eciesjs` so the heavy crypto dependency is
+ * only loaded when MWP transport is actually used. The returned object closes
+ * over the imported symbols, allowing synchronous methods like
+ * `generateKeyPair` and `validatePeerKey` to work without a second await.
+ *
+ * @returns A ready-to-use key manager instance.
+ */
+export async function createKeyManager(): Promise<IKeyManager> {
+  const { decrypt, encrypt, PrivateKey, PublicKey } = await import('eciesjs');
 
-  async encrypt(
-    plaintext: string,
-    theirPublicKey: Uint8Array,
-  ): Promise<string> {
-    const plaintextBuffer = Buffer.from(plaintext, 'utf8');
-    const encryptedBuffer = encrypt(theirPublicKey, plaintextBuffer);
-    return encryptedBuffer.toString('base64');
-  }
+  return {
+    generateKeyPair(): KeyPair {
+      const privateKey = new PrivateKey();
+      return {
+        privateKey: new Uint8Array(privateKey.secret),
+        publicKey: privateKey.publicKey.toBytes(true),
+      };
+    },
 
-  async decrypt(
-    encryptedB64: string,
-    myPrivateKey: Uint8Array,
-  ): Promise<string> {
-    const encryptedBuffer = Buffer.from(encryptedB64, 'base64');
-    const decryptedBuffer = await decrypt(myPrivateKey, encryptedBuffer);
-    return Buffer.from(decryptedBuffer).toString('utf8');
-  }
+    async encrypt(
+      plaintext: string,
+      theirPublicKey: Uint8Array,
+    ): Promise<string> {
+      const plaintextBuffer = Buffer.from(plaintext, 'utf8');
+      const encryptedBuffer = encrypt(theirPublicKey, plaintextBuffer);
+      return encryptedBuffer.toString('base64');
+    },
 
-  validatePeerKey(key: Uint8Array): void {
-    PublicKey.fromHex(Buffer.from(key).toString('hex'));
-  }
+    async decrypt(
+      encryptedB64: string,
+      myPrivateKey: Uint8Array,
+    ): Promise<string> {
+      const encryptedBuffer = Buffer.from(encryptedB64, 'base64');
+      const decryptedBuffer = await decrypt(myPrivateKey, encryptedBuffer);
+      return Buffer.from(decryptedBuffer).toString('utf8');
+    },
+
+    validatePeerKey(key: Uint8Array): void {
+      PublicKey.fromHex(Buffer.from(key).toString('hex'));
+    },
+  };
 }
-
-export const keymanager = new KeyManager();

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -16,7 +16,6 @@ import type {
   Session,
   SessionRequest,
 } from '@metamask/mobile-wallet-protocol-core';
-import { SessionStore } from '@metamask/mobile-wallet-protocol-core';
 import type { DappClient } from '@metamask/mobile-wallet-protocol-dapp-client';
 import {
   type SessionProperties,
@@ -808,6 +807,9 @@ export class MWPTransport implements ExtendedTransport {
 
   async getActiveSession(): Promise<Session | undefined> {
     const { kvstore } = this;
+    const { SessionStore } = await import(
+      '@metamask/mobile-wallet-protocol-core'
+    );
     const sessionStore = await SessionStore.create(kvstore);
 
     try {


### PR DESCRIPTION
## Explanation

Converts static imports of `@metamask/mobile-wallet-protocol-core`, `@metamask/mobile-wallet-protocol-dapp-client`, and `eciesjs` to dynamic `import()` calls so the entire MWP + crypto dependency tree is only loaded when MWP transport (QR code / deeplink pairing with MetaMask Mobile) is actually used. Desktop browser extension users never hit this code path and will no longer pay the load-time cost.

### Transitive dependencies now deferred

| Package | Brings in |
|---|---|
| `mwp-core` | `centrifuge` → `protobufjs` (12+ sub-packages incl. `@types/node`), `async-mutex`, `events` |
| `eciesjs` | `@ecies/ciphers`, `@noble/ciphers` (3 unique packages; `@noble/curves` / `@noble/hashes` shared with mwp-core) |

## What changed

### `packages/connect-multichain/src/multichain/index.ts`

- **Removed top-level value imports** of `ErrorCode`, `ProtocolError`, `SessionStore`, `WebSocketTransport` (mwp-core), `DappClient` (mwp-dapp-client), `MWPTransport` (local transport), and `keymanager` (KeyManager).
- **Kept / added type-only imports** for `SessionRequest` and `DappClient` (erased at compile time).
- **`#createDappClient()`** now dynamically imports all three MWP packages in parallel via `Promise.all`, then calls the new `createKeyManager()` async factory.
- **Added `#mwpModules` class field** — caches `ProtocolError` and `ErrorCode` from mwp-core after the first lazy load so `error instanceof ProtocolError` and `ErrorCode.REQUEST_EXPIRED` checks in catch blocks continue to work correctly.
- **Added `#transportType` class field** — replaces all `instanceof MWPTransport` checks with a tracked `TransportType` enum, eliminating the need for a static import of the `MWPTransport` class.

### `packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts`

- Converted from a class with a static `eciesjs` import + exported singleton to an **async factory function** (`createKeyManager()`) that dynamically imports `eciesjs` and returns an `IKeyManager` via closure. This prevents esbuild from hoisting the `eciesjs` external import to the bundle's top level.

### `packages/connect-multichain/src/multichain/transports/mwp/index.ts`

- Converted the static `import { SessionStore }` from mwp-core to a dynamic `import()` inside `getActiveSession()`. This was the last remaining static import that esbuild was hoisting to the top level.

## Bundle size analysis

| Format | Before | After | Delta |
|---|---|---|---|
| browser/es (ESM) | 138,433 B | 145,724 B | +7,291 B (+5.3%) |
| browser/umd | 141,811 B | 148,868 B | +7,057 B (+5.0%) |
| browser/iife | 1,592,709 B | 1,631,104 B | +38,395 B (+2.4%) |
| node/cjs | 139,590 B | 146,647 B | +7,057 B (+5.1%) |
| node/es | 136,008 B | 143,299 B | +7,291 B (+5.4%) |
| react-native/es | 134,320 B | 141,953 B | +7,633 B (+5.7%) |

The package's own bundle increases ~5–7 KB due to esbuild's async module init wrappers (`__esm` blocks). This is expected because MWP packages are currently bundled (not external) with `splitting: false`.

**The key improvement is for downstream consumers**: the ESM output now contains **zero** top-level static imports of mwp-core, mwp-dapp-client, or eciesjs. A consumer's bundler (webpack, Vite, etc.) can code-split the entire MWP + crypto tree into a lazy chunk that is never loaded for extension-only users.

> **Follow-up opportunity**: adding MWP packages to the `external` list in `tsup.config.ts` or enabling `splitting: true` for ESM builds would let the package's own build benefit from the split as well.

## Test plan

- [x] All 306 existing tests pass (4 pre-existing skips)
- [x] TypeScript build succeeds with full type checking
- [x] No linter errors introduced
- [x] `error instanceof ProtocolError` checks still work correctly via cached `#mwpModules`
- [x] Verified ESM build output has no top-level static imports of MWP packages or eciesjs

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1270

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
