### PR TITLE
fix: stale closure + wallet_sessionChanged update

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix potential stale closure in `handleCheckboxChange` and unconditional `useEffect` on session change ([#257](https://github.com/MetaMask/connect-monorepo/pull/257))
+
 ## [0.6.1]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -72,18 +72,18 @@ function App() {
 
   const handleCheckboxChange = useCallback(
     (value: string, isChecked: boolean) => {
-      if (isChecked) {
-        setCustomScopes(Array.from(new Set([...customScopes, value])));
-      } else {
-        setCustomScopes(customScopes.filter((item) => item !== value));
-      }
+      setCustomScopes((prev) =>
+        isChecked
+          ? Array.from(new Set([...prev, value]))
+          : prev.filter((item) => item !== value),
+      );
     },
-    [customScopes],
+    [],
   );
 
   useEffect(() => {
-    if (session) {
-      const scopes = Object.keys(session?.sessionScopes ?? {});
+    if (session && Object.keys(session?.sessionScopes ?? {}).length > 0) {
+      const scopes = Object.keys(session.sessionScopes);
       setCustomScopes(scopes);
 
       // Accumulate all accounts from all scopes


### PR DESCRIPTION
## Explanation

Two bugs caused Selenium tests to intermittently lose checkbox selections during `selectNetworks`:

**1. Stale closure in `handleCheckboxChange`**
`customScopes` was captured at callback-creation time. When Selenium clicked multiple checkboxes faster than React re-rendered, each handler saw the same snapshot — only the last update survived. Fixed by using a functional state updater (`setCustomScopes((prev) => ...)`) so every update reads the latest state regardless of render timing.

**2. `useEffect` unconditionally overwriting checkbox state**
The effect fired on every `session` change, including transient `wallet_sessionChanged` events emitted by the SDK with empty `sessionScopes`. This reset `customScopes` to `[]` mid-test, wiping selections already made. Fixed by guarding with a `length > 0` check so only a session with actual scopes updates the checkboxes.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
