### PR TITLE
feat: add connect-multichain getSession() 

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `MetamaskConnectEVM.create()` now hydrates initial client state by reading the current session synchronously via `core.getSession()` and invoking `#onSessionChanged` directly, replacing the previous `emitSessionChanged()` approach. ([#279](https://github.com/MetaMask/connect-monorepo/pull/279))
+
 ## [1.0.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -81,6 +81,7 @@ function createMockCore(): MockCore {
     emitSessionChanged: vi.fn().mockImplementation(async (): Promise<void> => {
       mockCore.emit('wallet_sessionChanged', { sessionScopes: {} });
     }),
+    getSession: vi.fn().mockResolvedValue({ sessionScopes: {} }),
     disconnect: vi.fn().mockResolvedValue(undefined),
     connect: vi.fn().mockResolvedValue(undefined),
     invokeMethod: vi.fn().mockResolvedValue('0xsignature'),

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -102,6 +102,61 @@ function createMockCore(): MockCore {
 }
 
 describe('MetamaskConnectEVM', () => {
+  describe('create', () => {
+    it('fetches the initial session via core.getSession() during initialization', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.getSession = vi.fn().mockResolvedValue(session);
+
+      await MetamaskConnectEVM.create({ core: mockCore });
+
+      expect(mockCore.getSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('ensures the client is connected when core.getSession() resolves with EVM session scopes', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.getSession = vi.fn().mockResolvedValue(session);
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      expect(client.accounts).toEqual([
+        '0x1234567890123456789012345678901234567890',
+      ]);
+      expect(client.selectedChainId).toBe('0x1');
+    });
+
+    it('leaves the client disconnected when core.getSession() resolves with an empty session', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.getSession = vi
+        .fn()
+        .mockResolvedValue({ sessionScopes: {} } satisfies SessionData);
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      expect(client.accounts).toEqual([]);
+    });
+  });
+
   describe('#onSessionChanged', () => {
     describe('disconnects', () => {
       let mockCore: MockCore;

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -14,8 +14,7 @@ import {
   isRejectionError,
   TransportType,
 } from '@metamask/connect-multichain';
-import { createDeferredPromise, hexToNumber } from '@metamask/utils';
-import type { DeferredPromise } from '@metamask/utils';
+import { hexToNumber } from '@metamask/utils';
 
 import { IGNORED_METHODS } from './constants';
 import { enableDebug, logger } from './logger';
@@ -119,9 +118,6 @@ export class MetamaskConnectEVM {
    */
   #pendingPreferredChainId: Hex | undefined;
 
-  /** Deferred that resolves once #onSessionChanged has completed for the first time. */
-  readonly #initPromise: DeferredPromise;
-
   /**
    * Creates a new MetamaskConnectEVM instance.
    * Use the static `create()` method instead to ensure proper async initialization.
@@ -157,8 +153,6 @@ export class MetamaskConnectEVM {
     this.#displayUriHandler = this.#onDisplayUri.bind(this);
     this.#core.on('display_uri', this.#displayUriHandler);
 
-    this.#initPromise = createDeferredPromise();
-
     logger('Connect/EVM constructor completed');
   }
 
@@ -177,8 +171,8 @@ export class MetamaskConnectEVM {
     options: MetamaskConnectEVMOptions,
   ): Promise<MetamaskConnectEVM> {
     const instance = new MetamaskConnectEVM(options);
-    await instance.#core.emitSessionChanged();
-    await instance.#initPromise.promise;
+    const session = await instance.#core.getSession();
+    await instance.#onSessionChanged(session);
     return instance;
   }
 
@@ -795,8 +789,6 @@ export class MetamaskConnectEVM {
         accounts: initialAccounts,
       });
     }
-
-    this.#initPromise.resolve();
   }
 
   /**

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `getSession()` method on `MultichainCore` / `MetaMaskConnectMultichain` that returns the current CAIP `SessionData`. Returns an empty session (`{ sessionScopes: {} }`) when no transport is connected, otherwise dispatches `wallet_getSession` through the active transport. This lets ecosystem clients (EVM, Solana, etc.) read the current session synchronously during initialization instead of waiting for a `wallet_sessionChanged` event. ([#279](https://github.com/MetaMask/connect-monorepo/pull/279))
+
 ## [0.12.1]
 
 ### Fixed

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -3,7 +3,12 @@ import type { MultichainApiClient } from '@metamask/multichain-api-client';
 import type { Json } from '@metamask/utils';
 import * as t from 'vitest';
 
-import { MultichainCore, TransportType, type ConnectionStatus } from '.';
+import {
+  MultichainCore,
+  TransportType,
+  type ConnectionStatus,
+  type SessionData,
+} from '.';
 import type { RPCAPI, RpcUrlsMap } from './api/types';
 import type {
   ExtendedTransport,
@@ -44,6 +49,8 @@ class MockMultichainCore extends MultichainCore {
   openSimpleDeeplinkIfNeeded = (): void => undefined;
 
   emitSessionChanged = async (): Promise<void> => Promise.resolve();
+
+  getSession = async (): Promise<SessionData> => ({ sessionScopes: {} });
 
   /**
    * Exposes options for test assertions.

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import type {
   MultichainApiClient,
+  SessionData,
   SessionProperties,
 } from '@metamask/multichain-api-client';
 import type { CaipAccountId, Json } from '@metamask/utils';
@@ -75,6 +76,8 @@ export abstract class MultichainCore extends EventEmitter<SDKEvents> {
   abstract openSimpleDeeplinkIfNeeded(): void;
 
   abstract emitSessionChanged(): Promise<void>;
+
+  abstract getSession(): Promise<SessionData>;
 
   constructor(protected options: MultichainOptions) {
     super();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -1036,25 +1036,28 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     }
   }
 
-  // Provides a way for ecosystem clients (EVM, Solana, etc.) to get the current CAIP session data
-  // when instantiating themselves (as they would have already missed any initial sessionChanged events emitted by ConnectMultichain)
-  // without having to concern themselves with the current transport connection status.
-  async emitSessionChanged(): Promise<void> {
+  async getSession(): Promise<SessionData> {
     const emptySession = { sessionScopes: {} };
 
     if (!this.#transport?.isConnected()) {
       // If we aren't connected or connecting, there definitely is no active CAIP session
       // so we optimistically emit an empty session to signify that to the ecosystem client consumers (EVM, Solana, etc.)
-      this.emit('wallet_sessionChanged', emptySession);
-      return;
+      return emptySession;
     }
 
     // Otherwise, we need to fetch the current CAIP session from the wallet
-    const response = await this.transport.request({
+    const response = (await this.transport.request({
       method: 'wallet_getSession',
-    });
+    })) as { result: SessionData };
 
-    // And then simulate a sessionChanged event with the current CAIP session data
-    this.emit('wallet_sessionChanged', response.result ?? emptySession);
+    return response.result ?? emptySession;
+  }
+
+  // Provides a way for ecosystem clients (EVM, Solana, etc.) to get the current CAIP session data
+  // when instantiating themselves (as they would have already missed any initial sessionChanged events emitted by ConnectMultichain)
+  // without having to concern themselves with the current transport connection status.
+  async emitSessionChanged(): Promise<void> {
+    const session = await this.getSession();
+    this.emit('wallet_sessionChanged', session);
   }
 }

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -364,6 +364,164 @@ function testSuite<T extends MultichainOptions>({
       },
       { timeout: 15000 },
     );
+
+    t.describe(`${platform} getSession`, () => {
+      t.it(
+        `${platform} returns an empty session when the SDK has no active connection`,
+        async () => {
+          // Provide a default mock so any passive wallet_getSession invocation
+          // (e.g. web's DefaultTransport.init) resolves with no session.
+          mockedData.mockWalletGetSession.mockImplementation(
+            async () => undefined as any,
+          );
+
+          // Do not seed a stored transport so the SDK initializes in its
+          // pre-connected state (status: 'loaded' or 'pending').
+          sdk = await createSDK(testOptions);
+
+          t.expect(sdk.status).not.toBe('connected');
+
+          const session = await sdk.getSession();
+
+          t.expect(session).toStrictEqual({ sessionScopes: {} });
+
+          // Non-web platforms have no transport instance until connect() is
+          // called, so getSession must short-circuit without issuing a
+          // wallet_getSession request to MWP.
+          if (platform !== 'web') {
+            t.expect(
+              mockedData.mockDappClient.sendRequest,
+            ).not.toHaveBeenCalledWith(
+              t.expect.objectContaining({
+                name: MULTICHAIN_PROVIDER_STREAM_NAME,
+                data: t.expect.objectContaining({
+                  method: 'wallet_getSession',
+                }),
+              }),
+            );
+          }
+        },
+      );
+
+      t.it(
+        `${platform} returns the wallet session when the transport is connected`,
+        async () => {
+          mockedData.nativeStorageStub.setItem(
+            'multichain-transport',
+            transportString,
+          );
+
+          // For non-web platforms, MWPTransport.request short-circuits via a
+          // cached response in storage. Pre-seed it with the expected session
+          // so the connected code path is exercised deterministically across
+          // all platforms.
+          if (platform !== 'web') {
+            mockedData.nativeStorageStub.setItem(
+              'cache_wallet_getSession',
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'wallet_sessionChanged',
+                result: mockSessionData,
+              }),
+            );
+          }
+
+          mockedData.mockWalletGetSession.mockImplementation(
+            async () => mockSessionData,
+          );
+
+          t.vi
+            .spyOn(SessionStore.prototype, 'list')
+            .mockImplementation(async () =>
+              Promise.resolve([
+                await (mockedData as any).mockWalletGetSession(),
+              ]),
+            );
+
+          sdk = await createSDK(testOptions);
+
+          t.expect(sdk.status).toBe('connected');
+
+          mockedData.mockDefaultTransport.request.mockClear();
+          mockedData.mockDappClient.sendRequest.mockClear();
+
+          const session = await sdk.getSession();
+
+          t.expect(session).toStrictEqual(mockSessionData);
+
+          if (platform === 'web') {
+            // Web has no caching layer, so getSession must dispatch a
+            // wallet_getSession request directly to the DefaultTransport.
+            t.expect(
+              mockedData.mockDefaultTransport.request,
+            ).toHaveBeenCalledWith(
+              t.expect.objectContaining({ method: 'wallet_getSession' }),
+              t.expect.anything(),
+            );
+          }
+        },
+      );
+
+      t.it(
+        `${platform} falls back to an empty session when the wallet returns no result`,
+        async () => {
+          mockedData.nativeStorageStub.setItem(
+            'multichain-transport',
+            transportString,
+          );
+
+          // Seed the SDK into a connected state with a valid session so init
+          // succeeds, then swap the wallet response below to verify that
+          // getSession's `?? emptySession` fallback applies.
+          if (platform !== 'web') {
+            mockedData.nativeStorageStub.setItem(
+              'cache_wallet_getSession',
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'wallet_sessionChanged',
+                result: mockSessionData,
+              }),
+            );
+          }
+
+          mockedData.mockWalletGetSession.mockImplementation(
+            async () => mockSessionData,
+          );
+
+          t.vi
+            .spyOn(SessionStore.prototype, 'list')
+            .mockImplementation(async () =>
+              Promise.resolve([
+                await (mockedData as any).mockWalletGetSession(),
+              ]),
+            );
+
+          sdk = await createSDK(testOptions);
+
+          t.expect(sdk.status).toBe('connected');
+
+          // Now make the wallet return no result and (for non-web) clear the
+          // cached response so getSession actually re-queries the wallet.
+          mockedData.mockWalletGetSession.mockImplementation(
+            async () => undefined as any,
+          );
+          if (platform !== 'web') {
+            mockedData.nativeStorageStub.setItem(
+              'cache_wallet_getSession',
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'wallet_sessionChanged',
+                // result intentionally omitted to model an empty wallet response
+              }),
+            );
+          }
+
+          const session = await sdk.getSession();
+
+          t.expect(session).toStrictEqual({ sessionScopes: {} });
+        },
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Explanation

Add `getSession()` to `MultichainCore` / `MetaMaskConnectMultichain` that returns the current session or empty sessionScopes if no active session.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
