### PR TITLE
feat(playground): add MWP deeplink failure repro panel

### DIFF
--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added an **MWP deeplink failure repros** collapsible panel (`MwpDeeplinkReproCard`) that surfaces one `metamask://connect/mwp?…` deeplink per failure branch in the mobile app's `ConnectionRegistry.handleConnectDeeplink`. Lets QA reproducibly trigger each branch (parse failures, internal-origin block, decompression mismatch, payload-too-large, etc.) without needing a misconfigured dapp, and acts as the verification surface for the Sentry coverage added in MetaMask/metamask-mobile#30343.
+
 ## [0.7.4]
 
 ### Changed

--- a/playground/browser-playground/src/App.tsx
+++ b/playground/browser-playground/src/App.tsx
@@ -15,6 +15,7 @@ import { ScopeCard } from './components/ScopeCard';
 import { LegacyEVMCard } from './components/LegacyEVMCard';
 import { WagmiCard } from './components/WagmiCard';
 import { SolanaWalletCard } from './components/SolanaWalletCard';
+import { MwpDeeplinkReproCard } from './components/MwpDeeplinkReproCard';
 import { AnalyticsTestBench } from './components/AnalyticsTestBench';
 import { useSolanaSDK } from './sdk/SolanaProvider';
 import { Buffer } from 'buffer';
@@ -471,6 +472,9 @@ function App() {
             </div>
           </section>
         )}
+        <div className="mt-8">
+          <MwpDeeplinkReproCard />
+        </div>
       </div>
     </div>
   );

