### PR TITLE
chore(analytics): drop MobileSDKConnectV2 types from generated schema

### DIFF
--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `MobileSDKConnectV2Payload` / `MobileSDKConnectV2Properties` from `schema.ts` and the `EventV2` oneOf; the `mobile/sdk-connect-v2` namespace has no emitters after [`metamask-mobile#27864`](https://github.com/MetaMask/metamask-mobile/pull/27864) and [`metamask-mobile#28322`](https://github.com/MetaMask/metamask-mobile/pull/28322), and the V2 endpoint is being updated to reject the namespace in [`metamask-sdk-analytics-api#29`](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/29). Internal types only — no change to the public API.
+
 ## [0.4.0]
 
 ### Changed

--- a/packages/analytics/src/schema.ts
+++ b/packages/analytics/src/schema.ts
@@ -519,9 +519,7 @@ export type components = {
        */
       platform: 'extension' | 'mobile';
     };
-    EventV2:
-      | components['schemas']['MMConnectPayload']
-      | components['schemas']['MobileSDKConnectV2Payload'];
+    EventV2: components['schemas']['MMConnectPayload'];
     MMConnectPayload: {
       /**
        * @description discriminator enum property added by openapi-typescript
@@ -538,21 +536,6 @@ export type components = {
         | 'mmconnect_wallet_action_failed'
         | 'mmconnect_wallet_action_rejected';
       properties: components['schemas']['MMConnectProperties'];
-    };
-    MobileSDKConnectV2Payload: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       */
-      namespace: 'mobile/sdk-connect-v2';
-      event_name:
-        | 'wallet_connection_request_received'
-        | 'wallet_connection_request_failed'
-        | 'wallet_connection_user_approved'
-        | 'wallet_connection_user_rejected'
-        | 'wallet_action_received'
-        | 'wallet_action_user_approved'
-        | 'wallet_action_user_rejected';
-      properties: components['schemas']['MobileSDKConnectV2Properties'];
     };
     MMConnectProperties: {
       /** @description Package versions keyed by connect package name */
@@ -576,11 +559,6 @@ export type components = {
       dapp_requested_chains?: string[];
       /** @description Array of CAIP-2 chain IDs that the user has permissioned */
       user_permissioned_chains?: string[];
-    };
-    MobileSDKConnectV2Properties: {
-      /** Format: uuid */
-      anon_id: string;
-      platform: 'mobile';
     };
   };
   responses: never;


### PR DESCRIPTION
## Summary

Removes `MobileSDKConnectV2Payload` / `MobileSDKConnectV2Properties` from `packages/analytics/src/schema.ts` and collapses the `EventV2` oneOf to just `MMConnectPayload`. The `mobile/sdk-connect-v2` namespace is dead code on both sides of the analytics pipeline.

## Why

- **Wallet side:** [MetaMask/metamask-mobile#28322](https://github.com/MetaMask/metamask-mobile/pull/28322) removed `@metamask/sdk-analytics` (the V1 client) from the mobile app. [MetaMask/metamask-mobile#27864](https://github.com/MetaMask/metamask-mobile/pull/27864) (merged 2026-04-17) deleted `app/core/SDKConnectV2/services/v2-analytics.ts` — the HTTP POST to the V2 relay's `mobile/sdk-connect-v2` namespace — and re-routes SDKConnectV2 / MWP wallet analytics through MetaMetrics (Segment) via `AnalyticsController`. The wallet side of this namespace will never emit again.
- **Dapp side (this package):** `Analytics.track()` in `src/analytics.ts` is hard-typed to `MMConnectPayload` (namespace `metamask/connect`). The `MobileSDKConnectV2*` types have never been emitted by this client — they were only carried in the generated schema because the upstream OpenAPI spec listed both namespaces in the `EventV2` oneOf.
- **Server side:** [consensys-vertical-apps/metamask-sdk-analytics-api#29](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/29) removes the namespace from `api.spec.yml`, the Go domain/service layer, and the V2 relay's namespace switch. Once that lands, the endpoint will reject `"namespace": "mobile/sdk-connect-v2"` with a 400.

## Changes

| File | Change |
|------|--------|
| `packages/analytics/src/schema.ts` | Drop `MobileSDKConnectV2Payload` + `MobileSDKConnectV2Properties` component types; collapse `EventV2` from a 2-member oneOf to just `MMConnectPayload` |
| `packages/analytics/CHANGELOG.md` | Add `Removed` entry under `[Unreleased]` |

Net diff: **+5 / −23** across 2 files.

## Scope note

I intentionally did **not** regenerate the schema from the current `api.spec.yml` on the API repo — doing so would additionally pull in `SmartAccountsKitPayload` (added in [sdk-analytics-api#27](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/27)), which the `@metamask/analytics` client doesn't emit and shouldn't be introduced as drive-by scope here. If the maintainers want those types, a separate regen can pick them up cleanly.

## Compatibility

- **No public API change.** `packages/analytics/src/index.ts` only exports the `analytics` client instance; the removed types were internal-only.
- `analytics.ts` already narrows `Event` to `MMConnectPayload` everywhere it's used — collapsing the union is a noop for the emitter.

## Test plan

- [x] `tsc --noEmit -p tsconfig.build.json` passes locally
- [ ] `yarn test` (vitest) green in CI
- [ ] `yarn build` green in CI
- [ ] Changelog-check workflow green

## Related

- Server-side cleanup: [consensys-vertical-apps/metamask-sdk-analytics-api#29](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/29)
- Supersedes the prerequisite PR [consensys-vertical-apps/metamask-sdk-analytics-api#28](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/28) (which added fields to the schema being removed here)