### PR TITLE
fix: ensure connect-evm client is fully initialized before returning client instance in createEVMClient

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `createEVMClient()` waits until the underlying instance is fully initialized before resolving ([#265](https://github.com/MetaMask/connect-monorepo/pull/265))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -15,7 +15,8 @@ import {
   isRejectionError,
   TransportType,
 } from '@metamask/connect-multichain';
-import { hexToNumber } from '@metamask/utils';
+import { createDeferredPromise, hexToNumber } from '@metamask/utils';
+import type { DeferredPromise } from '@metamask/utils';
 
 import { IGNORED_METHODS } from './constants';
 import { enableDebug, logger } from './logger';
@@ -119,6 +120,9 @@ export class MetamaskConnectEVM {
    */
   #pendingPreferredChainId: Hex | undefined;
 
+  /** Deferred that resolves once #onSessionChanged has completed for the first time. */
+  readonly #initPromise: DeferredPromise;
+
   /**
    * Creates a new MetamaskConnectEVM instance.
    * Use the static `create()` method instead to ensure proper async initialization.
@@ -154,6 +158,8 @@ export class MetamaskConnectEVM {
     this.#displayUriHandler = this.#onDisplayUri.bind(this);
     this.#core.on('display_uri', this.#displayUriHandler);
 
+    this.#initPromise = createDeferredPromise();
+
     logger('Connect/EVM constructor completed');
   }
 
@@ -173,6 +179,7 @@ export class MetamaskConnectEVM {
   ): Promise<MetamaskConnectEVM> {
     const instance = new MetamaskConnectEVM(options);
     await instance.#core.emitSessionChanged();
+    await instance.#initPromise.promise;
     return instance;
   }
 
@@ -789,6 +796,8 @@ export class MetamaskConnectEVM {
         accounts: initialAccounts,
       });
     }
+
+    this.#initPromise.resolve();
   }
 
   /**


### PR DESCRIPTION
## Explanation

Fixes a bug where `eth_accounts` was resolving with `[]` immediately after a successful call to `MultichainClient.connect()`. This seems to be the result of a race condition where the MultichainClient has not yet cached a value for `eth_accounts`, resulting in quick enough calls to `request()` resulting in the default value of `[]`

This PR fixes that by ensuring `createEVMClient()` doesn't return until the underlying instance is fully initialized.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
