### PR TITLE
chore(browser-playground): add address field for legacy-evm send-transaction 

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change LegacyEVM card's `sendTransaction` to have an address field and default it to the connected address ([#247](https://github.com/MetaMask/connect-monorepo/pull/247))
 - Bump wagmi from `^2.19.2` to `^3.5.0` and apply v3 migration changes: use `useConnectors()` instead of `useConnect().connectors`, `useChains()` instead of `useSwitchChain().chains`, and rename `useAccount` to `useConnection` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@wagmi/core` from `^2.22.1` to `^3.4.0` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))
 - Bump `@tanstack/react-query` from `>=5.45.1` to `^5.90.21` ([#233](https://github.com/MetaMask/connect-monorepo/pull/233))

--- a/playground/browser-playground/src/components/LegacyEVMCard.tsx
+++ b/playground/browser-playground/src/components/LegacyEVMCard.tsx
@@ -19,6 +19,7 @@ export function LegacyEVMCard({
   disconnect,
 }: LegacyEVMCardProps) {
   const [response, setResponse] = useState<string>('');
+  const [toAddress, setToAddress] = useState<string>(accounts[0] ?? '');
 
   const requestPermissions = async () => {
     if (!provider) {
@@ -112,7 +113,7 @@ export function LegacyEVMCard({
       setResponse('No account available');
       return;
     }
-    const to = '0x0000000000000000000000000000000000000000';
+    const to = toAddress || accounts[0];
     const transactionParameters = {
       to, // Required except during contract publications.
       from: accounts[0], // must match user's active address.
@@ -251,6 +252,13 @@ export function LegacyEVMCard({
           personal_sign
         </button>
 
+        <input
+          type="text"
+          value={toAddress}
+          onChange={(e) => setToAddress(e.target.value)}
+          placeholder={accounts[0] ?? '0x...'}
+          className="w-full border rounded px-3 py-2 text-sm font-mono"
+        />
         <button
           type="button"
           data-testid={TEST_IDS.legacyEvm.btnSendTransaction}


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, the Legacy EVM card `sendTransaction` targets the burn address. On the extension, this results in a unconfirmable transaction, which hinders E2E test reliability. This change allows specifying the destination address for `sendTransaction` while defaulting the value to the connected address (same pattern as other E2E test dapps).  

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
