### PR TITLE
feat: prefer injected solana provider

### DIFF
--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** registerWallet() now registers the MetaMask Connect Solana Provider as `MetaMask` instead of `MetaMask Connect` ([#275](https://github.com/MetaMask/connect-monorepo/pull/275))
 - Prefer the injected Solana provider by no longer announcing the MMC Solana provider if the injected Solana provider is detected ([#275](https://github.com/MetaMask/connect-monorepo/pull/275))
 
 ## [0.8.1]

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release
+- Initial Release
 
 [Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@0.8.1...HEAD
 [0.8.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@0.8.0...@metamask/connect-solana@0.8.1

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer the injected Solana provider by no longer announcing the MMC Solana provider if the injected Solana provider is detected ([#275](https://github.com/MetaMask/connect-monorepo/pull/275))
+
 ## [0.8.1]
 
 ### Changed

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@metamask/connect-multichain": "workspace:^",
     "@metamask/solana-wallet-standard": "^0.6.0",
+    "@wallet-standard/app": "~1.1.0",
     "@wallet-standard/base": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -178,14 +178,15 @@ describe('createSolanaClient', () => {
         });
       });
 
-      it('should no-op when auto-registration was used', async () => {
+      it('should skip when auto-registration already registered successfully', async () => {
         const client = await createSolanaClient(mockOptions);
-
         await vi.advanceTimersByTimeAsync(1000);
-        vi.clearAllMocks();
+
+        expect(registerSolanaWalletStandard).toHaveBeenCalledTimes(1);
+
         await client.registerWallet();
 
-        expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+        expect(registerSolanaWalletStandard).toHaveBeenCalledTimes(1);
       });
 
       it('should skip registration when MetaMask extension is already registered', async () => {

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -5,6 +5,7 @@ import {
   getWalletStandard,
   registerSolanaWalletStandard,
 } from '@metamask/solana-wallet-standard';
+import { getWallets } from '@wallet-standard/app';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { createSolanaClient } from './connect';
@@ -131,6 +132,17 @@ describe('createSolanaClient', () => {
 
       expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
     });
+
+    it('should skip auto-registration when MetaMask extension is already registered', async () => {
+      (getWallets as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: () => [{ name: 'MetaMask' }],
+      });
+
+      await createSolanaClient(mockOptions);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+    });
   });
 
   describe('SolanaClient', () => {
@@ -171,6 +183,21 @@ describe('createSolanaClient', () => {
 
         await vi.advanceTimersByTimeAsync(1000);
         vi.clearAllMocks();
+        await client.registerWallet();
+
+        expect(registerSolanaWalletStandard).not.toHaveBeenCalled();
+      });
+
+      it('should skip registration when MetaMask extension is already registered', async () => {
+        const client = await createSolanaClient({
+          ...mockOptions,
+          skipAutoRegister: true,
+        });
+
+        (getWallets as ReturnType<typeof vi.fn>).mockReturnValue({
+          get: () => [{ name: 'MetaMask' }],
+        });
+
         await client.registerWallet();
 
         expect(registerSolanaWalletStandard).not.toHaveBeenCalled();

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -10,6 +10,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createSolanaClient } from './connect';
 import type { SolanaConnectOptions } from './types';
 
+vi.mock('@wallet-standard/app', () => ({
+  getWallets: vi.fn(() => ({
+    get: (): [] => [],
+  })),
+}));
+
 describe('createSolanaClient', () => {
   const mockOptions: SolanaConnectOptions = {
     dapp: {
@@ -36,6 +42,7 @@ describe('createSolanaClient', () => {
   };
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     (createMultichainClient as ReturnType<typeof vi.fn>).mockResolvedValue(
       mockCore,
@@ -47,6 +54,7 @@ describe('createSolanaClient', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -110,9 +118,11 @@ describe('createSolanaClient', () => {
     it('should auto-register the wallet by default', async () => {
       await createSolanaClient(mockOptions);
 
+      await vi.advanceTimersByTimeAsync(1000);
+
       expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
         client: mockCore.provider,
-        walletName: 'MetaMask Connect',
+        walletName: 'MetaMask',
       });
     });
 
@@ -135,7 +145,7 @@ describe('createSolanaClient', () => {
 
         expect(getWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
         });
         expect(wallet).toBe(mockWallet);
       });
@@ -159,6 +169,7 @@ describe('createSolanaClient', () => {
       it('should no-op when auto-registration was used', async () => {
         const client = await createSolanaClient(mockOptions);
 
+        await vi.advanceTimersByTimeAsync(1000);
         vi.clearAllMocks();
         await client.registerWallet();
 

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -152,7 +152,7 @@ describe('createSolanaClient', () => {
 
         expect(registerSolanaWalletStandard).toHaveBeenCalledWith({
           client: mockCore.provider,
-          walletName: 'MetaMask Connect',
+          walletName: 'MetaMask',
         });
       });
 

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -99,22 +99,36 @@ export async function createSolanaClient(
   const walletName = 'MetaMask';
 
   let hasRegisteredMmc = false;
-  let handleInitRegistration!: () => void;
+  let handledInitRegistration!: () => void;
   const initRegistrationHandledPromise = new Promise<void>((resolve) => {
-    handleInitRegistration = resolve;
+    handledInitRegistration = resolve;
   });
 
+  const registerWallet = async (): Promise<void> => {
+    if (hasRegisteredMmc) {
+      logger('MetaMask Connect is already registered. Skipping...');
+      return;
+    }
+
+    if (isMetamaskExtensionRegistered()) {
+      logger('MetaMask extension is already registered. Skipping...');
+      return;
+    }
+
+    hasRegisteredMmc = true;
+    await registerSolanaWalletStandard({ client, walletName });
+  };
+
   if (skipAutoRegister) {
-    handleInitRegistration();
+    handledInitRegistration();
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     setTimeout(async () => {
-      if (isMetamaskExtensionRegistered()) {
-        logger('MetaMask extension is already registered. Skipping...');
-      } else {
-        await registerSolanaWalletStandard({ client, walletName });
-        hasRegisteredMmc = true;
+      try {
+        await registerWallet();
+      } finally {
+        handledInitRegistration();
       }
-      handleInitRegistration();
     }, 1000);
   }
 
@@ -123,18 +137,7 @@ export async function createSolanaClient(
     getWallet: () => getWalletStandard({ client, walletName }),
     registerWallet: async (): Promise<void> => {
       await initRegistrationHandledPromise;
-      if(hasRegisteredMmc) {
-        logger('MetaMask Connect is already registered. Skipping...');
-        return;
-      }
-
-      if (isMetamaskExtensionRegistered()) {
-        logger('MetaMask extension is already registered. Skipping...');
-        return;
-      }
-
-      await registerSolanaWalletStandard({ client, walletName });
-      hasRegisteredMmc = true;
+      await registerWallet();
     },
     disconnect: async () =>
       await core.disconnect(Object.values(SOLANA_CAIP_IDS) as Scope[]),

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -115,8 +115,8 @@ export async function createSolanaClient(
       return;
     }
 
-    hasRegisteredMmc = true;
     await registerSolanaWalletStandard({ client, walletName });
+    hasRegisteredMmc = true; // eslint-disable-line require-atomic-updates
   };
 
   if (skipAutoRegister) {

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -14,7 +14,7 @@ import type {
   SolanaConnectOptions,
   SolanaSupportedNetworks,
 } from './types';
-import { isMetamaskExtensionRegistered, logger, enableDebug } from './utils';
+import { isMetamaskExtensionRegistered, logger } from './utils';
 
 // Value substitued by tsup at build time
 declare const __PACKAGE_VERSION__: string | undefined;
@@ -61,10 +61,6 @@ declare const __PACKAGE_VERSION__: string | undefined;
 export async function createSolanaClient(
   options: SolanaConnectOptions,
 ): Promise<SolanaClient> {
-  if (options.debug) {
-    enableDebug();
-  }
-
   const defaultNetworks: SolanaSupportedNetworks = {
     mainnet: 'https://api.mainnet-beta.solana.com',
   };

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -14,6 +14,7 @@ import type {
   SolanaConnectOptions,
   SolanaSupportedNetworks,
 } from './types';
+import { isMetamaskExtensionRegistered, logger, enableDebug } from './utils';
 
 // Value substitued by tsup at build time
 declare const __PACKAGE_VERSION__: string | undefined;
@@ -60,6 +61,10 @@ declare const __PACKAGE_VERSION__: string | undefined;
 export async function createSolanaClient(
   options: SolanaConnectOptions,
 ): Promise<SolanaClient> {
+  if (options.debug) {
+    enableDebug();
+  }
+
   const defaultNetworks: SolanaSupportedNetworks = {
     mainnet: 'https://api.mainnet-beta.solana.com',
   };
@@ -91,20 +96,45 @@ export async function createSolanaClient(
 
   const client = core.provider;
 
-  const walletName = 'MetaMask Connect';
+  const walletName = 'MetaMask';
 
-  if (!skipAutoRegister) {
-    await registerSolanaWalletStandard({ client, walletName });
+  let hasRegisteredMmc = false;
+  let handleInitRegistration!: () => void;
+  const initRegistrationHandledPromise = new Promise<void>((resolve) => {
+    handleInitRegistration = resolve;
+  });
+
+  if (skipAutoRegister) {
+    handleInitRegistration();
+  } else {
+    setTimeout(async () => {
+      if (isMetamaskExtensionRegistered()) {
+        logger('MetaMask extension is already registered. Skipping...');
+      } else {
+        await registerSolanaWalletStandard({ client, walletName });
+        hasRegisteredMmc = true;
+      }
+      handleInitRegistration();
+    }, 1000);
   }
 
   return {
     core,
     getWallet: () => getWalletStandard({ client, walletName }),
     registerWallet: async (): Promise<void> => {
-      if (!skipAutoRegister) {
+      await initRegistrationHandledPromise;
+      if(hasRegisteredMmc) {
+        logger('MetaMask Connect is already registered. Skipping...');
         return;
       }
+
+      if (isMetamaskExtensionRegistered()) {
+        logger('MetaMask extension is already registered. Skipping...');
+        return;
+      }
+
       await registerSolanaWalletStandard({ client, walletName });
+      hasRegisteredMmc = true;
     },
     disconnect: async () =>
       await core.disconnect(Object.values(SOLANA_CAIP_IDS) as Scope[]),

--- a/packages/connect-solana/src/mocks/connect-multichain.ts
+++ b/packages/connect-solana/src/mocks/connect-multichain.ts
@@ -3,4 +3,4 @@ import { vi } from 'vitest';
 export const createMultichainClient = vi.fn();
 export const getInfuraRpcUrls = vi.fn();
 export const enableDebug = vi.fn();
-export const createLogger = vi.fn();
+export const createLogger = vi.fn(() => vi.fn());

--- a/packages/connect-solana/src/mocks/connect-multichain.ts
+++ b/packages/connect-solana/src/mocks/connect-multichain.ts
@@ -2,3 +2,5 @@ import { vi } from 'vitest';
 
 export const createMultichainClient = vi.fn();
 export const getInfuraRpcUrls = vi.fn();
+export const enableDebug = vi.fn();
+export const createLogger = vi.fn();

--- a/packages/connect-solana/src/utils.ts
+++ b/packages/connect-solana/src/utils.ts
@@ -1,0 +1,28 @@
+import {
+  createLogger,
+  enableDebug as debug,
+} from '@metamask/connect-multichain';
+import { getWallets } from '@wallet-standard/app';
+
+const namespace = 'metamask-connect:solana';
+
+// @ts-expect-error logger needs to be typed properly
+export const logger = createLogger(namespace, '93');
+
+export const enableDebug = (): void => {
+  // @ts-expect-error logger needs to be typed properly
+  debug(namespace);
+};
+
+/**
+ * Check if MetaMask extension is registered on Solana wallet-standard registry
+ *
+ * @returns True if extension is registered, false otherwise
+ */
+export const isMetamaskExtensionRegistered = (): boolean => {
+  const wallets = getWallets();
+
+  return wallets
+    .get()
+    .some((wallet) => wallet.name.toLowerCase().includes('metamask'));
+};

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use any Solana provider that announces itself as `MetaMask` instead of preferring `MetaMask Connect` ([#275](https://github.com/MetaMask/connect-monorepo/pull/275))
 
-
 ## [0.6.6]
 
 ### Added

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use any Solana provider that announces itself as `MetaMask` instead of preferring `MetaMask Connect` ([#275](https://github.com/MetaMask/connect-monorepo/pull/275))
+
+
 ## [0.6.6]
 
 ### Added

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -174,7 +174,7 @@ function App() {
 
     // Find the MetaMask wallet in registered wallets
     const metamaskWallet = wallets.find((w) =>
-      w.adapter.name.toLowerCase().includes('metamask connect'),
+      w.adapter.name.toLowerCase().includes('metamask'),
     );
     if (metamaskWallet) {
       // Just select the wallet - autoConnect in WalletProvider will handle connection

--- a/playground/browser-playground/src/sdk/SolanaProvider.tsx
+++ b/playground/browser-playground/src/sdk/SolanaProvider.tsx
@@ -1,4 +1,7 @@
-import { createSolanaClient, type SolanaClient } from '@metamask/connect-solana';
+import {
+  createSolanaClient,
+  type SolanaClient,
+} from '@metamask/connect-solana';
 import { METAMASK_PROD_CHROME_ID } from '@metamask/playground-ui';
 import {
   ConnectionProvider,
@@ -56,6 +59,7 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
     initRef.current = true;
 
     createSolanaClient({
+      debug: true,
       dapp: {
         name: 'MetaMask Connect Playground',
         url: window.location.origin,
@@ -77,7 +81,14 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const contextValue = useMemo(
-    () => ({ client, isRegistered, endpoint, setEndpoint, walletError, clearWalletError }),
+    () => ({
+      client,
+      isRegistered,
+      endpoint,
+      setEndpoint,
+      walletError,
+      clearWalletError,
+    }),
     [client, isRegistered, endpoint, walletError, clearWalletError],
   );
 
@@ -93,7 +104,10 @@ const SolanaClientInitializer: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <SolanaSDKContext.Provider value={contextValue}>
-      <ConnectionProvider endpoint={endpoint} config={{ commitment: 'confirmed' }}>
+      <ConnectionProvider
+        endpoint={endpoint}
+        config={{ commitment: 'confirmed' }}
+      >
         <WalletProvider wallets={[]} autoConnect onError={onWalletError}>
           <WalletModalProvider>{children}</WalletModalProvider>
         </WalletProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4121,6 +4121,7 @@ __metadata:
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@types/jsdom": "npm:^21.1.7"
     "@vitest/coverage-v8": "npm:^3.2.4"
+    "@wallet-standard/app": "npm:~1.1.0"
     "@wallet-standard/base": "npm:^1.1.0"
     jsdom: "npm:^26.1.0"
     prettier: "npm:^3.3.3"
@@ -8580,7 +8581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-standard/app@npm:^1.1.0":
+"@wallet-standard/app@npm:^1.1.0, @wallet-standard/app@npm:~1.1.0":
   version: 1.1.0
   resolution: "@wallet-standard/app@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
## Explanation

Prefer the injected solana provider now that we have passive listening for extension and IAB that ensures our other ecosystem clients will be notified when an injected solana provider initiates a wallet_createSession

This can be tested by:
1. Using browser playground with extension enabled
2. Connect to solana, be sure to include EVM networks
3. EVM and Solana cards should appear in the playground despite the Solana connection flow going through the injected Solana provider
4. ~~Check in the console.logs to ensure the injected provider was preferred~~ Add breakpoints to the `connect.ts` code to ensure the injected provider was announced first. The debug logger is broken currently, see [slack](https://consensys.slack.com/archives/C08SWDEN2GG/p1776802144246869). 


https://github.com/user-attachments/assets/e3da8893-32b3-4d62-8a27-0258481751da



## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1083

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
