### PR TITLE
fix: Update EvmClient.status to reflect actual instance status

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** `EvmClient.status` now reflects the actual internal status of the `EvmClient` instance instead of proxying the underlying `MultichainClient.status`. The return type changes from `ConnectionStatus` to `ConnectEvmStatus`. ([#270](https://github.com/MetaMask/connect-monorepo/pull/270))
+
 ## [0.10.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -590,6 +590,91 @@ describe('MetamaskConnectEVM', () => {
     });
   });
 
+  describe('status', () => {
+    it('returns disconnected before any session is established', async () => {
+      const mockCore = createMockCore();
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+      expect(client.status).toBe('disconnected');
+    });
+
+    it('returns connecting while a connect() call is in progress', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+
+      let resolveConnect: () => void;
+      mockCore.connect.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveConnect = resolve;
+          }),
+      );
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+      const connectPromise = client.connect({ chainIds: ['0x1'] });
+
+      expect(client.status).toBe('connecting');
+
+      // Resolve with a session so the connect promise can settle
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      resolveConnect!();
+      await connectPromise;
+    });
+
+    it('returns connected after a session is established', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+
+      expect(client.status).toBe('connected');
+    });
+
+    it('returns disconnected after disconnect is called', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+
+      await client.disconnect();
+      expect(client.status).toBe('disconnected');
+    });
+  });
+
   describe('core event subscriptions', () => {
     let mockCore: MockCore;
     let client: Awaited<ReturnType<typeof MetamaskConnectEVM.create>>;

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -673,6 +673,97 @@ describe('MetamaskConnectEVM', () => {
       await client.disconnect();
       expect(client.status).toBe('disconnected');
     });
+
+    it('returns disconnected when the wallet revokes the session', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+
+      expect(client.status).toBe('connected');
+
+      const disconnectPromise = new Promise<void>((resolve) => {
+        client.getProvider().once('disconnect', resolve);
+      });
+      mockCore.emit('wallet_sessionChanged', { sessionScopes: {} });
+      await disconnectPromise;
+
+      expect(client.status).toBe('disconnected');
+    });
+
+    it('returns disconnected when the wallet revokes all evm scopes', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+            methods: [],
+            notifications: [],
+            accounts: [
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:0x1234567890123456789012345678901234567890',
+            ],
+          },
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+
+      expect(client.status).toBe('connected');
+
+      const disconnectPromise = new Promise<void>((resolve) => {
+        client.getProvider().once('disconnect', resolve);
+      });
+      mockCore.emit('wallet_sessionChanged', {
+        sessionScopes: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+            methods: [],
+            notifications: [],
+            accounts: [
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:0x1234567890123456789012345678901234567890',
+            ],
+          },
+        },
+      });
+      await disconnectPromise;
+
+      expect(client.status).toBe('disconnected');
+    });
+
+    it('resets to disconnected when connect() rejects', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.connect.mockRejectedValue(new Error('user rejected'));
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await expect(client.connect({ chainIds: ['0x1'] })).rejects.toThrow(
+        'user rejected',
+      );
+
+      expect(client.status).toBe('disconnected');
+    });
   });
 
   describe('core event subscriptions', () => {

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -601,9 +601,9 @@ describe('MetamaskConnectEVM', () => {
       const mockCore = createMockCore();
       mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
 
-      let resolveConnect: () => void;
+      let resolveConnect: () => void = () => undefined;
       mockCore.connect.mockImplementation(
-        () =>
+        async () =>
           new Promise<void>((resolve) => {
             resolveConnect = resolve;
           }),
@@ -625,7 +625,7 @@ describe('MetamaskConnectEVM', () => {
         },
       };
       mockCore.emit('wallet_sessionChanged', session);
-      resolveConnect!();
+      resolveConnect();
       await connectPromise;
     });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -970,8 +970,8 @@ export class MetamaskConnectEVM {
    *
    * @returns The current connection status
    */
-  get status(): ConnectionStatus {
-    return this.#core.status;
+  get status(): ConnectEvmStatus {
+    return this.#status;
   }
 }
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -3,7 +3,6 @@
 import { analytics } from '@metamask/analytics';
 import { parseScopeString } from '@metamask/chain-agnostic-permission';
 import type {
-  ConnectionStatus,
   MultichainCore,
   MultichainOptions,
   Scope,


### PR DESCRIPTION
## Explanation

Currently `EvmClient.status` returns the underlying `MultichainClient.status` value. This is problematic as the MultichainClient being connected does not necessarily mean that EVM accounts are permissioned. Additionally, the MultichainClient's connected status does not correctly indicated whether or not the EvmClient itself has internally reached a fully connected state.

This PR fixes that by making `EvmClient.status` reflect the actual internal status of the EvmClient instance. This is a breaking change to the API.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
