### PR TITLE
chore(browser-playground): add support for local nodes via wagmi

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `localhost` to wagmi's configured chains ([#245](https://github.com/MetaMask/connect-monorepo/pull/246))
+- Add `localhost` to wagmi's configured chains ([#246](https://github.com/MetaMask/connect-monorepo/pull/246))
 - Bump wagmi from `^2.19.2` to `^3.5.0` and apply v3 migration changes: use `useConnectors()` instead of `useConnect().connectors`, `useChains()` instead of `useSwitchChain().chains`, and rename `useAccount` to `useConnection` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@wagmi/core` from `^2.22.1` to `^3.4.0` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@tanstack/react-query` from `>=5.45.1` to `^5.90.21` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add `localhost` to wagmi's configured chains ([#245](https://github.com/MetaMask/connect-monorepo/pull/246))
 - Bump wagmi from `^2.19.2` to `^3.5.0` and apply v3 migration changes: use `useConnectors()` instead of `useConnect().connectors`, `useChains()` instead of `useSwitchChain().chains`, and rename `useAccount` to `useConnection` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@wagmi/core` from `^2.22.1` to `^3.4.0` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@tanstack/react-query` from `>=5.45.1` to `^5.90.21` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))

--- a/playground/browser-playground/src/wagmi/config.ts
+++ b/playground/browser-playground/src/wagmi/config.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-restricted-globals -- Browser playground uses window */
 import { createConfig, http } from 'wagmi';
-import { mainnet, sepolia, optimism, celo } from 'wagmi/chains';
+import { mainnet, sepolia, optimism, celo, localhost } from 'wagmi/chains';
 
 import { metaMask } from './metamask-connector';
 
 export const wagmiConfig = createConfig({
-  chains: [mainnet, sepolia, optimism, celo],
+  chains: [mainnet, sepolia, optimism, celo, localhost],
   connectors: [
     metaMask({
       dapp: {
@@ -19,6 +19,7 @@ export const wagmiConfig = createConfig({
     [sepolia.id]: http(),
     [optimism.id]: http(),
     [celo.id]: http(),
+    [localhost.id]: http(),
   },
 });
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds support for connecting to local nodes on the browser-playground. This is needed because in the [extension E2E test](
https://github.com/MetaMask/metamask-extension/pull/40976
), MetaMask is connected to localhost:8545 (chain 1337), but wagmi's config doesn't include that chain. When wagmi calls `sendTransaction`, it uses its own transport to send the tx — and `http()` with no URL defaults to the chain's public RPC endpoint, which doesn't exist for chain 1337.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
