### PR TITLE
refactor(connect-evm): inline CAIP helpers, drop `@metamask/chain-agnostic-permission`

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `@metamask/chain-agnostic-permission` dependency. The two helpers used from it (`getEthAccounts`, `getPermittedEthChainIds`) and the `parseScopeString` utility are now implemented locally on top of `@metamask/utils` primitives. This drops the transitive `@metamask/controller-utils` / `lodash` / `bn.js` / `eth-ens-namehash` / `fast-deep-equal` / `@metamask/ethjs-unit` chain from the `connect-evm` bundle.
+
 ## [1.2.0]
 
 ### Added

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@metamask/analytics": "workspace:^",
-    "@metamask/chain-agnostic-permission": "^1.2.2",
     "@metamask/connect-multichain": "workspace:^",
     "@metamask/utils": "^11.8.1"
   },

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-syntax -- Private class properties use established patterns */
 /* eslint-disable @typescript-eslint/naming-convention -- __PACKAGE_VERSION__ is an esbuild define convention */
 import { analytics } from '@metamask/analytics';
-import { parseScopeString } from '@metamask/chain-agnostic-permission';
 import type {
   MultichainCore,
   MultichainOptions,
@@ -29,7 +28,11 @@ import type {
   ProviderRequest,
   ProviderRequestInterceptor,
 } from './types';
-import { getEthAccounts, getPermittedEthChainIds } from './utils/caip';
+import {
+  getEthAccounts,
+  getPermittedEthChainIds,
+  parseScopeString,
+} from './utils/caip';
 import {
   isAccountsRequest,
   isAddChainRequest,

--- a/packages/connect-evm/src/utils/caip.test.ts
+++ b/packages/connect-evm/src/utils/caip.test.ts
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/no-shadow -- Vitest globals */
+import type { SessionData } from '@metamask/connect-multichain';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getEthAccounts,
+  getPermittedEthChainIds,
+  parseScopeString,
+} from './caip';
+
+describe('parseScopeString', () => {
+  it('returns just the namespace for a bare CAIP namespace', () => {
+    expect(parseScopeString('eip155')).toStrictEqual({ namespace: 'eip155' });
+    expect(parseScopeString('wallet')).toStrictEqual({ namespace: 'wallet' });
+  });
+
+  it('returns namespace + reference for a full CAIP-2 chain ID', () => {
+    expect(parseScopeString('eip155:1')).toStrictEqual({
+      namespace: 'eip155',
+      reference: '1',
+    });
+    expect(parseScopeString('eip155:137')).toStrictEqual({
+      namespace: 'eip155',
+      reference: '137',
+    });
+    expect(
+      parseScopeString('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+    ).toStrictEqual({
+      namespace: 'solana',
+      reference: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    });
+  });
+
+  it('returns an empty object for invalid scope strings', () => {
+    expect(parseScopeString('')).toStrictEqual({});
+    expect(parseScopeString('not a scope')).toStrictEqual({});
+    expect(parseScopeString('eip155:1:extra')).toStrictEqual({});
+  });
+});
+
+describe('getEthAccounts', () => {
+  it('returns [] for undefined sessionScopes', () => {
+    expect(getEthAccounts(undefined)).toStrictEqual([]);
+  });
+
+  it('returns [] for empty sessionScopes', () => {
+    expect(getEthAccounts({})).toStrictEqual([]);
+  });
+
+  it('extracts EIP-155 accounts across multiple scopes', () => {
+    const sessionScopes = {
+      'eip155:1': {
+        accounts: ['eip155:1:0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa'],
+        methods: [],
+        notifications: [],
+      },
+      'eip155:137': {
+        accounts: ['eip155:137:0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb'],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([
+      '0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa',
+      '0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb',
+    ]);
+  });
+
+  it('parses the eip155:0:<address> reference-zero form', () => {
+    const sessionScopes = {
+      'eip155:0': {
+        accounts: ['eip155:0:0xabc0000000000000000000000000000000000000'],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([
+      '0xabc0000000000000000000000000000000000000',
+    ]);
+  });
+
+  it('deduplicates addresses that appear in multiple scopes', () => {
+    const sharedAddress = '0xCCCCccccCCCCccccCCCCccccCCCCccccCCCCcccc';
+    const sessionScopes = {
+      'eip155:1': {
+        accounts: [`eip155:1:${sharedAddress}`],
+        methods: [],
+        notifications: [],
+      },
+      'eip155:10': {
+        accounts: [`eip155:10:${sharedAddress}`],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([sharedAddress]);
+  });
+
+  it('skips non-EIP-155 namespaces (e.g. solana, bip122)', () => {
+    const sessionScopes = {
+      'eip155:1': {
+        accounts: ['eip155:1:0xDDDDddddDDDDddddDDDDddddDDDDddddDDDDdddd'],
+        methods: [],
+        notifications: [],
+      },
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+        accounts: [
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([
+      '0xDDDDddddDDDDddddDDDDddddDDDDddddDDDDdddd',
+    ]);
+  });
+
+  it('drops accounts whose address is not a strict 0x hex string', () => {
+    const sessionScopes = {
+      'eip155:1': {
+        accounts: [
+          'eip155:1:0xEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeee',
+          'eip155:1:not-a-hex-address',
+        ],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([
+      '0xEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeee',
+    ]);
+  });
+
+  it('ignores scopes whose accounts array is missing or empty', () => {
+    const sessionScopes = {
+      'eip155:1': {
+        accounts: ['eip155:1:0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffff'],
+        methods: [],
+        notifications: [],
+      },
+      'eip155:137': {
+        methods: [],
+        notifications: [],
+      },
+      'eip155:42161': {
+        accounts: [],
+        methods: [],
+        notifications: [],
+      },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getEthAccounts(sessionScopes)).toStrictEqual([
+      '0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffff',
+    ]);
+  });
+});
+
+describe('getPermittedEthChainIds', () => {
+  it('returns [] for undefined sessionScopes', () => {
+    expect(getPermittedEthChainIds(undefined)).toStrictEqual([]);
+  });
+
+  it('returns [] for empty sessionScopes', () => {
+    expect(getPermittedEthChainIds({})).toStrictEqual([]);
+  });
+
+  it('converts EIP-155 references to 0x-prefixed hex chain IDs', () => {
+    const sessionScopes = {
+      'eip155:1': { accounts: [], methods: [], notifications: [] },
+      'eip155:137': { accounts: [], methods: [], notifications: [] },
+      'eip155:42161': { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual([
+      '0x1',
+      '0x89',
+      '0xa4b1',
+    ]);
+  });
+
+  it('skips bare-namespace scopes without a reference', () => {
+    const sessionScopes = {
+      eip155: { accounts: [], methods: [], notifications: [] },
+      'eip155:1': { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual(['0x1']);
+  });
+
+  it('skips non-EIP-155 namespaces', () => {
+    const sessionScopes = {
+      'eip155:1': { accounts: [], methods: [], notifications: [] },
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+        accounts: [],
+        methods: [],
+        notifications: [],
+      },
+      wallet: { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual(['0x1']);
+  });
+
+  it('handles chain IDs larger than Number.MAX_SAFE_INTEGER via BigInt', () => {
+    const big = '12345678901234567890';
+    const sessionScopes = {
+      [`eip155:${big}`]: { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual([
+      `0x${BigInt(big).toString(16)}`,
+    ]);
+  });
+
+  it('passes through already-hex references without double-encoding', () => {
+    const sessionScopes = {
+      'eip155:0xabc': { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual(['0xabc']);
+  });
+
+  it('deduplicates duplicate chain IDs (e.g. decimal vs hex form)', () => {
+    const sessionScopes = {
+      'eip155:1': { accounts: [], methods: [], notifications: [] },
+      'eip155:0x1': { accounts: [], methods: [], notifications: [] },
+    } as unknown as SessionData['sessionScopes'];
+
+    expect(getPermittedEthChainIds(sessionScopes)).toStrictEqual(['0x1']);
+  });
+});

--- a/packages/connect-evm/src/utils/caip.ts
+++ b/packages/connect-evm/src/utils/caip.ts
@@ -1,17 +1,97 @@
-import type { InternalScopesObject } from '@metamask/chain-agnostic-permission';
-import {
-  getPermittedEthChainIds as _getPermittedEthChainIds,
-  getEthAccounts as _getEthAccounts,
-} from '@metamask/chain-agnostic-permission';
 import type { SessionData } from '@metamask/connect-multichain';
+import {
+  isCaipChainId,
+  isCaipNamespace,
+  KnownCaipNamespace,
+  parseCaipAccountId,
+  parseCaipChainId,
+} from '@metamask/utils';
 
 import type { Address, Hex } from '../types';
 
 /**
- * Get the Ethereum accounts from the session data
+ * Result of parsing a CAIP scope string.
+ */
+type ParsedScope = {
+  namespace?: string;
+  reference?: string;
+};
+
+/**
+ * Parses a CAIP-217 scope string (`namespace` or `namespace:reference`) into
+ * its components.
  *
- * @param sessionScopes - The session scopes
- * @returns The Ethereum accounts
+ * Mirrors the behavior of `parseScopeString` from
+ * `@metamask/chain-agnostic-permission` so we can drop that dependency (and
+ * its transitive `@metamask/controller-utils` / `lodash` / `bn.js` /
+ * `eth-ens-namehash` chain) from the `connect-evm` bundle.
+ *
+ * @param scopeString - The scope string to parse.
+ * @returns An object containing `namespace` and (optionally) `reference`.
+ * Returns an empty object if the input is neither a valid CAIP namespace nor
+ * a valid CAIP-2 chain ID.
+ */
+export const parseScopeString = (scopeString: string): ParsedScope => {
+  if (isCaipNamespace(scopeString)) {
+    return { namespace: scopeString };
+  }
+  if (isCaipChainId(scopeString)) {
+    return parseCaipChainId(scopeString);
+  }
+  return {};
+};
+
+/**
+ * Returns true if the scope string is either an `eip155:*` chain scope or the
+ * `wallet:eip155` cross-chain wallet scope.
+ *
+ * @param scopeString - The scope string to check.
+ * @returns True if EIP-155-namespaced.
+ */
+const isEip155ScopeString = (scopeString: string): boolean => {
+  const { namespace } = parseScopeString(scopeString);
+  return (
+    namespace === KnownCaipNamespace.Eip155 ||
+    scopeString === `${KnownCaipNamespace.Wallet}:${KnownCaipNamespace.Eip155}`
+  );
+};
+
+/**
+ * Returns true if the value is a `0x`-prefixed strict hex string.
+ *
+ * @param value - The value to check.
+ * @returns True if `value` matches `/^0x[0-9a-fA-F]+$/`.
+ */
+const isStrictHexString = (value: string): value is Hex =>
+  /^0x[0-9a-fA-F]+$/u.test(value);
+
+/**
+ * Converts a CAIP-2 EIP-155 `reference` (decimal string, e.g. `"137"`) into a
+ * `0x`-prefixed hex chain ID. Tolerates already-hex inputs to mirror
+ * `@metamask/controller-utils.toHex`. Uses `BigInt` so chain IDs larger than
+ * `Number.MAX_SAFE_INTEGER` (e.g. some experimental chains) are handled
+ * correctly.
+ *
+ * @param reference - The CAIP-2 reference component of an `eip155` scope.
+ * @returns The reference as a `0x`-prefixed hex string.
+ */
+const referenceToHexChainId = (reference: string): Hex => {
+  if (isStrictHexString(reference)) {
+    return reference;
+  }
+  return `0x${BigInt(reference).toString(16)}`;
+};
+
+/**
+ * Get the unique Ethereum (EIP-155) accounts from the session scopes.
+ *
+ * Walks every scope's `accounts` array, keeps CAIP-10 account IDs whose chain
+ * is EIP-155 (or the `wallet:eip155` cross-chain wallet scope), and returns
+ * the unique 0x addresses.
+ *
+ * @param sessionScopes - The session scopes from `wallet_createSession` /
+ * `wallet_getSession` / `wallet_sessionChanged`.
+ * @returns The unique Ethereum addresses across all EIP-155 scopes.
  */
 export const getEthAccounts = (
   sessionScopes: SessionData['sessionScopes'] | undefined,
@@ -20,18 +100,33 @@ export const getEthAccounts = (
     return [];
   }
 
-  return _getEthAccounts({
-    requiredScopes: sessionScopes as InternalScopesObject,
-    optionalScopes: sessionScopes as InternalScopesObject,
-  });
+  const ethAccounts: Address[] = [];
+  for (const { accounts } of Object.values(sessionScopes)) {
+    if (!accounts) {
+      continue;
+    }
+    for (const account of accounts) {
+      const { address, chainId } = parseCaipAccountId(account);
+      if (isEip155ScopeString(chainId) && isStrictHexString(address)) {
+        ethAccounts.push(address);
+      }
+    }
+  }
+
+  return Array.from(new Set(ethAccounts));
 };
 
 /**
- * Get the permitted Ethereum chain IDs from the session scopes.
- * Wrapper around getPermittedEthChainIds from @metamask/chain-agnostic-permission
+ * Get the unique permitted Ethereum (EIP-155) chain IDs from the session
+ * scopes.
  *
- * @param sessionScopes - The session scopes
- * @returns The permitted Ethereum chain IDs
+ * Iterates the scope keys, keeps the `eip155:<reference>` ones, converts each
+ * decimal `reference` to a `0x`-prefixed hex chain ID, and returns the unique
+ * set.
+ *
+ * @param sessionScopes - The session scopes from `wallet_createSession` /
+ * `wallet_getSession` / `wallet_sessionChanged`.
+ * @returns The unique EIP-155 chain IDs as `0x`-prefixed hex strings.
  */
 export const getPermittedEthChainIds = (
   sessionScopes: SessionData['sessionScopes'] | undefined,
@@ -40,8 +135,13 @@ export const getPermittedEthChainIds = (
     return [];
   }
 
-  return _getPermittedEthChainIds({
-    requiredScopes: sessionScopes as InternalScopesObject,
-    optionalScopes: sessionScopes as InternalScopesObject,
-  });
+  const ethChainIds: Hex[] = [];
+  for (const scopeString of Object.keys(sessionScopes)) {
+    const { namespace, reference } = parseScopeString(scopeString);
+    if (namespace === KnownCaipNamespace.Eip155 && reference) {
+      ethChainIds.push(referenceToHexChainId(reference));
+    }
+  }
+
+  return Array.from(new Set(ethChainIds));
 };

--- a/packages/connect-evm/src/utils/caip.ts
+++ b/packages/connect-evm/src/utils/caip.ts
@@ -1,3 +1,16 @@
+// Inlined from `@metamask/chain-agnostic-permission@1.2.2` to avoid pulling
+// its transitive `controller-utils` / `lodash` / `bn.js` / `eth-ens-namehash`
+// chain into every consumer's `connect-evm` bundle (e.g. wagmi → LiFi).
+// Built on `@metamask/utils` primitives; semantics are identical to upstream.
+//
+// Upstream sources (pinned to commit `82aec7d`):
+// - `parseScopeString`: https://github.com/MetaMask/core/blob/82aec7d537f0cca3663c44c17e1560f6e00c9b8c/packages/chain-agnostic-permission/src/scope/types.ts#L93-L107
+// - `getEthAccounts`: https://github.com/MetaMask/core/blob/82aec7d537f0cca3663c44c17e1560f6e00c9b8c/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.ts#L77-L91
+// - `getPermittedEthChainIds`: https://github.com/MetaMask/core/blob/82aec7d537f0cca3663c44c17e1560f6e00c9b8c/packages/chain-agnostic-permission/src/operators/caip-permission-operator-permittedChains.ts#L43-L58
+//
+// If upstream changes semantics, mirror the change and bump the pinned commit.
+// Revisit if upstream ever splits `controller-utils` so the dep becomes cheap.
+
 import type { SessionData } from '@metamask/connect-multichain';
 import {
   isCaipChainId,
@@ -19,12 +32,7 @@ type ParsedScope = {
 
 /**
  * Parses a CAIP-217 scope string (`namespace` or `namespace:reference`) into
- * its components.
- *
- * Mirrors the behavior of `parseScopeString` from
- * `@metamask/chain-agnostic-permission` so we can drop that dependency (and
- * its transitive `@metamask/controller-utils` / `lodash` / `bn.js` /
- * `eth-ens-namehash` chain) from the `connect-evm` bundle.
+ * its components. See file header for upstream reference.
  *
  * @param scopeString - The scope string to parse.
  * @returns An object containing `namespace` and (optionally) `reference`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,7 +3998,6 @@ __metadata:
   dependencies:
     "@metamask/analytics": "workspace:^"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/chain-agnostic-permission": "npm:^1.2.2"
     "@metamask/connect-multichain": "workspace:^"
     "@metamask/utils": "npm:^11.8.1"
     "@types/jsdom": "npm:^21.1.7"


### PR DESCRIPTION
## Explanation

Replaces the three helpers `connect-evm` consumes from `@metamask/chain-agnostic-permission` (`getEthAccounts`, `getPermittedEthChainIds`, and `parseScopeString`) with a local ~70-line implementation that only uses primitives from `@metamask/utils` (`parseCaipChainId`, `parseCaipAccountId`, `isCaipChainId`, `isCaipNamespace`, `KnownCaipNamespace`).

This lets us drop `@metamask/chain-agnostic-permission` from `connect-evm`'s runtime dependencies, which transitively removes a sizeable subgraph from the consumer-side bundle: `@metamask/controller-utils` (and through it `bn.js`, `eth-ens-namehash`, `fast-deep-equal`, `lodash`, `@metamask/ethjs-unit`). `controller-utils` exports these via a single `util.mjs` module that is hard for downstream bundlers to split, so even tiny helper imports drag the whole subgraph in.

This is the smallest, lowest-risk PR in the LiFi bundle-size investigation series — no API change, no behavior change, just dropping an external dep.

### Behavior preservation

Identical semantics to the upstream helpers:

- `getEthAccounts` — walks every scope's `accounts[]`, keeps CAIP-10 IDs whose chain is `eip155:*` or the `wallet:eip155` cross-chain wallet scope, validates the address is a strict `0x` hex string, and dedups across scopes.
- `getPermittedEthChainIds` — iterates scope keys, keeps `eip155:<reference>`, hex-encodes the reference, and dedups. Uses `BigInt` so chain IDs larger than `Number.MAX_SAFE_INTEGER` (e.g. some experimental chains) are handled correctly.
- `parseScopeString` — returns `{namespace}` for a bare CAIP namespace, `{namespace, reference}` for a full CAIP-2 chain ID, and `{}` for invalid input.

The wrapper signature in `connect-evm` is unchanged (still takes `SessionData['sessionScopes']`), so all existing call sites in `connect.ts` work without modification.

## What changed

### `packages/connect-evm/src/utils/caip.ts`

- Removed all imports from `@metamask/chain-agnostic-permission`.
- Added local `parseScopeString` (now exported, previously imported from upstream).
- Added private helpers `isEip155ScopeString`, `isStrictHexString`, `referenceToHexChainId`.
- Reimplemented `getEthAccounts` and `getPermittedEthChainIds` using only `@metamask/utils` primitives.

### `packages/connect-evm/src/connect.ts`

- Replaced `import { parseScopeString } from '@metamask/chain-agnostic-permission'` with the local export from `./utils/caip`. Single call site (the `disconnect()` method) is unchanged.

### `packages/connect-evm/package.json`

- Removed `"@metamask/chain-agnostic-permission": "^1.2.2"` from `dependencies`.

### `packages/connect-evm/src/utils/caip.test.ts` (new)

19 new tests covering all three helpers, including:

- The `eip155:0:<address>` reference-zero account-id form.
- Mixed namespaces — `eip155`, `solana`, `wallet`, `bip122` — confirming non-EIP-155 scopes are correctly skipped.
- Dedup of addresses appearing in multiple scopes.
- Dedup of chain IDs in mixed decimal/hex form (`eip155:1` + `eip155:0x1`).
- Missing/empty `accounts` arrays.
- Address-validation rejection (e.g. `eip155:1:not-a-hex-address` is dropped).
- Large chain IDs that overflow `Number.MAX_SAFE_INTEGER` (verified via `BigInt`).
- Already-hex references (defensive, in case a non-conformant wallet ever produces them).

### `packages/connect-evm/CHANGELOG.md`

Added entry under `[Unreleased]` > `### Removed`.

## Bundle size analysis

Verified against `packages/connect-evm/dist/browser/es/connect-evm.mjs`:

| External imports | Before | After |
|---|---|---|
| `@metamask/utils` | ✅ kept | ✅ kept |
| `@metamask/chain-agnostic-permission` | ❌ external import | ✅ removed |

| Built file | Before | After | Delta |
|---|---|---|---|
| `dist/browser/es/connect-evm.mjs` | 42,667 B | 44,136 B | +1,469 B (+3.4%) |

The package's own bundle grows by ~1.5 KB because the `chain-agnostic-permission` helpers were previously marked `external` (not bundled into `connect-evm.mjs`); now their ~70-line replacement is inlined.

**The win is for downstream consumers**: with the previous `external` setup, every consumer's bundler had to fetch and pull in the `chain-agnostic-permission` → `controller-utils` → `lodash` / `bn.js` / `eth-ens-namehash` / `fast-deep-equal` / `ethjs-unit` graph. After this PR, none of those packages appear anywhere in the `connect-evm` import graph. For a representative wagmi-via-`@wagmi/connectors` consumer (e.g. LiFi/Jumper), this removes tens of KB gzipped from the lazy `@metamask/connect-evm` chunk — combined with the PR #244 lazy-MWP work, materially closes the bundle-size gap LiFi raised.

## Test plan

- [x] All 63 `connect-evm` tests pass (was 44 before; added 19 in the new `caip.test.ts`).
- [x] Full monorepo `yarn turbo run test` passes (16/16 tasks, includes `connect-multichain` and the playground packages that consume `connect-evm`).
- [x] Full monorepo `yarn build` passes (11/11 tasks).
- [x] `yarn constraints`, `yarn lint:dependencies`, prettier, and ESLint on all touched files pass clean. The 2 unrelated pre-existing lint errors in `playground/react-native-playground/expo-env.d.ts` are unchanged from `main`.
- [x] Bundle inspection: confirmed `dist/browser/es/connect-evm.mjs` no longer references `chain-agnostic-permission`, `controller-utils`, `lodash`, `bn.js`, `eth-ens-namehash`, `fast-deep-equal`, or `ethjs-unit` — only `@metamask/utils` remains as an external import.

## References

* Fixes https://consensyssoftware.atlassian.net/browse/WAPI-1487
* Related to https://github.com/MetaMask/connect-monorepo/pull/244 (lazy-MWP — same bundle-size workstream)