### PR TITLE
fix(connect-multichain): three `isRejectionError` correctness fixes (unwrap, drop 4100, tighten "user" heuristic)

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `isRejectionError` now unwraps `RPCInvokeMethodErr` so a wallet-side `code: 4001` survives the SDK's transport-boundary wrapping and is correctly classified as a user rejection. Previously the outer `code: 53` masked the inner code, and rejections were only caught via a fragile message-substring fallback — any rejection whose message didn't contain "reject" / "denied" / "cancel" was misclassified as a failure and inflated the `mmconnect_wallet_action_failed` count.
+- Tightened the `isRejectionError` message heuristics so generic "user" mentions (e.g. Account Abstraction's `"user operation reverted"`) are no longer treated as user rejections — only explicit phrases like "user rejected" / "user denied" / "user cancelled" / "user canceled".
+
 ## [0.13.0]
 
 ### Uncategorized

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `isRejectionError` now unwraps `RPCInvokeMethodErr` so wallet-side codes (e.g. `4001`) survive the SDK's transport-boundary wrapping instead of being masked by the wrapper's static `code: 53` and falling through to a message-substring fallback. ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
-- `isRejectionError` no longer treats `code: 4100 Unauthorized` as a user rejection. `4100` is returned by the CAIP-25 permission layer when a method isn't in the granted scope (it fires before the method handler runs) — a permission/support signal, not a user decision. Pairs with the new `wallet_unauthorized` `failure_reason` bucket added in [#290](https://github.com/MetaMask/connect-monorepo/pull/290). ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
-- Tightened the `isRejectionError` "user" message heuristic so phrases like "user operation reverted" (Account Abstraction) no longer count as rejections — only explicit "user rejected" / "user denied" / "user cancelled" / "user canceled". ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
+- Tightened `isRejectionError` so `mmconnect_wallet_action_rejected` more accurately reflects user-driven cancellations: it now unwraps `RPCInvokeMethodErr` (so wallet-side codes survive the router's transport-boundary wrapping rather than being masked by the wrapper's `code: 53`), no longer classifies EIP-1193 `4100 Unauthorized` as a rejection (it's a CAIP-25 permission denial, not a user decision), and narrows the bare `"user"` substring match to four explicit phrases — `"user rejected"` / `"user denied"` / `"user cancelled"` / `"user canceled"` — so unrelated messages like Account Abstraction's `"user operation reverted"` no longer count. Net effect: `_rejected` becomes more precise; `_failed` picks up everything `4100` was previously hiding. ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
 
 ## [0.13.0]
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `isRejectionError` now unwraps `RPCInvokeMethodErr` so a wallet-side `code: 4001` survives the SDK's transport-boundary wrapping and is correctly classified as a user rejection. Previously the outer `code: 53` masked the inner code, and rejections were only caught via a fragile message-substring fallback — any rejection whose message didn't contain "reject" / "denied" / "cancel" was misclassified as a failure and inflated the `mmconnect_wallet_action_failed` count.
-- Tightened the `isRejectionError` message heuristics so generic "user" mentions (e.g. Account Abstraction's `"user operation reverted"`) are no longer treated as user rejections — only explicit phrases like "user rejected" / "user denied" / "user cancelled" / "user canceled".
+- `isRejectionError` now unwraps `RPCInvokeMethodErr` so wallet-side codes (e.g. `4001`) survive the SDK's transport-boundary wrapping instead of being masked by the wrapper's static `code: 53` and falling through to a message-substring fallback. ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
+- `isRejectionError` no longer treats `code: 4100 Unauthorized` as a user rejection. `4100` is returned by the CAIP-25 permission layer when a method isn't in the granted scope (it fires before the method handler runs) — a permission/support signal, not a user decision. Pairs with the new `wallet_unauthorized` `failure_reason` bucket added in [#290](https://github.com/MetaMask/connect-monorepo/pull/290). ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
+- Tightened the `isRejectionError` "user" message heuristic so phrases like "user operation reverted" (Account Abstraction) no longer count as rejections — only explicit "user rejected" / "user denied" / "user cancelled" / "user canceled". ([#292](https://github.com/MetaMask/connect-monorepo/pull/292))
 
 ## [0.13.0]
 

--- a/packages/connect-multichain/src/multichain/utils/analytics.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.test.ts
@@ -16,11 +16,23 @@ t.describe('isRejectionError', () => {
     t.expect(isRejectionError({ code: 4001, message: 'anything' })).toBe(true);
   });
 
-  t.it('returns true for code 4100 (unauthorized)', () => {
-    t.expect(isRejectionError({ code: 4100, message: 'denied by user' })).toBe(
-      true,
-    );
-  });
+  t.it(
+    'returns false for code 4100 (unauthorized) — a permission/support signal, not a user rejection',
+    () => {
+      // 4100 is what the CAIP-25 permission layer returns when a method
+      // isn't in the granted scope. Classifying it as `_rejected` inflated
+      // the rejected bucket and hid permission issues from `_failed`. The
+      // canonical 4100 message even contains the substring "by the user",
+      // so we have to inspect the code explicitly to avoid mis-bucketing.
+      t.expect(
+        isRejectionError({
+          code: 4100,
+          message:
+            'The requested account and/or method has not been authorized by the user.',
+        }),
+      ).toBe(false);
+    },
+  );
 
   t.it('returns true for messages mentioning explicit user action', () => {
     t.expect(isRejectionError({ message: 'User rejected the request' })).toBe(

--- a/packages/connect-multichain/src/multichain/utils/analytics.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable id-length -- vitest alias */
+import * as t from 'vitest';
+
+import { isRejectionError } from './analytics';
+import { RPCInvokeMethodErr } from '../../domain';
+
+t.describe('isRejectionError', () => {
+  t.it('returns false for non-object errors', () => {
+    t.expect(isRejectionError(null)).toBe(false);
+    t.expect(isRejectionError(undefined)).toBe(false);
+    t.expect(isRejectionError('User rejected')).toBe(false);
+    t.expect(isRejectionError(42)).toBe(false);
+  });
+
+  t.it('returns true for EIP-1193 user-rejected code 4001', () => {
+    t.expect(isRejectionError({ code: 4001, message: 'anything' })).toBe(true);
+  });
+
+  t.it('returns true for code 4100 (unauthorized)', () => {
+    t.expect(isRejectionError({ code: 4100, message: 'denied by user' })).toBe(
+      true,
+    );
+  });
+
+  t.it('returns true for messages mentioning explicit user action', () => {
+    t.expect(isRejectionError({ message: 'User rejected the request' })).toBe(
+      true,
+    );
+    t.expect(isRejectionError({ message: 'User denied signature' })).toBe(true);
+    t.expect(isRejectionError({ message: 'User cancelled' })).toBe(true);
+    t.expect(isRejectionError({ message: 'Request rejected' })).toBe(true);
+  });
+
+  t.it(
+    'does NOT treat unrelated "user" mentions as rejections (avoids false positives)',
+    () => {
+      // Account Abstraction error messages often contain "user operation"
+      t.expect(isRejectionError({ message: 'user operation reverted' })).toBe(
+        false,
+      );
+      t.expect(isRejectionError({ message: 'user agent not supported' })).toBe(
+        false,
+      );
+    },
+  );
+
+  t.it(
+    'unwraps RPCInvokeMethodErr to detect wallet-side rejection codes',
+    () => {
+      // Outer error has code: 53 (the SDK's static internal code), but the
+      // inner wallet code is 4001 — the classifier must look at rpcCode.
+      const wrapped = new RPCInvokeMethodErr(
+        'RPC Request failed with code 4001: Some random message that does not match heuristics',
+        4001,
+        'Some random message that does not match heuristics',
+      );
+      t.expect(isRejectionError(wrapped)).toBe(true);
+    },
+  );
+});

--- a/packages/connect-multichain/src/multichain/utils/analytics.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.ts
@@ -60,15 +60,20 @@ export function isRejectionError(error: unknown): boolean {
   const { code, message } = getUnwrappedErrorDetails(error);
   const errorMessage = message.toLowerCase();
 
+  // EIP-1193 4001 "User Rejected Request" is the canonical rejection code.
+  // Note: 4100 "Unauthorized" is deliberately NOT matched here. On multichain
+  // sessions it's what the CAIP-25 permission layer returns when a method
+  // isn't in the granted scope (the layer rejects it before the method
+  // handler runs). That's a permission/support signal, not a user-driven
+  // rejection — misclassifying it as `_rejected` hides genuine permission
+  // issues from `_failed`.
   return (
-    code === 4001 || // User rejected request (common EIP-1193 code)
-    code === 4100 || // Unauthorized (common rejection code)
+    code === 4001 ||
     errorMessage.includes('reject') ||
     errorMessage.includes('denied') ||
     errorMessage.includes('cancel') ||
-    // Bare "user" match is intentionally narrow to avoid false positives on
-    // messages like "user operation reverted" (Account Abstraction). Only
-    // treats it as a rejection if it sounds like the user actively declined.
+    // Narrow "user …" matches — bare "user" is too greedy (catches Account
+    // Abstraction errors like "user operation reverted").
     errorMessage.includes('user rejected') ||
     errorMessage.includes('user denied') ||
     errorMessage.includes('user cancelled') ||

--- a/packages/connect-multichain/src/multichain/utils/analytics.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.ts
@@ -9,10 +9,45 @@ import type {
   StoreClient,
   TransportType,
 } from '../../domain';
-import { getPlatformType } from '../../domain';
+import { getPlatformType, RPCInvokeMethodErr } from '../../domain';
+
+/**
+ * Pulls the most informative `code` / `message` pair out of an error,
+ * unwrapping `RPCInvokeMethodErr` so the wallet-side code (e.g. 4001) is
+ * visible to classifiers instead of being hidden behind the SDK's static
+ * `code: 53`. Falls back to the outer error if there is no inner wallet code.
+ *
+ * @param error - The error object to inspect
+ * @returns The most relevant `{ code, message }` pair we can extract
+ */
+function getUnwrappedErrorDetails(error: unknown): {
+  code: number | undefined;
+  message: string;
+} {
+  if (typeof error !== 'object' || error === null) {
+    return { code: undefined, message: '' };
+  }
+
+  if (error instanceof RPCInvokeMethodErr) {
+    return {
+      code: error.rpcCode ?? error.code,
+      message: error.rpcMessage ?? error.message ?? '',
+    };
+  }
+
+  const errorObj = error as { code?: number; message?: string };
+  return {
+    code: errorObj.code,
+    message: errorObj.message ?? '',
+  };
+}
 
 /**
  * Checks if an error represents a user rejection.
+ *
+ * Unwraps `RPCInvokeMethodErr` so the wallet's `code: 4001` survives the
+ * SDK's transport-boundary wrapping (the outer error otherwise reports
+ * `code: 53`, which would never match the heuristics here).
  *
  * @param error - The error object to check
  * @returns True if the error indicates a user rejection, false otherwise
@@ -22,17 +57,22 @@ export function isRejectionError(error: unknown): boolean {
     return false;
   }
 
-  const errorObj = error as { code?: number; message?: string };
-  const errorCode = errorObj.code;
-  const errorMessage = errorObj.message?.toLowerCase() ?? '';
+  const { code, message } = getUnwrappedErrorDetails(error);
+  const errorMessage = message.toLowerCase();
 
   return (
-    errorCode === 4001 || // User rejected request (common EIP-1193 code)
-    errorCode === 4100 || // Unauthorized (common rejection code)
+    code === 4001 || // User rejected request (common EIP-1193 code)
+    code === 4100 || // Unauthorized (common rejection code)
     errorMessage.includes('reject') ||
     errorMessage.includes('denied') ||
     errorMessage.includes('cancel') ||
-    errorMessage.includes('user')
+    // Bare "user" match is intentionally narrow to avoid false positives on
+    // messages like "user operation reverted" (Account Abstraction). Only
+    // treats it as a rejection if it sounds like the user actively declined.
+    errorMessage.includes('user rejected') ||
+    errorMessage.includes('user denied') ||
+    errorMessage.includes('user cancelled') ||
+    errorMessage.includes('user canceled')
   );
 }
 


### PR DESCRIPTION
## Summary

Three related correctness fixes in `isRejectionError`, the classifier that decides whether a failed wallet promise should fire `mmconnect_wallet_action_rejected` (user cancelled) or `mmconnect_wallet_action_failed` (something went wrong).

### 1. Unwrap `RPCInvokeMethodErr`

The multichain `RequestRouter` re-throws every wallet error wrapped in `RPCInvokeMethodErr`, whose outer `code` is the SDK's static `53`. `isRejectionError` was only inspecting the outer error, so the wallet's actual `code` (e.g. `4001` for "user rejected") was invisible.

When the wallet's error message *also* contained a substring like `"reject"` / `"denied"` / `"cancel"` we got lucky and the fallback heuristic caught it. But anything else — say `code: 4001` with message `"Signature aborted by user"` — fell through and was misclassified as a `_failed` event.

The fix introduces a small `getUnwrappedErrorDetails` helper that returns the inner `rpcCode` / `rpcMessage` when the error is an `RPCInvokeMethodErr`, falling back to the outer `code` / `message` otherwise. `isRejectionError` now reads from this helper.

### 2. Drop `code: 4100` from the rejection set

EIP-1193 `4100 Unauthorized` was being treated as a user rejection. On the multichain transport, `4100` is what the [CAIP-25 permission layer](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/src/handlers/wallet-invokeMethod.ts) returns when a method isn't in the granted scope — it fires before the wallet's method handler ever runs. That's a permission/support signal, not a user-driven rejection.

Classifying it as `_rejected` inflated the rejected bucket (every "method outside scope" call counted as a cancellation) and hid genuine permission issues from `_failed`. After this change, those cases correctly surface as `_failed` — and pair with the new `wallet_unauthorized` `failure_reason` bucket added in #290 once both PRs land.

Note: the canonical `4100` error message literally contains `"by the user"`, so we explicitly check the code rather than relying on message heuristics.

### 3. Tighten the "user" message heuristic

The previous heuristic flagged anything containing the bare substring `"user"` as a rejection. Too greedy — Account Abstraction routinely produces errors like `"user operation reverted"` which have nothing to do with the user actively declining a prompt. Replaced with four explicit phrases: `"user rejected"`, `"user denied"`, `"user cancelled"`, `"user canceled"` (US + UK spelling).

## Test plan

New `analytics.test.ts` covers:

- Non-object inputs → `false`.
- `code === 4001` → `true`.
- **`code === 4100` → `false`** (with the canonical `"... by the user."` message to prove the message-substring fallback doesn't re-route it).
- Plain rejection messages (`"User rejected"`, `"User denied"`, `"User cancelled"`, `"Request rejected"`) → `true`.
- **Regression**: `RPCInvokeMethodErr` wrapping `{ code: 4001, message: "Some non-matching message" }` → `true` (proves the unwrap works).
- **Regression**: `"user operation reverted"` / `"user agent not supported"` → `false` (proves the heuristic is no longer greedy).

- [x] `yarn test` passes on `@metamask/connect-multichain`.
- [x] `yarn build` succeeds across the workspace.
- [x] `yarn lint:eslint` and `yarn changelog:validate` clean.

## Why this can ship independently

- No public API change — `isRejectionError` keeps the same signature.
- Doesn't depend on the [`failure_reason` schema PR](https://github.com/consensys-vertical-apps/metamask-sdk-analytics-api/pull/31).
- Conflict-free with #290: both PRs introduce an identical `getUnwrappedErrorDetails` helper, but the helper is byte-identical on both branches so git merges them cleanly.

## Expected analytics effect after merge

`mmconnect_wallet_action_rejected` will go **down** (4100s and unwrapped rejections both leave the rejected bucket) and `mmconnect_wallet_action_failed` will go **up** by an unknown magnitude. Worth flagging in the team channel when this rolls out so nobody panics that "failure rate spiked" or "rejection rate dropped 30%."

## Related

- Spike: [WAPI-1253](https://consensyssoftware.atlassian.net/browse/WAPI-1253).
- Sibling PR from the same spike (independent — can land in any order):
  - [#290](https://github.com/MetaMask/connect-monorepo/pull/290) — attach `failure_reason` to `mmconnect_wallet_action_failed` / `mmconnect_connection_failed`. Adds the `wallet_unauthorized` bucket this PR's `4100` change feeds into.
- [#291](https://github.com/MetaMask/connect-monorepo/pull/291) was previously paired with this PR but was closed — source review showed the EVM-intercepted-method paths never reach `RequestRouter`, so the "duplication" it claimed to remove didn't actually exist.

