### PR TITLE
fix: Fix `wallet_switchEthereumChain` to forward 'Unrecognized chain ID' error 

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cleanup initialization promise logic ([#281](https://github.com/MetaMask/connect-monorepo/pull/281))
 
+### Fixed
+
+- Fix `wallet_switchEthereumChain` (and `EvmClient.switchChain()` when called without a `chainConfiguration` fallback) to forward the original `Unrecognized chain ID` error to the dapp instead of replacing it with `No chain configuration found.` ([#287](https://github.com/MetaMask/connect-monorepo/pull/287))
+
 ## [1.0.0]
 
 ### Changed

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -84,6 +84,7 @@ function createMockCore(): MockCore {
     disconnect: vi.fn().mockResolvedValue(undefined),
     connect: vi.fn().mockResolvedValue(undefined),
     invokeMethod: vi.fn().mockResolvedValue('0xsignature'),
+    openSimpleDeeplinkIfNeeded: vi.fn(),
     provider: {
       getSession: vi.fn().mockResolvedValue({ sessionScopes: {} }),
     },
@@ -685,6 +686,122 @@ describe('MetamaskConnectEVM', () => {
       ]);
       expect(connectWithResult.chainId).toBe('0x89');
       expect(connectWithResult.result).toBe('0xtxhash');
+    });
+  });
+
+  describe('switchChain', () => {
+    let mockCore: MockCore;
+    let client: Awaited<ReturnType<typeof MetamaskConnectEVM.create>>;
+
+    const polygonChainConfiguration = {
+      chainId: '0x89',
+      chainName: 'Polygon',
+      nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
+      rpcUrls: ['https://polygon-rpc.com'],
+    };
+
+    beforeEach(async () => {
+      mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const session: SessionData = {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+          },
+        },
+      };
+      mockCore.emit('wallet_sessionChanged', session);
+      await new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+
+      // Ignore the eth_accounts call made during the connect flow above so
+      // each test can assert against a clean call log.
+      mockCore.transport.sendEip1193Message.mockClear();
+    });
+
+    it('falls back to wallet_addEthereumChain when wallet_switchEthereumChain fails with "Unrecognized chain ID" and chainConfiguration is provided', async () => {
+      mockCore.transport.sendEip1193Message.mockImplementation(
+        async (request: { method: string }) => {
+          if (request.method === 'wallet_switchEthereumChain') {
+            const error = new Error('Unrecognized chain ID 0x89') as Error & {
+              code: number;
+            };
+            error.code = 4902;
+            throw error;
+          }
+          return { result: null, id: 1, jsonrpc: '2.0' as const };
+        },
+      );
+
+      await client.switchChain({
+        chainId: '0x89',
+        chainConfiguration: polygonChainConfiguration,
+      });
+
+      const calls = mockCore.transport.sendEip1193Message.mock.calls.map(
+        ([req]) => (req as { method: string }).method,
+      );
+      expect(calls).toEqual([
+        'wallet_switchEthereumChain',
+        'wallet_addEthereumChain',
+      ]);
+    });
+
+    it('rethrows the original "Unrecognized chain ID" error (preserving code 4902) when no chainConfiguration is provided', async () => {
+      mockCore.transport.sendEip1193Message.mockImplementation(
+        async (request: { method: string }) => {
+          if (request.method === 'wallet_switchEthereumChain') {
+            const error = new Error('Unrecognized chain ID 0x89') as Error & {
+              code: number;
+            };
+            error.code = 4902;
+            throw error;
+          }
+          return { result: null, id: 1, jsonrpc: '2.0' as const };
+        },
+      );
+
+      await expect(
+        client.switchChain({ chainId: '0x89' }),
+      ).rejects.toMatchObject({
+        message: 'Unrecognized chain ID 0x89',
+        code: 4902,
+      });
+
+      const calls = mockCore.transport.sendEip1193Message.mock.calls.map(
+        ([req]) => (req as { method: string }).method,
+      );
+      expect(calls).toEqual(['wallet_switchEthereumChain']);
+      expect(calls).not.toContain('wallet_addEthereumChain');
+    });
+
+    it('rethrows non "Unrecognized chain ID" errors without falling back, even when chainConfiguration is provided', async () => {
+      mockCore.transport.sendEip1193Message.mockImplementation(
+        async (request: { method: string }) => {
+          if (request.method === 'wallet_switchEthereumChain') {
+            throw new Error('User rejected the request');
+          }
+          return { result: null, id: 1, jsonrpc: '2.0' as const };
+        },
+      );
+
+      await expect(
+        client.switchChain({
+          chainId: '0x89',
+          chainConfiguration: polygonChainConfiguration,
+        }),
+      ).rejects.toThrow('User rejected the request');
+
+      const calls = mockCore.transport.sendEip1193Message.mock.calls.map(
+        ([req]) => (req as { method: string }).method,
+      );
+      expect(calls).toEqual(['wallet_switchEthereumChain']);
+      expect(calls).not.toContain('wallet_addEthereumChain');
     });
   });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -579,8 +579,8 @@ export class MetamaskConnectEVM {
       return Promise.resolve();
     } catch (error) {
       await this.#trackWalletActionFailed(method, scope, params, error);
-      // Fallback to add the chain if its not configured in the wallet.
-      if ((error as Error).message.includes('Unrecognized chain ID')) {
+      const isChainMissingInWallet = (error as Error).message.includes('Unrecognized chain ID');
+      if (isChainMissingInWallet && chainConfiguration) {
         return this.#addEthereumChain(chainConfiguration);
       }
       throw error;

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -579,7 +579,9 @@ export class MetamaskConnectEVM {
       return Promise.resolve();
     } catch (error) {
       await this.#trackWalletActionFailed(method, scope, params, error);
-      const isChainMissingInWallet = (error as Error).message.includes('Unrecognized chain ID');
+      const isChainMissingInWallet = (error as Error).message.includes(
+        'Unrecognized chain ID',
+      );
       if (isChainMissingInWallet && chainConfiguration) {
         return this.#addEthereumChain(chainConfiguration);
       }


### PR DESCRIPTION
## Explanation

Previously, if the EIP-1193 provider was called with `wallet_switchEthereumChain` or the EvmClient's `switchChain()` was called without an add chain `chainConfiguration` fallback AND the chain did not exist on the wallet, the caller would get an error `"No chain configuration found."`. This was an incorrect and breaking change to the `Unrecognized chain ID` error expected by dapps for `wallet_switchEthereumChain` . 

This has been fixed by changing `switchChain()`/`wallet_switchEthereumChain` to correctly forward/re-throw a `Unrecognized chain ID` error if `chainConfiguration` is not provided.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
