### PR TITLE
fix: browser-playground connect-evm import path

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `@metamask/connect/evm` import path to use `@metamask/connect-evm` directly ([#263](https://github.com/MetaMask/connect-monorepo/pull/263))
+
 ## [0.6.3]
 
 ### Changed

--- a/playground/browser-playground/src/components/LegacyEVMCard.tsx
+++ b/playground/browser-playground/src/components/LegacyEVMCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { EIP1193Provider } from '@metamask/connect/evm';
+import type { EIP1193Provider } from '@metamask/connect-evm';
 import { TEST_IDS } from '@metamask/playground-ui';
 import { send_eth_signTypedData_v4, send_personal_sign } from '../helpers/SignHelpers';
 


### PR DESCRIPTION
## Explanation

Fix `@metamask/connect/evm` import path to use `@metamask/connect-evm` directly

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
