### PR TITLE
ci: build RN playground APK on every release bump

### DIFF
--- a/.github/workflows/build-rn-playground-apk.yml
+++ b/.github/workflows/build-rn-playground-apk.yml
@@ -131,9 +131,19 @@ jobs:
           TAG="${{ inputs.release_tag }}"
           APK="${{ steps.apk.outputs.apk_name }}"
 
+          # The RN playground is `"private": true` so our release tooling
+          # doesn't tag it the way it tags other workspaces. Create the tag
+          # on the release commit ourselves so the GitHub Release below has
+          # something to attach to.
+          if ! git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Creating git tag $TAG at ${{ github.sha }}..."
+            git tag "$TAG" "${{ github.sha }}"
+            git push origin "refs/tags/$TAG"
+          fi
+
           # Ensure a GitHub Release exists for this tag (action-publish-release
-          # may only create one for the root monorepo tag). --notes-file /dev/null
-          # keeps it tidy; --verify-tag ensures the tag already exists in git.
+          # may only create one for the root monorepo tag). --verify-tag
+          # ensures the tag exists in git before we create the Release.
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             echo "Creating GitHub Release for $TAG..."
             gh release create "$TAG" \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -107,20 +107,26 @@ jobs:
           PLAYGROUND_TAG="${PKG_NAME}@${PKG_VERSION}"
           echo "PLAYGROUND_TAG=$PLAYGROUND_TAG" >> "$GITHUB_OUTPUT"
 
-          # Check that the tag exists AND was created on this commit.
-          # A tag from a prior release would point to an older commit.
-          TAG_COMMIT=$(git rev-list -n 1 "refs/tags/$PLAYGROUND_TAG" 2>/dev/null || echo "")
+          # Detect a release by comparing the playground version against the
+          # parent commit. The RN playground is `"private": true` (so it is
+          # never npm-published), and our release tooling only tags
+          # non-private workspaces. We therefore can't rely on a per-package
+          # tag existing on the release commit the way we can for other
+          # workspaces — see build-rn-playground-apk.yml, which creates the
+          # tag itself when uploading the APK.
+          if git cat-file -e "${{ github.sha }}^:playground/react-native-playground/package.json" 2>/dev/null; then
+            git show "${{ github.sha }}^:playground/react-native-playground/package.json" > /tmp/prev-rn-pkg.json
+            PREV_VERSION=$(node -p "require('/tmp/prev-rn-pkg.json').version")
+          else
+            PREV_VERSION=""
+          fi
 
-          if [ "$TAG_COMMIT" = "${{ github.sha }}" ]; then
+          if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$PKG_VERSION" ]; then
             echo "RELEASED=true" >> "$GITHUB_OUTPUT"
-            echo "$PLAYGROUND_TAG points to ${{ github.sha }} — released in this run"
+            echo "$PKG_NAME bumped $PREV_VERSION -> $PKG_VERSION in ${{ github.sha }} — will build APK"
           else
             echo "RELEASED=false" >> "$GITHUB_OUTPUT"
-            if [ -z "$TAG_COMMIT" ]; then
-              echo "$PLAYGROUND_TAG does not exist — playground was not released"
-            else
-              echo "$PLAYGROUND_TAG points to $TAG_COMMIT, not ${{ github.sha }} — stale tag from a prior release"
-            fi
+            echo "$PKG_NAME version unchanged at $PKG_VERSION — skipping APK build"
           fi
 
   publish-wagmi-to-gh-pages:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -121,9 +121,21 @@ jobs:
             PREV_VERSION=""
           fi
 
+          # Also skip if a tag for this version already exists. `git revert` of
+          # a release commit produces a "Revert ..." message that the
+          # IS_RELEASE filter (main.yml) rejects, so reverts never reach this
+          # step directly. But a release that re-uses a previously-tagged
+          # version (e.g., a re-release after a revert, or a workflow re-run)
+          # would otherwise rebuild the APK and fail when uploading to an
+          # existing release asset.
           if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$PKG_VERSION" ]; then
