### PR TITLE
feat: add integrationType to Solana client

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `analytics.integrationType` param to `createSolanaClient()` ([#260](https://github.com/MetaMask/connect-monorepo/pull/260))
+
 ## [0.7.1]
 
 ### Changed

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -73,6 +73,7 @@ describe('createSolanaClient', () => {
             'https://api.mainnet-beta.solana.com',
         },
       },
+      analytics: { integrationType: 'direct' },
       versions: { 'connect-solana': expect.any(String) },
     });
   });
@@ -94,6 +95,7 @@ describe('createSolanaClient', () => {
             'https://api.mainnet-beta.solana.com',
         },
       },
+      analytics: { integrationType: 'direct' },
       versions: { 'connect-solana': expect.any(String) },
     });
   });

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -76,8 +76,8 @@ export async function createSolanaClient(
       supportedNetworks,
     },
     analytics: {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        integrationType: options.analytics?.integrationType || 'direct',
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      integrationType: options.analytics?.integrationType || 'direct',
     },
     versions: {
       // typeof guard needed: Metro (React Native) bundles TS source directly,

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -29,6 +29,8 @@ declare const __PACKAGE_VERSION__: string | undefined;
  * @param options.dapp - Dapp identification and branding settings
  * @param options.api - Optional API configuration with supported networks
  * @param options.api.supportedNetworks - Record mapping network names (mainnet, devnet, testnet) to RPC URLs
+ * @param [options.analytics] - Analytics configuration
+ * @param [options.analytics.integrationType] - Integration type for analytics (defaults to 'direct')
  * @param options.debug - Enable debug logging
  * @param options.skipAutoRegister - Skip auto-registering the wallet during creation (defaults to false)
  * @returns A promise that resolves to the Solana client instance
@@ -72,6 +74,10 @@ export async function createSolanaClient(
     dapp: options.dapp,
     api: {
       supportedNetworks,
+    },
+    analytics: {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        integrationType: options.analytics?.integrationType || 'direct',
     },
     versions: {
       // typeof guard needed: Metro (React Native) bundles TS source directly,

--- a/packages/connect-solana/src/types.ts
+++ b/packages/connect-solana/src/types.ts
@@ -27,7 +27,10 @@ export type SolanaSupportedNetworks = Partial<Record<SolanaNetwork, string>>;
  *
  * Derived from MultichainOptions to ensure consistency with the core SDK.
  */
-export type SolanaConnectOptions = Pick<MultichainOptions, 'dapp'> & {
+export type SolanaConnectOptions = Pick<
+  MultichainOptions,
+  'dapp' | 'analytics'
+> & {
   /**
    * Optional API configuration.
    * Maps network names (mainnet, devnet, testnet) to RPC URLs.


### PR DESCRIPTION
## Explanation

Adds a new `analytics.integrationType` param to `createSolanaClient`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
