### PR TITLE
refactor(connect-evm): stop double-tracking EVM intercepted methods

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove `@metamask/chain-agnostic-permission` dependency. The two helpers used from it (`getEthAccounts`, `getPermittedEthChainIds`) and the `parseScopeString` utility are now implemented locally on top of `@metamask/utils` primitives. This drops the transitive `@metamask/controller-utils` / `lodash` / `bn.js` / `eth-ens-namehash` / `fast-deep-equal` / `@metamask/ethjs-unit` chain from the `connect-evm` bundle.
+- Remove duplicate `mmconnect_wallet_action_*` tracking from `MetamaskConnectEVM.switchChain`, the `wallet_requestPermissions` / `eth_requestAccounts` interceptor branch, and `#addEthereumChain`. These methods are already tracked by the multichain `RequestRouter` when the request lands at the wallet, so the EVM shim was double-firing on Mixpanel. The `@metamask/analytics` package and the `getWalletActionAnalyticsProperties` / `isRejectionError` helpers are no longer imported here.
 
 ## [1.2.0]
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-syntax -- Private class properties use established patterns */
 /* eslint-disable @typescript-eslint/naming-convention -- __PACKAGE_VERSION__ is an esbuild define convention */
-import { analytics } from '@metamask/analytics';
 import type {
   MultichainCore,
   MultichainOptions,
@@ -9,8 +8,6 @@ import type {
 } from '@metamask/connect-multichain';
 import {
   createMultichainClient,
-  getWalletActionAnalyticsProperties,
-  isRejectionError,
   TransportType,
 } from '@metamask/connect-multichain';
 import { hexToNumber } from '@metamask/utils';
@@ -182,125 +179,6 @@ export class MetamaskConnectEVM {
     }
     await instance.#onSessionChanged(session);
     return instance;
-  }
-
-  /**
-   * Gets the core options for analytics checks.
-   *
-   * @returns The multichain options from the core instance
-   */
-  #getCoreOptions(): MultichainOptions {
-    return (this.#core as any).options as MultichainOptions;
-  }
-
-  /**
-   * Creates invoke options for analytics tracking.
-   *
-   * @param method - The RPC method name
-   * @param scope - The CAIP chain ID scope
-   * @param params - The method parameters
-   * @returns Invoke options object for analytics
-   */
-  #createInvokeOptions(
-    method: string,
-    scope: Scope,
-    params: unknown[],
-  ): {
-    scope: Scope;
-    request: { method: string; params: unknown[] };
-  } {
-    return {
-      scope,
-      request: { method, params },
-    };
-  }
-
-  /**
-   * Tracks a wallet action requested event.
-   *
-   * @param method - The RPC method name
-   * @param scope - The CAIP chain ID scope
-   * @param params - The method parameters
-   */
-  async #trackWalletActionRequested(
-    method: string,
-    scope: Scope,
-    params: unknown[],
-  ): Promise<void> {
-    const coreOptions = this.#getCoreOptions();
-    try {
-      const invokeOptions = this.#createInvokeOptions(method, scope, params);
-      const props = await getWalletActionAnalyticsProperties(
-        coreOptions,
-        this.#core.storage,
-        invokeOptions,
-        this.#core.transportType,
-      );
-      analytics.track('mmconnect_wallet_action_requested', props);
-    } catch (error) {
-      logger('Error tracking mmconnect_wallet_action_requested event', error);
-    }
-  }
-
-  /**
-   * Tracks a wallet action succeeded event.
-   *
-   * @param method - The RPC method name
-   * @param scope - The CAIP chain ID scope
-   * @param params - The method parameters
-   */
-  async #trackWalletActionSucceeded(
-    method: string,
-    scope: Scope,
-    params: unknown[],
-  ): Promise<void> {
-    const coreOptions = this.#getCoreOptions();
-    try {
-      const invokeOptions = this.#createInvokeOptions(method, scope, params);
-      const props = await getWalletActionAnalyticsProperties(
-        coreOptions,
-        this.#core.storage,
-        invokeOptions,
-        this.#core.transportType,
-      );
-      analytics.track('mmconnect_wallet_action_succeeded', props);
-    } catch (error) {
-      logger('Error tracking mmconnect_wallet_action_succeeded event', error);
-    }
-  }
-
-  /**
-   * Tracks a wallet action failed or rejected event based on the error.
-   *
-   * @param method - The RPC method name
-   * @param scope - The CAIP chain ID scope
-   * @param params - The method parameters
-   * @param error - The error that occurred
-   */
-  async #trackWalletActionFailed(
-    method: string,
-    scope: Scope,
-    params: unknown[],
-    error: unknown,
-  ): Promise<void> {
-    const coreOptions = this.#getCoreOptions();
-    try {
-      const invokeOptions = this.#createInvokeOptions(method, scope, params);
-      const props = await getWalletActionAnalyticsProperties(
-        coreOptions,
-        this.#core.storage,
-        invokeOptions,
-        this.#core.transportType,
-      );
-      const isRejection = isRejectionError(error);
-      if (isRejection) {
-        analytics.track('mmconnect_wallet_action_rejected', props);
-      } else {
-        analytics.track('mmconnect_wallet_action_failed', props);
-      }
-    } catch {
-      logger('Error tracking wallet action rejected or failed event', error);
-    }
   }
 
   /**
@@ -538,8 +416,6 @@ export class MetamaskConnectEVM {
     chainId: Hex;
     chainConfiguration?: AddEthereumChainParameter;
   }): Promise<void> {
-    const method = 'wallet_switchEthereumChain';
-    const scope: Scope = `eip155:${hexToNumber(chainId)}`;
     const params = [{ chainId }];
 
     // TODO (wenfix): better way to return here other than resolving.
@@ -558,9 +434,10 @@ export class MetamaskConnectEVM {
       return Promise.resolve();
     }
 
-    await this.#trackWalletActionRequested(method, scope, params);
-
     try {
+      // Analytics for `wallet_switchEthereumChain` is emitted by the
+      // multichain `RequestRouter` when the request lands at the wallet;
+      // tracking here as well would double-fire on Mixpanel.
       const result = await this.#request({
         method: 'wallet_switchEthereumChain',
         params,
@@ -573,7 +450,6 @@ export class MetamaskConnectEVM {
         throw new Error(resultWithError.error.message);
       }
 
-      await this.#trackWalletActionSucceeded(method, scope, params);
       if ((result as { result: unknown }).result === null) {
         // result is successful we eagerly call onChainChanged to update the provider's selected chain ID.
         await this.#cacheChainId(chainId);
@@ -581,7 +457,6 @@ export class MetamaskConnectEVM {
       }
       return Promise.resolve();
     } catch (error) {
-      await this.#trackWalletActionFailed(method, scope, params, error);
       const isChainMissingInWallet = (error as Error).message.includes(
         'Unrecognized chain ID',
       );
@@ -626,7 +501,6 @@ export class MetamaskConnectEVM {
       const shouldForceConnectionRequest =
         request.method === 'wallet_requestPermissions';
 
-      const { method, params } = request;
       const permitted = getPermittedEthChainIds(this.#sessionScopes);
       if (permitted.length === 0) {
         permitted.push(DEFAULT_CHAIN_ID);
@@ -641,21 +515,15 @@ export class MetamaskConnectEVM {
         ...permitted.filter((id) => id !== preferred),
       ];
 
-      const scope: Scope = `eip155:${hexToNumber(preferred)}`;
-
-      await this.#trackWalletActionRequested(method, scope, params);
-
-      try {
-        const result = await this.connect({
-          chainIds,
-          forceRequest: shouldForceConnectionRequest,
-        });
-        await this.#trackWalletActionSucceeded(method, scope, params);
-        return result;
-      } catch (error) {
-        await this.#trackWalletActionFailed(method, scope, params, error);
-        throw error;
-      }
+      // Connection-level analytics (`mmconnect_connection_*`) for this path
+      // is emitted inside `MultichainCore.connect()`. Wallet-action analytics
+      // for `eth_requestAccounts` / `wallet_requestPermissions` would
+      // double-count on Mixpanel if tracked here, so we let the multichain
+      // layer handle it.
+      return this.connect({
+        chainIds,
+        forceRequest: shouldForceConnectionRequest,
+      });
     }
 
     if (isSwitchChainRequest(request)) {
@@ -699,7 +567,6 @@ export class MetamaskConnectEVM {
     chainConfiguration?: AddEthereumChainParameter,
   ): Promise<void> {
     logger('addEthereumChain called', { chainConfiguration });
-    const method = 'wallet_addEthereumChain';
 
     if (!chainConfiguration) {
       throw new Error('No chain configuration found.');
@@ -710,27 +577,20 @@ export class MetamaskConnectEVM {
       (chainConfiguration.chainId as Hex) ||
       this.#provider.selectedChainId ||
       '0x1';
-    const decimalChainId = hexToNumber(chainId);
-    const scope: Scope = `eip155:${decimalChainId}`;
     const params = [chainConfiguration];
 
-    await this.#trackWalletActionRequested(method, scope, params);
+    // Analytics for `wallet_addEthereumChain` is emitted by the multichain
+    // `RequestRouter` when the request lands at the wallet; tracking here as
+    // well would double-fire on Mixpanel.
+    const result = await this.#request({
+      method: 'wallet_addEthereumChain',
+      params,
+    });
 
-    try {
-      const result = await this.#request({
-        method: 'wallet_addEthereumChain',
-        params,
-      });
-
-      if ((result as { result: unknown }).result === null) {
-        // if result is successful we eagerly call onChainChanged to update the provider's selected chain ID.
-        await this.#cacheChainId(chainId);
-        this.#onChainChanged(chainId);
-      }
-      await this.#trackWalletActionSucceeded(method, scope, params);
-    } catch (error) {
-      await this.#trackWalletActionFailed(method, scope, params, error);
-      throw error;
+    if ((result as { result: unknown }).result === null) {
+      // if result is successful we eagerly call onChainChanged to update the provider's selected chain ID.
+      await this.#cacheChainId(chainId);
+      this.#onChainChanged(chainId);
     }
   }
 


### PR DESCRIPTION
## Summary

`MetamaskConnectEVM` was tracking `wallet_switchEthereumChain`, `wallet_addEthereumChain`, and `eth_requestAccounts` / `wallet_requestPermissions` at the EVM shim layer **in addition to** the multichain `RequestRouter`. Mixpanel was seeing **two** `_failed` events for one logical failure (and similarly two `_succeeded` / two `_requested`).

This PR removes the shim's tracking; the router is the single source of truth for these methods. The `@metamask/analytics` import and the `getWalletActionAnalyticsProperties` / `isRejectionError` helpers are no longer needed in `connect-evm`.

## Behaviour change to flag on review

On the `switchChain` → "Unrecognized chain ID" → `addEthereumChain` recovery path, the failed switch attempt **no longer fires a `_failed` event on its own**. The shim swallows the original `Unrecognized chain ID` error and recovers via `addEthereumChain`; only the successful add is tracked.

This matches the user's experience of one logical chain switch and was an explicit product call. If we want to keep visibility on switch-attempts-that-needed-recovery, we can add that as a separate dedicated event in a follow-up rather than re-introducing the duplicate `_failed`.

## Test plan

- [x] `yarn test` passes on `@metamask/connect-evm` (63 tests; no shim tracking assertions existed, so nothing to update).
- [x] `yarn build` succeeds across the workspace.
- [x] `yarn lint:eslint` and `yarn changelog:validate` clean.
- [ ] Reviewer: confirm we're OK with the recovery-path behaviour change.

## Related

- Spike: [WAPI-1253](https://consensyssoftware.atlassian.net/browse/WAPI-1253) — _Unpack all code paths that trigger `mmconnect_wallet_action_failed`_.
- Sibling PRs from the same spike (independent — can land in any order):
  - **This PR** — dedupe EVM shim tracking.
  - **Coming**: fix `isRejectionError` to unwrap `RPCInvokeMethodErr` and tighten the "user" heuristic.
  - **Coming**: attach `failure_reason` to `mmconnect_wallet_action_failed` / `mmconnect_connection_failed`.

## Out of scope

- `failure_reason` plumbing, classifier helper, schema changes — separate PR.
- `isRejectionError` unwrap fix — separate PR.