--- a/playground/browser-playground/src/components/MwpDeeplinkReproCard.tsx
+++ b/playground/browser-playground/src/components/MwpDeeplinkReproCard.tsx
@@ -1,0 +1,232 @@
+/**
+ * MwpDeeplinkReproCard
+ *
+ * A QA-focused debug panel that surfaces a curated set of MWP (Mobile Wallet
+ * Protocol) deeplinks designed to exercise both the happy path and every known
+ * failure path inside the mobile app's `ConnectionRegistry.handleConnectDeeplink`
+ * (`metamask-mobile/app/core/SDKConnectV2/services/connection-registry.ts`).
+ *
+ * Goals:
+ * 1. Give QA / SDETs a reproducible way to trigger each failure branch without
+ *    needing a real dapp that happens to be misconfigured in just the right way.
+ * 2. Provide a target surface for verifying Sentry coverage of those failure
+ *    branches (see MetaMask/metamask-mobile PR #30343).
+ *
+ * Each row renders:
+ *   - A human-readable label and the failure branch it targets
+ *   - The literal deeplink URL (so it can be copied)
+ *   - A "Tap on mobile" anchor (only useful on a mobile browser, since
+ *     `metamask://` URLs only resolve when the OS has MetaMask installed)
+ *
+ * NOTE: This panel is for QA only. It is collapsed by default and gated behind
+ * an explicit toggle so it does not clutter the default playground UX.
+ */
+
+import { useMemo, useState } from 'react';
+
+type ReproRow = {
+  id: string;
+  label: string;
+  expectedFailure: string;
+  buildUrl: () => string;
+};
+
+const VALID_REQUEST = {
+  sessionRequest: {
+    id: '11111111-2222-3333-4444-555555555555',
+    publicKeyB64: 'AoBDLWxRbJNe8yUv5bmmoVnNo8DCilzbFz/nWD+RKC2V',
+    channel: 'handshake:aabbccdd-1122-3344-5566-778899aabbcc',
+    mode: 'trusted',
+    // `expiresAt` is intentionally far in the future so the request itself is
+    // not the reason a downstream check fails.
+    expiresAt: Date.now() + 1000 * 60 * 60,
+  },
+  metadata: {
+    dapp: {
+      name: 'MMC Playground (QA Repro)',
+      url: 'https://playground.metamask.io',
+    },
+    sdk: {
+      version: '0.0.0-qa-repro',
+      platform: 'JavaScript',
+    },
+  },
+};
+
+const encode = (obj: unknown) => encodeURIComponent(JSON.stringify(obj));
+
+const ROWS: ReproRow[] = [
+  {
+    id: 'control-happy-path',
+    label: 'Control: well-formed connect deeplink',
+    expectedFailure:
+      'No failure — the mobile app should reach Connection.create and then fail at the relay handshake (which is the only step we cannot fake from a dapp). Useful as a baseline.',
+    buildUrl: () =>
+      `metamask://connect/mwp?p=${encode(VALID_REQUEST)}`,
+  },
+  {
+    id: 'no-payload',
+    label: 'No payload param',
+    expectedFailure: 'parseConnectionRequest throws "No payload found in URL."',
+    buildUrl: () => 'metamask://connect/mwp',
+  },
+  {
+    id: 'malformed-json',
+    label: 'Payload is not valid JSON',
+    expectedFailure:
+      'JSON.parse inside parseConnectionRequest throws SyntaxError.',
+    buildUrl: () => 'metamask://connect/mwp?p=not-json',
+  },
+  {
+    id: 'invalid-shape',
+    label: 'Payload parses as JSON but is not a ConnectionRequest',
+    expectedFailure:
+      'isConnectionRequest() returns false → "Invalid connection request structure."',
+    buildUrl: () => `metamask://connect/mwp?p=${encode({ hello: 'world' })}`,
+  },
+  {
+    id: 'invalid-uuid',
+    label: 'sessionRequest.id is not a UUID',
+    expectedFailure:
+      'isConnectionRequest() rejects the non-UUID id → "Invalid connection request structure."',
+    buildUrl: () =>
+      `metamask://connect/mwp?p=${encode({
+        ...VALID_REQUEST,
+        sessionRequest: {
+          ...VALID_REQUEST.sessionRequest,
+          id: 'not-a-uuid',
+        },
+      })}`,
+  },
+  {
+    id: 'internal-origin-dapp-url',
+    label: 'dapp.url claims to be an internal origin',
+    expectedFailure:
+      'INTERNAL_ORIGINS check throws "External transactions cannot use internal origins". (In practice isConnectionRequest already rejects non-https dapp.url values, so this hits the upstream guard first.)',
+    buildUrl: () =>
+      `metamask://connect/mwp?p=${encode({
+        ...VALID_REQUEST,
+        metadata: {
+          ...VALID_REQUEST.metadata,
+          dapp: { ...VALID_REQUEST.metadata.dapp, url: 'metamask' },
+        },
+      })}`,
+  },
+  {
+    id: 'compression-flag-mismatch',
+    label: 'c=1 (compressed) flag set, but payload is plain JSON',
+    expectedFailure:
+      'decompressPayloadB64 throws while trying to inflate non-deflated bytes.',
+    buildUrl: () =>
+      `metamask://connect/mwp?p=${encode(VALID_REQUEST)}&c=1`,
+  },
+  {
+    id: 'payload-too-large',
+    label: 'Payload over 1MB',
+    expectedFailure: 'parseConnectionRequest throws "Payload too large (max 1MB)."',
+    buildUrl: () => {
+      // 1MB + 1 byte after URL encoding. Repeating "a" stays the same length
+      // when URI-encoded, so length === byte count for the `p` value.
+      const oneMbPlusOne = 'a'.repeat(1024 * 1024 + 1);
+      return `metamask://connect/mwp?p=${oneMbPlusOne}`;
+    },
+  },
+];
+
+export function MwpDeeplinkReproCard() {
+  const [expanded, setExpanded] = useState(false);
+  const rows = useMemo(() => ROWS, []);
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="text-sm text-gray-500 underline hover:text-gray-700"
+      >
+        Show QA: MWP deeplink failure repros
+      </button>
+    );
+  }
+
+  return (
+    <section className="bg-white rounded-lg p-8 mb-6 shadow-sm border border-dashed border-gray-300">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-800">
+            QA: MWP deeplink failure repros
+          </h2>
+          <p className="text-sm text-gray-600 mt-1 max-w-2xl">
+            Each row below produces a <code>metamask://connect/mwp?…</code>{' '}
+            deeplink that targets a specific branch inside the mobile app&apos;s{' '}
+            <code>ConnectionRegistry.handleConnectDeeplink</code> error
+            handling. Open this page on a mobile device with MetaMask Mobile
+            installed and tap a row to exercise that branch. Each failure
+            should produce both a <code>REMOTE_CONNECTION_REQUEST_FAILED</code>{' '}
+            MetaMetrics event and a Sentry event tagged{' '}
+            <code>feature: mm-connect</code>.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="text-xs text-gray-400 hover:text-gray-600 ml-4"
+        >
+          Hide
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {rows.map((row) => {
+          const url = (() => {
+            try {
+              return row.buildUrl();
+            } catch (e) {
+              return `<failed to build URL: ${
+                e instanceof Error ? e.message : String(e)
+              }>`;
+            }
+          })();
+          return (
+            <div
+              key={row.id}
+              className="border border-gray-200 rounded p-4"
+              data-testid={`mwp-repro-${row.id}`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-gray-800">{row.label}</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    {row.expectedFailure}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 shrink-0">
+                  <a
+                    href={url}
+                    className="text-center bg-blue-500 text-white px-3 py-1 rounded text-sm hover:bg-blue-600 transition-colors"
+                  >
+                    Tap on mobile
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      navigator.clipboard?.writeText(url).catch(() => {
+                        /* clipboard unavailable; ignore */
+                      });
+                    }}
+                    className="bg-gray-200 text-gray-700 px-3 py-1 rounded text-sm hover:bg-gray-300 transition-colors"
+                  >
+                    Copy URL
+                  </button>
+                </div>
+              </div>
+              <p className="font-mono text-[11px] text-gray-500 mt-3 break-all">
+                {url.length > 200 ? `${url.slice(0, 200)}… (${url.length} chars)` : url}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a collapsible **QA: MWP deeplink failure repros** card to the browser-playground that surfaces one `metamask://connect/mwp?…` deeplink per known failure branch in MetaMask Mobile's `ConnectionRegistry.handleConnectDeeplink`.

Companion PR: [fix(sdk-connect-v2): report deeplink failures to Sentry](https://github.com/MetaMask/metamask-mobile/pull/30343). This panel is the verification surface for the Sentry coverage added there — without it, reproducibly exercising each failure branch from a real dapp is awkward (it generally requires a misconfigured dapp built specifically to trigger one branch).

### What's in the panel

Each row renders the literal deeplink URL, a **Copy URL** button, and a **Tap on mobile** anchor that resolves on devices with MetaMask Mobile installed. The targeted branches:

| # | Label | Failure branch in mobile |
|---|---|---|
| 1 | Control: well-formed connect deeplink | None — happy path through `parseConnectionRequest`; should fail at the relay handshake (the one step that cannot be faked from the dapp) |
| 2 | No payload param | `parseConnectionRequest` → `"No payload found in URL."` |
| 3 | Payload is not valid JSON | `JSON.parse` → `SyntaxError` |
| 4 | Payload parses but is not a ConnectionRequest | `isConnectionRequest()` → `"Invalid connection request structure."` |
| 5 | `sessionRequest.id` is not a UUID | `isConnectionRequest()` rejects non-UUID id |
| 6 | `dapp.url` claims to be an internal origin | `INTERNAL_ORIGINS` check (in practice the URL-shape validator inside `isConnectionRequest` hits first; both are useful to confirm) |
| 7 | `c=1` flag set but payload is plain JSON | `decompressPayloadB64` throws on non-deflated bytes |
| 8 | Payload over 1MB | `parseConnectionRequest` → `"Payload too large (max 1MB)."` |

The panel is **collapsed by default** behind a small *Show QA: MWP deeplink failure repros* link, so it does not pollute the default playground UX.

### Why not generate QR codes too?

QR codes for `metamask://` URIs would be useful for testing from desktop, but adding a QR library to the playground is more dependency surface than this is worth. The Copy + tap-on-mobile combo covers the realistic QA flow (open the playground on the device, tap each row).

## Test plan

Local dev:

- [ ] `yarn start` in `playground/browser-playground` and open in a desktop browser → playground renders unchanged; the collapsed *Show QA: MWP deeplink failure repros* link appears at the bottom of the page.
- [ ] Click the link → the panel expands and shows 8 rows with copy + tap-on-mobile buttons.
- [ ] Click *Copy URL* on each row → URL lands in the clipboard.
- [ ] *Hide* button collapses the panel back.

End-to-end (with [companion mobile PR](https://github.com/MetaMask/metamask-mobile/pull/30343) installed on a debug build):

- [ ] Open the playground on a mobile device with MetaMask Mobile installed.
- [ ] Tap *Tap on mobile* on row 2 (No payload param) → mobile shows the connection error toast.
- [ ] Confirm a `REMOTE_CONNECTION_REQUEST_FAILED` MetaMetrics event was fired with `failure_reason: "No payload found in URL."`.
- [ ] Confirm a Sentry event was captured with tags `feature: mm-connect`, `operation: handle_connect_deeplink` and the redacted URL in context.
- [ ] Repeat for rows 3–8 and confirm each `failure_reason` matches the table above.
- [ ] Tap row 1 (control) → should reach the handshake (eventually times out at the relay since no wallet is on the other end of the session id).

## Notes

- No existing tests changed; the existing `App.test.tsx` (which is broken pre-existing — Babel JSX parse error) is unaffected.
- No runtime deps added.
- Changelog entry added under `[Unreleased]`.