### PR TITLE
fix: prevent CSP connect-src violation from QR code image fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ img-src data:;
 
 - `wss://mm-sdk-relay.api.cx.metamask.io` — the WebSocket URL of the MetaMask relay used for remote connections (mobile, no-extension, etc.). Unavoidable — the relay cannot be proxied or deferred from within the library, and remote connections will fail without it.
 - `https://mm-sdk-analytics.api.cx.metamask.io` — the telemetry endpoint used by `@metamask/analytics`. Required for the connection lifecycle events the SDK emits by default. You can override the host via the `METAMASK_ANALYTICS_ENDPOINT` env var at build time, but some analytics endpoint must be reachable.
-- `img-src data:` — the install/QR-code modal in `@metamask/multichain-ui` embeds the MetaMask fox SVG as a `data:` URI inside the generated QR code. Without this, the QR code will fail to render the center logo.
+- `img-src data:` — the install/QR-code modal in `@metamask/multichain-ui` embeds the MetaMask fox SVG as a `data:` URI inside the generated QR code. Without this, the QR code will fail to render entirely.
 
 ### Also consider
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ npm install @metamask/connect-multichain
 
 ## Content Security Policy
 
-Host pages integrating MetaMask Connect need to allow a few origins in their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). The library itself does not ship or inject its own CSP — these directives must be configured on the host page.
+Host pages integrating MetaMask Connect need to allow a few origins in their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
 
 ### Required
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ npm install @metamask/connect-solana
 npm install @metamask/connect-multichain
 ```
 
+## Content Security Policy
+
+Host pages integrating MetaMask Connect need to allow a few origins in their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). The library itself does not ship or inject its own CSP — these directives must be configured on the host page.
+
+### Required
+
+```
+connect-src wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io;
+img-src data:;
+```
+
+- `wss://mm-sdk-relay.api.cx.metamask.io` — the WebSocket URL of the MetaMask relay used for remote connections (mobile, no-extension, etc.). Unavoidable — the relay cannot be proxied or deferred from within the library, and remote connections will fail without it.
+- `https://mm-sdk-analytics.api.cx.metamask.io` — the telemetry endpoint used by `@metamask/analytics`. Required for the connection lifecycle events the SDK emits by default. You can override the host via the `METAMASK_ANALYTICS_ENDPOINT` env var at build time, but some analytics endpoint must be reachable.
+- `img-src data:` — the install/QR-code modal in `@metamask/multichain-ui` embeds the MetaMask fox SVG as a `data:` URI inside the generated QR code. Without this, the QR code will fail to render the center logo.
+
+### Also consider
+
+- **`style-src 'unsafe-inline'`** — `@metamask/multichain-ui` is built with [Stencil](https://stenciljs.com/), which injects component styles at runtime inside Shadow DOM. Strict CSPs without `'unsafe-inline'` (or an equivalent nonce/hash strategy) may break modal styling.
+- **RPC endpoints you pass to `api.infuraProjectId` / `api.readonlyRPCMap` / `supportedNetworks`** — e.g. `https://*.infura.io`, your own node provider, or a public RPC. These are supplied by your dApp, so add whatever `connect-src` entries match the endpoints you configure.
+- **`https://metamask.app.link` and `metamask://`** — used for mobile deeplinks / universal links. These are top-level navigations and are not normally subject to `connect-src`, but strict CSPs that use `navigate-to` or `form-action` may need to allow them.
+
+### Minimal example
+
+For a dApp using the default analytics endpoint, Infura, and the install modal:
+
+```
+connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io https://*.infura.io;
+img-src 'self' data:;
+style-src 'self' 'unsafe-inline';
+```
+
+See [`playground/browser-playground/public/index.html`](./playground/browser-playground/public/index.html) for a working reference CSP.
+
 ## Packages
 
 | Package                                                       | npm                                                               | Description                                                           |

--- a/packages/multichain-ui/CHANGELOG.md
+++ b/packages/multichain-ui/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `saveAsBlob: false` in QR code image options to prevent `XMLHttpRequest` on the embedded `data:` URI, which violated `connect-src` CSP policies on host pages
+
 ## [0.4.0]
 
 ### Removed

--- a/packages/multichain-ui/CHANGELOG.md
+++ b/packages/multichain-ui/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Set `saveAsBlob: false` in QR code image options to prevent `XMLHttpRequest` on the embedded `data:` URI, which violated `connect-src` CSP policies on host pages
+- Set `saveAsBlob: false` in QR code image options to prevent `XMLHttpRequest` on the embedded `data:` URI, which violated `connect-src` CSP policies on host pages ([#268](https://github.com/MetaMask/connect-monorepo/pull/268))
 
 ## [0.4.0]
 

--- a/packages/multichain-ui/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/multichain-ui/src/components/mm-install-modal/mm-install-modal.tsx
@@ -1,4 +1,13 @@
-import { Component, Prop, h, Event, EventEmitter, State, Element, Watch } from '@stencil/core';
+import {
+  Component,
+  Prop,
+  h,
+  Event,
+  EventEmitter,
+  State,
+  Element,
+  Watch,
+} from '@stencil/core';
 import { WidgetWrapper } from '../widget-wrapper/widget-wrapper';
 import InstallIcon from '../misc/InstallIcon';
 import CloseButton from '../misc/CloseButton';
@@ -11,10 +20,10 @@ import QRCodeStyling, {
   ErrorCorrectionLevel,
   Mode,
   TypeNumber,
-} from "qr-code-styling";
+} from 'qr-code-styling';
 
 import { SimpleI18n } from '../misc/simple-i18n';
-import SVG from '../../assets/fox.svg'
+import SVG from '../../assets/fox.svg';
 
 @Component({
   tag: 'mm-install-modal',
@@ -22,7 +31,7 @@ import SVG from '../../assets/fox.svg'
   shadow: true,
 })
 export class InstallModal {
-  @Prop() link: string
+  @Prop() link: string;
 
   @Prop() expiresIn: number;
 
@@ -45,7 +54,8 @@ export class InstallModal {
 
   constructor() {
     this.onClose = this.onClose.bind(this);
-    this.onStartDesktopOnboardingHandler = this.onStartDesktopOnboardingHandler.bind(this);
+    this.onStartDesktopOnboardingHandler =
+      this.onStartDesktopOnboardingHandler.bind(this);
     this.render = this.render.bind(this);
 
     this.i18nInstance = new SimpleI18n();
@@ -57,7 +67,7 @@ export class InstallModal {
 
   async connectedCallback() {
     await this.i18nInstance.init({
-      fallbackLng: 'en'
+      fallbackLng: 'en',
     });
     this.translationsLoaded = true;
   }
@@ -72,8 +82,8 @@ export class InstallModal {
       image: SVG,
       imageOptions: {
         hideBackgroundDots: true,
-        crossOrigin: 'anonymous',
-        imageSize:0.3,
+        crossOrigin: undefined,
+        imageSize: 0.3,
       },
       dotsOptions: {
         color: '#222222',
@@ -84,9 +94,9 @@ export class InstallModal {
       cornersSquareOptions: {
         color: '#222222',
         type: 'square' as CornerSquareType,
-        gradient: undefined
+        gradient: undefined,
       },
-      cornersDotOptions: {
+      cornersDotOptions: {
         color: '#ff5c16',
       },
       backgroundOptions: {
@@ -95,7 +105,7 @@ export class InstallModal {
       qrOptions: {
         typeNumber: 0 as TypeNumber,
         mode: 'Byte' as Mode,
-        errorCorrectionLevel: 'Q' as ErrorCorrectionLevel
+        errorCorrectionLevel: 'Q' as ErrorCorrectionLevel,
       },
     };
     const qrCode = new QRCodeStyling(options);
@@ -112,7 +122,7 @@ export class InstallModal {
   }
 
   @Watch('link')
-  updateLinkHandler(link:string) {
+  updateLinkHandler(link: string) {
     this.generateQRCode(link);
   }
 
@@ -133,48 +143,54 @@ export class InstallModal {
 
     return (
       <WidgetWrapper className="install-model">
-        <div class='backdrop' onClick={() => this.onClose(true)}></div>
-        <div class='modal'>
-          <div class='closeButtonContainer'>
-            <div class='right'>
-              <span class='closeButton' onClick={() => this.onClose(true)}>
+        <div class="backdrop" onClick={() => this.onClose(true)}></div>
+        <div class="modal">
+          <div class="closeButtonContainer">
+            <div class="right">
+              <span class="closeButton" onClick={() => this.onClose(true)}>
                 <CloseButton />
               </span>
             </div>
           </div>
-          <div class='modalHeader'>
-            <h2 class='modalTitle'>{t('CONNECT_WITH_METAMASK')}</h2>
+          <div class="modalHeader">
+            <h2 class="modalTitle">{t('CONNECT_WITH_METAMASK')}</h2>
           </div>
 
-          <div class='modalContent'>
+          <div class="modalContent">
             {showExtensionFirst ? (
               // Extension first, then mobile
               <div>
                 {/* Extension Section */}
-                <div class='connectionSection'>
-                  <h3 class='sectionTitle'>{t('USE_EXTENSION')}</h3>
-                  <p class='sectionDescription'>{t('ONE_CLICK_CONNECT')}</p>
+                <div class="connectionSection">
+                  <h3 class="sectionTitle">{t('USE_EXTENSION')}</h3>
+                  <p class="sectionDescription">{t('ONE_CLICK_CONNECT')}</p>
 
                   <button
-                    class='button extensionButton'
+                    class="button extensionButton"
                     onClick={() => this.onStartDesktopOnboardingHandler()}
                   >
                     <InstallIcon />
-                    <span class='buttonText'>
+                    <span class="buttonText">
                       {t('CONNECT_WITH_EXTENSION')}
                     </span>
                   </button>
                 </div>
 
-                <div class='sectionDivider'></div>
+                <div class="sectionDivider"></div>
 
                 {/* Mobile Section */}
-                <div class='connectionSection'>
-                  <h3 class='sectionTitle'>{t('USE_MOBILE')}</h3>
-                  <p class='sectionDescription'>{t('SCAN_TO_CONNECT')}</p>
+                <div class="connectionSection">
+                  <h3 class="sectionTitle">{t('USE_MOBILE')}</h3>
+                  <p class="sectionDescription">{t('SCAN_TO_CONNECT')}</p>
 
-                  <div class='qrContainer'>
-                    <div id="sdk-mm-qrcode" class='qrCode' ref={(el) => { if (el) this.qrCodeContainer = el; }} />
+                  <div class="qrContainer">
+                    <div
+                      id="sdk-mm-qrcode"
+                      class="qrCode"
+                      ref={(el) => {
+                        if (el) this.qrCodeContainer = el;
+                      }}
+                    />
                   </div>
                 </div>
               </div>
@@ -182,28 +198,36 @@ export class InstallModal {
               // Mobile first, then extension
               <div>
                 {/* Mobile Section */}
-                <div class='connectionSection'>
-                  <h3 class='sectionTitle'>{t('USE_MOBILE')}</h3>
-                  <p class='sectionDescription'>{t('SCAN_TO_CONNECT')}</p>
+                <div class="connectionSection">
+                  <h3 class="sectionTitle">{t('USE_MOBILE')}</h3>
+                  <p class="sectionDescription">{t('SCAN_TO_CONNECT')}</p>
 
-                  <div class='qrContainer'>
-                    <div id="sdk-mm-qrcode" class='qrCode' ref={(el) => { if (el) this.qrCodeContainer = el; }} />
+                  <div class="qrContainer">
+                    <div
+                      id="sdk-mm-qrcode"
+                      class="qrCode"
+                      ref={(el) => {
+                        if (el) this.qrCodeContainer = el;
+                      }}
+                    />
                   </div>
                 </div>
 
-                <div class='sectionDivider'></div>
+                <div class="sectionDivider"></div>
 
                 {/* Extension Section */}
-                <div class='connectionSection'>
-                  <h3 class='sectionTitle'>{t('USE_EXTENSION')}</h3>
-                  <p class='sectionDescription'>{t('INSTALL_MODAL.INSTALL_META_MASK_EXTENSION_TEXT')}</p>
+                <div class="connectionSection">
+                  <h3 class="sectionTitle">{t('USE_EXTENSION')}</h3>
+                  <p class="sectionDescription">
+                    {t('INSTALL_MODAL.INSTALL_META_MASK_EXTENSION_TEXT')}
+                  </p>
 
                   <button
-                    class='button extensionButton'
+                    class="button extensionButton"
                     onClick={() => this.onStartDesktopOnboardingHandler()}
                   >
                     <InstallIcon />
-                    <span class='buttonText'>
+                    <span class="buttonText">
                       {t('INSTALL_MODAL.INSTALL_META_MASK_EXTENSION_BUTTON')}
                     </span>
                   </button>
@@ -212,8 +236,7 @@ export class InstallModal {
             )}
           </div>
         </div>
-    </WidgetWrapper>
-    )
+      </WidgetWrapper>
+    );
   }
 }
-

--- a/packages/multichain-ui/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/multichain-ui/src/components/mm-install-modal/mm-install-modal.tsx
@@ -84,6 +84,7 @@ export class InstallModal {
         hideBackgroundDots: true,
         crossOrigin: undefined,
         imageSize: 0.3,
+        saveAsBlob: false,
       },
       dotsOptions: {
         color: '#222222',

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `Content-Security-Policy` meta tag to simulate host-page CSP constraints during local testing
+- Add `Content-Security-Policy` meta tag to simulate host-page CSP constraints during local testing ([#268](https://github.com/MetaMask/connect-monorepo/pull/268))
 
 ## [0.6.3]
 

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Content-Security-Policy` meta tag to simulate host-page CSP constraints during local testing
+
 ## [0.6.3]
 
 ### Changed

--- a/playground/browser-playground/public/index.html
+++ b/playground/browser-playground/public/index.html
@@ -13,8 +13,9 @@
       content="default-src 'self';
                script-src 'self' 'unsafe-inline' 'unsafe-eval';
                style-src 'self' 'unsafe-inline';
-               img-src 'self' data: blob:;
-               connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://*.infura.io;
+               img-src 'self' data:;
+               connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io https://*.infura.io;
+               frame-src https://fwd.metamask.io;
                font-src 'self';"
     />
   </head>

--- a/playground/browser-playground/public/index.html
+++ b/playground/browser-playground/public/index.html
@@ -8,6 +8,15 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>Multichain Test Dapp</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self';
+               script-src 'self' 'unsafe-inline' 'unsafe-eval';
+               style-src 'self' 'unsafe-inline';
+               img-src 'self' data: blob:;
+               connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://*.infura.io;
+               font-src 'self';"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Problem

When the install modal renders the QR code, `qr-code-styling` was triggering a `connect-src` CSP violation on host pages. The root cause: Stencil inlines `fox.svg` as a `data:image/svg+xml;base64,...` URI, which gets passed as the `image` option to `qr-code-styling`. That library defaults `imageOptions.saveAsBlob` to `true`, which causes it to do:

```js
xhr.open("GET", "data:image/svg+xml;base64,...");
xhr.responseType = "blob";
xhr.send();
```

Browsers treat XHR on `data:` URIs as network requests and check them against `connect-src`. Since host pages have no reason to include `data:` in their `connect-src`, this violated their CSP silently in production.

## Fix

Set `saveAsBlob: false` in the QR code `imageOptions`. Since we only ever append the QR code to the DOM (never export it), the blob conversion is unnecessary work. Also removed the `crossOrigin: 'anonymous'` setting, which is meaningless for a data URI.

```diff
 imageOptions: {
   hideBackgroundDots: true,
-  crossOrigin: 'anonymous',
+  crossOrigin: undefined,
   imageSize: 0.3,
+  saveAsBlob: false,
 },
```

## Browser Playground

Added a restrictive `Content-Security-Policy` meta tag to the browser playground so this class of violation is caught locally during manual testing, rather than discovered in production. The policy mirrors what a typical host page would enforce — notably `connect-src` does **not** include `data:`.

## Notes for consumers

Host pages integrating this library still need the following in their CSP:

```
connect-src wss://mm-sdk-relay.api.cx.metamask.io;
```

This is unavoidable — it's the WebSocket relay and cannot be proxied or deferred from within the library.

## Test plan

- [ ] Run `yarn start` in `browser-playground`, open DevTools console, click Connect — no CSP violations should appear when the QR modal renders
- [ ] To verify the fix is necessary: temporarily revert `saveAsBlob: false`, repeat — a `connect-src` violation for the `data:image/svg+xml` URI should appear in the console