### PR TITLE
fix: localhost scopes for legacy-evm

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add global `localhost` scopes ([#250](https://github.com/MetaMask/connect-monorepo/pull/250))
+
 ## [0.6.0]
 
 ### Changed

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -23,7 +23,11 @@ global.Buffer = Buffer;
 const CONNECT_AND_SIGN_MESSAGE = 'Hello from MetaMask Connect Playground!';
 
 function App() {
-  const [customScopes, setCustomScopes] = useState<string[]>(['eip155:1']);
+  const [customScopes, setCustomScopes] = useState<string[]>(
+    window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost'
+      ? ['eip155:1337']
+      : ['eip155:1'],
+  );
   const [caipAccountIds, setCaipAccountIds] = useState<CaipAccountId[]>([]);
 
   const [wagmiError, setWagmiError] = useState<Error | null>(null);

--- a/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
+++ b/playground/browser-playground/src/sdk/LegacyEVMSDKProvider.tsx
@@ -75,6 +75,7 @@ export const LegacyEVMSDKProvider = ({
               'eip155:5': 'https://goerli.infura.io/v3/demo',
               'eip155:11155111': 'https://sepolia.infura.io/v3/demo',
               'eip155:137': 'https://polygon-rpc.com',
+              'eip155:1337': 'http://127.0.0.1:8545',
             };
         const supportedNetworks = convertCaipToHexKeys(caipNetworks);
 

--- a/playground/playground-ui/src/constants/networks.ts
+++ b/playground/playground-ui/src/constants/networks.ts
@@ -15,6 +15,7 @@ export const FEATURED_NETWORKS = {
   'zkSync Era Mainnet': 'eip155:324',
   'Base Mainnet': 'eip155:8453',
   'Solana Mainnet': 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  'Localhost 8545': 'eip155:1337',
 } as const;
 
 /**


### PR DESCRIPTION
## Explanation

Similar to https://github.com/MetaMask/connect-monorepo/pull/246, legacy-evm also needs the localhost scopes available in order to complete transactions on E2E environments.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