-            echo "RELEASED=true" >> "$GITHUB_OUTPUT"
-            echo "$PKG_NAME bumped $PREV_VERSION -> $PKG_VERSION in ${{ github.sha }} — will build APK"
+            if git rev-parse "refs/tags/$PLAYGROUND_TAG" >/dev/null 2>&1; then
+              echo "RELEASED=false" >> "$GITHUB_OUTPUT"
+              echo "$PLAYGROUND_TAG already exists in git — skipping APK build"
+            else
+              echo "RELEASED=true" >> "$GITHUB_OUTPUT"
+              echo "$PKG_NAME bumped $PREV_VERSION -> $PKG_VERSION in ${{ github.sha }} — will build APK"
+            fi
           else
             echo "RELEASED=false" >> "$GITHUB_OUTPUT"
             echo "$PKG_NAME version unchanged at $PKG_VERSION — skipping APK build"


### PR DESCRIPTION
## Summary

The `Build and publish RN Playground APK` job in `Publish Release` has been silently **skipped** on every release since `@metamask/react-native-playground` was made `"private": true` in #200 (back at v18.0.0). As a result, no APK has ever been attached to a GitHub Release for the RN playground, blocking the MMConnect mobile E2E migration that needs that APK.

## Root cause

`publish-release.yml`'s `check-rn-playground` step only sets `RELEASED=true` when a tag like `@metamask/react-native-playground@<version>` exists on the release commit. Our release tooling tags non-private workspaces (e.g. `@metamask/browser-playground` is tagged every release) but does not tag private ones. So the tag never appears, the gate is always false, and the APK job is skipped.

Verified empirically:

| Package | `private`? | Latest tag | Latest `package.json` |
|---|---|---|---|
| `@metamask/browser-playground` | no | `0.7.0` (Release/31.0.0) | 0.7.0 ✓ |
| `@metamask/react-native-playground` | **yes** | `0.1.3` (Release/18.0.0) | **0.4.0** ✗ |

Confirmed across the last several releases (27, 29, 30, 31): `Build and publish RN Playground APK` conclusion = `skipped`.

## Fix

Decouple the gate from tag existence:

1. **`publish-release.yml`** — `check-rn-playground` now detects a release by diffing the playground version against the parent commit (`HEAD~1`), instead of looking for a per-package tag.
2. **`build-rn-playground-apk.yml`** — when `upload_to_release` is true, the workflow now creates the `@metamask/react-native-playground@<version>` git tag on the release SHA itself before creating the GitHub Release and uploading the APK. This keeps `--verify-tag` happy without depending on upstream tooling.

`"private": true` stays in place — no change to the npm-publish-skip behavior.

## Verification (local, pre-merge)

Replayed the new gate logic against historical commits:

| SHA | prev → cur | new gate output |
|---|---|---|
| `bcb80300` Release/31.0.0 | 0.3.6 → 0.4.0 | `RELEASED=true` ✓ |
| `78c8677e` Release/30.0.0 | 0.3.5 → 0.3.6 | `RELEASED=true` ✓ |
| `796d865d` Release/29.0.0 | 0.3.4 → 0.3.5 | `RELEASED=true` ✓ |
| `583222d7` Release/28.0.0 | 0.3.3 → 0.3.4 | `RELEASED=true` ✓ |
| `5eb149e0` Release/27.0.0 | 0.3.2 → 0.3.3 | `RELEASED=true` ✓ |
| `4a10c242` (non-release fix) | 0.3.3 → 0.3.3 | `RELEASED=false` ✓ |

## Test plan

- [ ] Smoke test on this branch: `gh workflow run build-rn-playground-apk.yml --ref fix/rn-playground-apk-release-gate` (no inputs) — verifies the build still passes; uploads APK as a workflow artifact only.
- [ ] After merge, dispatch from `main` with `release_tag=@metamask/react-native-playground@0.4.0` to validate the tag-push code path against the current main commit and produce an APK on a real GitHub Release for the MMConnect E2E migration to consume.
- [ ] On the next release that bumps the RN playground, confirm `Build and publish RN Playground APK` runs (not skipped) and uploads to the Release.

## Open question

If the repo has tag protection rules that block `GITHUB_TOKEN` from pushing tags, the post-merge dispatch test will fail at `git push origin "refs/tags/$TAG"`. If that happens, we'll need to swap to a PAT or attach the APK to the existing root `vX.Y.Z` Release instead of creating a per-package one.

## Related

- Reported by Christopher Ferreira in the mobile E2E migration thread: https://consensys.slack.com/archives/C097JHB70J0/p1776425745812679
- Original (incorrect) failing-job link pointed at metamask-mobile, not this repo. The job here is being skipped, never running.