### PR TITLE
fix: preserve selected chain on wallet_requestPermissions re-prompt

### DIFF
--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -512,6 +512,46 @@ describe('MetamaskConnectEVM', () => {
       const forceRequestArg = secondConnectCall[3];
       expect(forceRequestArg).toBe(true);
     });
+
+    it('wallet_requestPermissions keeps cached chain first in chainIds when still permitted', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x89'));
+
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0xabc0000000000000000000000000000000000001'],
+            },
+            'eip155:137': {
+              methods: [],
+              notifications: [],
+              accounts: [
+                'eip155:137:0xabc0000000000000000000000000000000000001',
+              ],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await client.connect({ chainIds: ['0x89', '0x1'] });
+
+      await client.getProvider().request({
+        method: 'wallet_requestPermissions',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
+      });
+
+      const secondConnectCall = mockCore.connect.mock.calls[1];
+      const scopes = secondConnectCall[0] as string[];
+      expect(scopes[0]).toBe('eip155:137');
+      expect(scopes).toContain('eip155:1');
+    });
   });
 
   describe('disconnect', () => {

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -617,14 +617,27 @@ export class MetamaskConnectEVM {
         request.method === 'wallet_requestPermissions';
 
       const { method, params } = request;
-      const initiallySelectedChainId = DEFAULT_CHAIN_ID;
-      const scope: Scope = `eip155:${initiallySelectedChainId}`;
+      const permitted = getPermittedEthChainIds(this.#sessionScopes);
+      if (permitted.length === 0) {
+        permitted.push(DEFAULT_CHAIN_ID);
+      }
+
+      const selected = this.#provider.selectedChainId;
+      const preferred =
+        selected && permitted.includes(selected) ? selected : permitted[0];
+
+      const chainIds = [
+        preferred,
+        ...permitted.filter((id) => id !== preferred),
+      ];
+
+      const scope: Scope = `eip155:${hexToNumber(preferred)}`;
 
       await this.#trackWalletActionRequested(method, scope, params);
 
       try {
         const result = await this.connect({
-          chainIds: [initiallySelectedChainId],
+          chainIds,
           forceRequest: shouldForceConnectionRequest,
         });
         await this.#trackWalletActionSucceeded(method, scope, params);


### PR DESCRIPTION
## Summary

- **Preserve the user's current chain on `wallet_requestPermissions`** — `connect()` treats `chainIds[0]` as `#pendingPreferredChainId`, which wins over the cached chain when it's still permitted. Passing `[DEFAULT_CHAIN_ID]` (current behavior after revert) snaps back to mainnet on every re-prompt even when the user switched to e.g. Polygon. This puts `this.#provider.selectedChainId` first when it's still in the session's permitted set, so account-only re-prompts don't cause an unexpected `chainChanged`.
- **Fix analytics `scope` format** — uses `hexToNumber(preferred)` for correct decimal CAIP-2 format (`eip155:137`) instead of hex (`eip155:0x89`), matching `switchChain` and other handlers.
- **Add test** — verifies `wallet_requestPermissions` keeps the cached chain (`0x89` / Polygon) first in the scopes passed to `core.connect` when it's still in the multi-chain session.

## Test plan

- [ ] Run `yarn test` in `packages/connect-evm`
- [ ] Manual: connect on Polygon, call `wallet_requestPermissions`, verify chain stays on Polygon after account selection