### PR TITLE
fix(connect-evm): normalize account request returns

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return method-specific values from intercepted EIP-1193 account requests: `eth_requestAccounts` now resolves to an accounts array, and `eth_coinbase` now resolves to the selected account instead of the full accounts array.
+
 ### Removed
 
 - Remove `@metamask/chain-agnostic-permission` dependency. The two helpers used from it (`getEthAccounts`, `getPermittedEthChainIds`) and the `parseScopeString` utility are now implemented locally on top of `@metamask/utils` primitives. This drops the transitive `@metamask/controller-utils` / `lodash` / `bn.js` / `eth-ens-namehash` / `fast-deep-equal` / `@metamask/ethjs-unit` chain from the `connect-evm` bundle.

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Return method-specific values from intercepted EIP-1193 account requests: `eth_requestAccounts` now resolves to an accounts array, and `eth_coinbase` now resolves to the selected account instead of the full accounts array.
-
 ### Removed
 
 - Remove `@metamask/chain-agnostic-permission` dependency. The two helpers used from it (`getEthAccounts`, `getPermittedEthChainIds`) and the `parseScopeString` utility are now implemented locally on top of `@metamask/utils` primitives. This drops the transitive `@metamask/controller-utils` / `lodash` / `bn.js` / `eth-ens-namehash` / `fast-deep-equal` / `@metamask/ethjs-unit` chain from the `connect-evm` bundle.
+
+### Fixed
+
+- Return method-specific values from intercepted EIP-1193 account requests: `eth_requestAccounts` now resolves to an accounts array, and `eth_coinbase` now resolves to the selected account instead of the full accounts array. [297](https://github.com/MetaMask/connect-monorepo/pull/297)
 
 ## [1.2.0]
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Return method-specific values from intercepted EIP-1193 account requests: `eth_requestAccounts` now resolves to an accounts array, and `eth_coinbase` now resolves to the selected account instead of the full accounts array. [297](https://github.com/MetaMask/connect-monorepo/pull/297)
+- Return method-specific values from intercepted EIP-1193 account requests: `eth_requestAccounts` now resolves to an accounts array, and `eth_coinbase` now resolves to the selected account instead of the full accounts array. ([#297](https://github.com/MetaMask/connect-monorepo/pull/297))
 
 ## [1.2.0]
 

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -871,6 +871,119 @@ describe('MetamaskConnectEVM', () => {
   });
 
   describe('#requestInterceptor', () => {
+    it('returns an accounts array for eth_requestAccounts', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await expect(
+        client.getProvider().request({
+          method: 'eth_requestAccounts',
+          params: [],
+        }),
+      ).resolves.toEqual(['0x1234567890123456789012345678901234567890']);
+    });
+
+    it('keeps wallet_requestPermissions returning the connect result', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      mockCore.connect.mockImplementation(async (): Promise<void> => {
+        const session: SessionData = {
+          sessionScopes: {
+            'eip155:1': {
+              methods: [],
+              notifications: [],
+              accounts: ['eip155:1:0x1234567890123456789012345678901234567890'],
+            },
+          },
+        };
+        mockCore.emit('wallet_sessionChanged', session);
+      });
+
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      await expect(
+        client.getProvider().request({
+          method: 'wallet_requestPermissions',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          params: [{ eth_accounts: {} }],
+        }),
+      ).resolves.toEqual({
+        accounts: ['0x1234567890123456789012345678901234567890'],
+        chainId: '0x1',
+      });
+    });
+
+    it('returns all accounts for eth_accounts', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const connectPromise = new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+      mockCore.emit('wallet_sessionChanged', {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: [
+              'eip155:1:0x1111111111111111111111111111111111111111',
+              'eip155:1:0x2222222222222222222222222222222222222222',
+            ],
+          },
+        },
+      });
+      await connectPromise;
+
+      await expect(
+        client.getProvider().request({ method: 'eth_accounts', params: [] }),
+      ).resolves.toEqual([
+        '0x1111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222',
+      ]);
+    });
+
+    it('returns the selected account for eth_coinbase', async () => {
+      const mockCore = createMockCore();
+      mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
+      const client = await MetamaskConnectEVM.create({ core: mockCore });
+
+      const connectPromise = new Promise<void>((resolve) => {
+        client.getProvider().once('connect', () => resolve());
+      });
+      mockCore.emit('wallet_sessionChanged', {
+        sessionScopes: {
+          'eip155:1': {
+            methods: [],
+            notifications: [],
+            accounts: [
+              'eip155:1:0x1111111111111111111111111111111111111111',
+              'eip155:1:0x2222222222222222222222222222222222222222',
+            ],
+          },
+        },
+      });
+      await connectPromise;
+
+      await expect(
+        client.getProvider().request({ method: 'eth_coinbase', params: [] }),
+      ).resolves.toBe('0x1111111111111111111111111111111111111111');
+    });
+
     it('wallet_requestPermissions passes forceRequest: true to core.connect', async () => {
       const mockCore = createMockCore();
       mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -651,6 +651,9 @@ export class MetamaskConnectEVM {
           forceRequest: shouldForceConnectionRequest,
         });
         await this.#trackWalletActionSucceeded(method, scope, params);
+        if (request.method === 'eth_requestAccounts') {
+          return result.accounts;
+        }
         return result;
       } catch (error) {
         await this.#trackWalletActionFailed(method, scope, params, error);
@@ -669,6 +672,9 @@ export class MetamaskConnectEVM {
     }
 
     if (isAccountsRequest(request)) {
+      if (request.method === 'eth_coinbase') {
+        return this.#provider.selectedAccount ?? null;
+      }
       return this.#provider.accounts;
     }
 


### PR DESCRIPTION
## Explanation

This fixes the EIP-1193 return shapes for intercepted Connect EVM account requests while preserving the existing request routing through the Connect EVM interceptor and `connect()` flow.

Previously, `provider.request({ method: 'eth_requestAccounts' })` resolved to the higher-level `client.connect()` result:

```ts
{ accounts, chainId }
```

EIP-1193 consumers expect the method-specific result instead, so `eth_requestAccounts` now resolves to the accounts array:

```ts
accounts
```

The same audit found `eth_coinbase` sharing the `eth_accounts` handler and returning the full accounts array. `eth_coinbase` now resolves to the selected account, while `eth_accounts` continues to resolve to the full accounts array.

`wallet_requestPermissions` intentionally keeps the existing Connect EVM return shape for this PR.

## References

- Related external validation: thirdweb-dev/web3-onboard#2390
- EIP-1193 requires `provider.request()` to resolve with the requested method's result.
- EIP-1102 specifies `eth_requestAccounts` resolves to an accounts array.

## Testing

- `yarn workspace @metamask/connect-evm test:unit`
- `yarn tsc --noEmit -p packages/connect-evm/tsconfig.json`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
