### PR TITLE
feat: send `sessionProperties: { eip1193-compatible': true }` on every `wallet_createSession` request issued by `connect-evm`

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send `sessionProperties: { 'eip1193-compatible': true }` on every `wallet_createSession` request issued by `connect-evm`. This lets wallets distinguish EIP-1193-style connections established through `@metamask/connect-evm` from pure Multichain API connections or other provider types (e.g. Solana Wallet Standard).
+
 ## [1.1.0]
 
 ### Changed

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Send `sessionProperties: { 'eip1193-compatible': true }` on every `wallet_createSession` request issued by `connect-evm`. This lets wallets distinguish EIP-1193-style connections established through `@metamask/connect-evm` from pure Multichain API connections or other provider types (e.g. Solana Wallet Standard).
+- Send `sessionProperties: { 'eip1193-compatible': true }` on every `wallet_createSession` request issued by `connect-evm`. This lets wallets distinguish EIP-1193-style connections established through `@metamask/connect-evm` from pure Multichain API connections or other provider types (e.g. Solana Wallet Standard) ([#285](https://github.com/MetaMask/connect-monorepo/pull/285))
 
 ## [1.1.0]
 

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -131,7 +131,7 @@ describe('MetamaskConnectEVM', () => {
       });
     });
 
-    it('passes { "eip1193-compatible": true } as sessionProperties on connect via wallet_requestPermissions', async () => {
+    it('passes { "eip1193-compatible": true } as sessionProperties when `wallet_requestPermissions` is called directly on provider', async () => {
       const mockCore = createMockCore();
       mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
       mockCore.connect.mockImplementation(async (): Promise<void> => {

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -104,6 +104,71 @@ function createMockCore(): MockCore {
 }
 
 describe('MetamaskConnectEVM', () => {
+  describe('sessionProperties', () => {
+    it('passes { "eip1193-compatible": true } as sessionProperties on connect', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await client.connect({ chainIds: ['0x1'] });
+
+      expect(mockCore.connect).toHaveBeenCalledTimes(1);
+      const [, , sessionProperties] = mockCore.connect.mock.calls[0];
+      expect(sessionProperties).toStrictEqual({
+        'eip1193-compatible': true,
+      });
+    });
+
+    it('passes { "eip1193-compatible": true } as sessionProperties on connect via wallet_requestPermissions', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0xabc0000000000000000000000000000000000001'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await client.connect({ chainIds: ['0x1'] });
+
+      await client.getProvider().request({
+        method: 'wallet_requestPermissions',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        params: [{ eth_accounts: {} }],
+      });
+
+      // Both connect calls (initial connect + the one triggered by
+      // wallet_requestPermissions) must include the eip1193-compatible flag
+      expect(mockCore.connect).toHaveBeenCalledTimes(2);
+      mockCore.connect.mock.calls.forEach((call) => {
+        const [, , sessionProperties] = call;
+        expect(sessionProperties).toStrictEqual({
+          'eip1193-compatible': true,
+        });
+      });
+    });
+  });
+
   describe('create', () => {
     it('fetches the current session via core.provider.getSession() during initialization', async () => {
       const mockCore = createMockCore();

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -16,7 +16,7 @@ import {
 } from '@metamask/connect-multichain';
 import { hexToNumber } from '@metamask/utils';
 
-import { IGNORED_METHODS } from './constants';
+import { CONNECT_EVM_SESSION_PROPERTIES, IGNORED_METHODS } from './constants';
 import { enableDebug, logger } from './logger';
 import { EIP1193Provider } from './provider';
 import type {
@@ -392,7 +392,7 @@ export class MetamaskConnectEVM {
       await this.#core.connect(
         caipChainIds as Scope[],
         caipAccountIds as CaipAccountId[],
-        undefined,
+        CONNECT_EVM_SESSION_PROPERTIES,
         forceRequest,
       );
 

--- a/packages/connect-evm/src/constants.ts
+++ b/packages/connect-evm/src/constants.ts
@@ -26,3 +26,22 @@ export const INTERCEPTABLE_METHODS = [
   'wallet_switchEthereumChain',
   'wallet_addEthereumChain',
 ];
+
+/**
+ * Session property key used to signal that the connection originated from an
+ * EIP-1193-compatible client (i.e. `@metamask/connect-evm`).
+ *
+ * Wallets receiving a `wallet_createSession` request can use this property to
+ * apply EIP-1193-specific UX (e.g. rendering a network picker on the dapp
+ * connection bar) that does not apply to pure Multichain API connections or
+ * other provider types like Solana Wallet Standard.
+ */
+export const EIP1193_COMPATIBLE_SESSION_PROPERTY = 'eip1193-compatible';
+
+/**
+ * Session properties sent on every `wallet_createSession` request issued by
+ * `@metamask/connect-evm` to identify the connection as EIP-1193-compatible.
+ */
+export const CONNECT_EVM_SESSION_PROPERTIES = {
+  [EIP1193_COMPATIBLE_SESSION_PROPERTY]: true,
+} as const;


### PR DESCRIPTION
## Summary

Sends `sessionProperties: { 'eip1193-compatible': true }` on every `wallet_createSession` request issued by `@metamask/connect-evm`. This lets the wallet distinguish EIP-1193-style connections established through `connect-evm` (which surfaces a familiar `window.ethereum`-like interface on top of the Multichain API) from pure Multichain API connections and other provider types like Solana Wallet Standard.

The wallet can then apply EVM-specific UX — most immediately, conditionally rendering the dapp connection bar's network picker only for connections that have this property — without inflicting that UX on non-EVM connections.

Jira: [WAPI-1482](https://consensyssoftware.atlassian.net/browse/WAPI-1482)

## What changed

### `packages/connect-evm/src/constants.ts`

- Added `EIP1193_COMPATIBLE_SESSION_PROPERTY` constant (`'eip1193-compatible'`).
- Added `CONNECT_EVM_SESSION_PROPERTIES` constant (`{ 'eip1193-compatible': true }`) — the session properties object sent with every connection.

### `packages/connect-evm/src/connect.ts`

- In `MetamaskConnectEVM.connect()`, replaced the `undefined` third argument to `this.#core.connect()` with `CONNECT_EVM_SESSION_PROPERTIES`. The `connect-multichain` layer already supports `sessionProperties` end-to-end (`mergeRequestedSessionWithExisting()` and all transport `connect()` paths), so the property flows through to the `wallet_createSession` request payload without any changes to `connect-multichain`.

### `packages/connect-evm/src/connect.test.ts`

- Added a new `describe('sessionProperties', ...)` block with two tests:
  - `connect()` passes `{ 'eip1193-compatible': true }` to `core.connect`.
  - `wallet_requestPermissions` re-entry path also passes the same session properties.

### `packages/connect-evm/CHANGELOG.md`

- Added an `### Added` entry under `[Unreleased]` documenting the new session property and the rationale.

## Test plan

- [x] Unit tests pass (41/41) — `yarn workspace @metamask/connect-evm run test:unit`
- [x] Lint passes with no warnings — `npx eslint packages/connect-evm/src/**`
- [x] Build succeeds — `yarn workspace @metamask/connect-evm run build`
- [x] Changelog validates — `yarn workspace @metamask/connect-evm run changelog:validate`
- [ ] Manual smoke test: connect via `connect-evm` against an extension build that surfaces the new session property and verify it appears in the persisted CAIP-25 caveat (requires the downstream `chain-agnostic-permission` change [here](https://github.com/MetaMask/core/pull/8731))
