### PR TITLE
fix: ensure EIP-1193 provider properties are updated before emitting `connect` event

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure EIP-1193 provider properties (`selectedChainId`, `accounts`) are updated before emitting the `connect` event ([#269](https://github.com/MetaMask/connect-monorepo/pull/269))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -195,6 +195,65 @@ describe('MetamaskConnectEVM', () => {
         );
       });
 
+      it('has provider accounts and chainId populated before the connect event fires', async () => {
+        const mockCore = createMockCore();
+        mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+        const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+        const connectPromise = new Promise<void>((resolve) => {
+          client.getProvider().once('connect', () => {
+            expect(client.accounts).toEqual([
+              '0x1234567890123456789012345678901234567890',
+            ]);
+            expect(client.selectedChainId).toBe('0x1');
+            resolve();
+          });
+        });
+
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+
+        await connectPromise;
+      });
+
+      it('emits events in order: connect, chainChanged, accountsChanged', async () => {
+        const mockCore = createMockCore();
+        mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+        const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+        const events: string[] = [];
+
+        client.getProvider().on('connect', () => events.push('connect'));
+        client.getProvider().on('chainChanged', () => events.push('chainChanged'));
+        client.getProvider().on('accountsChanged', () => events.push('accountsChanged'));
+
+        const connectPromise = new Promise<void>((resolve) => {
+          client.getProvider().once('accountsChanged', () => resolve());
+        });
+
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+
+        await connectPromise;
+        expect(events).toEqual(['connect', 'chainChanged', 'accountsChanged']);
+      });
+
       it('connects using accounts from a eth_accounts response when the MultichainClient is connected', async () => {
         const mockCore = createMockCore();
         mockCore._status = 'connected';

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -232,8 +232,12 @@ describe('MetamaskConnectEVM', () => {
         const events: string[] = [];
 
         client.getProvider().on('connect', () => events.push('connect'));
-        client.getProvider().on('chainChanged', () => events.push('chainChanged'));
-        client.getProvider().on('accountsChanged', () => events.push('accountsChanged'));
+        client
+          .getProvider()
+          .on('chainChanged', () => events.push('chainChanged'));
+        client
+          .getProvider()
+          .on('accountsChanged', () => events.push('accountsChanged'));
 
         const connectPromise = new Promise<void>((resolve) => {
           client.getProvider().once('accountsChanged', () => resolve());

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -802,8 +802,8 @@ export class MetamaskConnectEVM {
     }
     logger('handler: chainChanged', { chainId });
     this.#provider.selectedChainId = chainId;
-    this.#eventHandlers?.chainChanged?.(chainId);
     this.#provider.emit('chainChanged', chainId);
+    this.#eventHandlers?.chainChanged?.(chainId);
   }
 
   /**

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -3,6 +3,7 @@
 import { analytics } from '@metamask/analytics';
 import { parseScopeString } from '@metamask/chain-agnostic-permission';
 import type {
+  ConnectionStatus,
   MultichainCore,
   MultichainOptions,
   Scope,

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -3,7 +3,6 @@
 import { analytics } from '@metamask/analytics';
 import { parseScopeString } from '@metamask/chain-agnostic-permission';
 import type {
-  ConnectionStatus,
   MultichainCore,
   MultichainOptions,
   Scope,
@@ -844,37 +843,47 @@ export class MetamaskConnectEVM {
       accounts,
     };
 
-    if (this.#status !== 'connected') {
-      this.#status = 'connected';
-      this.#provider.emit('connect', data);
-      this.#eventHandlers?.connect?.(data);
-
-      this.#removeNotificationHandler?.();
-
-      const onAccountsChanged = (accs: string[]): void => {
-        logger('core-event: accountsChanged', accs);
-        this.#onAccountsChanged(accs as Address[]);
-      };
-
-      const onChainChanged = (chainChanged: { chainId: string }): void => {
-        logger('core-event: chainChanged', chainChanged.chainId);
-        this.#cacheChainId(chainChanged.chainId as Hex).catch((error) => {
-          logger('Error caching chainId in notification handler', error);
-        });
-        this.#onChainChanged(chainChanged.chainId as Hex);
-      };
-
-      this.#core.on('metamask_accountsChanged', onAccountsChanged);
-      this.#core.on('metamask_chainChanged', onChainChanged);
-
-      this.#removeNotificationHandler = (): void => {
-        this.#core.off('metamask_accountsChanged', onAccountsChanged);
-        this.#core.off('metamask_chainChanged', onChainChanged);
-      };
+    if (this.#status === 'connected') {
+      this.#onChainChanged(chainId);
+      this.#onAccountsChanged(accounts);
+      return;
     }
 
-    this.#onChainChanged(chainId);
-    this.#onAccountsChanged(accounts);
+    this.#provider.selectedChainId = chainId;
+    this.#provider.accounts = accounts;
+
+    this.#status = 'connected';
+    this.#provider.emit('connect', data);
+    this.#eventHandlers?.connect?.(data);
+
+    this.#provider.emit('chainChanged', chainId);
+    this.#eventHandlers?.chainChanged?.(chainId);
+
+    this.#provider.emit('accountsChanged', accounts);
+    this.#eventHandlers?.accountsChanged?.(accounts);
+
+    this.#removeNotificationHandler?.();
+
+    const onAccountsChanged = (accs: string[]): void => {
+      logger('core-event: accountsChanged', accs);
+      this.#onAccountsChanged(accs as Address[]);
+    };
+
+    const onChainChanged = (chainChanged: { chainId: string }): void => {
+      logger('core-event: chainChanged', chainChanged.chainId);
+      this.#cacheChainId(chainChanged.chainId as Hex).catch((error) => {
+        logger('Error caching chainId in notification handler', error);
+      });
+      this.#onChainChanged(chainChanged.chainId as Hex);
+    };
+
+    this.#core.on('metamask_accountsChanged', onAccountsChanged);
+    this.#core.on('metamask_chainChanged', onChainChanged);
+
+    this.#removeNotificationHandler = (): void => {
+      this.#core.off('metamask_accountsChanged', onAccountsChanged);
+      this.#core.off('metamask_chainChanged', onChainChanged);
+    };
   }
 
   /**


### PR DESCRIPTION
## Explanation

Previously, the EvmClient and EIP-1193 Provider would emit `connect` events before the EIP-1193 Provider properties were updated. These values were also used as the cache for `eth_chainId` and `eth_accounts` requests. This resulted in empty values being returned to the caller when making requests to either method inside the event handler for a `connect` event.

This PR fixes that by ensuring the EIP-1193 provider's property values are updated before emitting `connect`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
