### PR TITLE
feat: allow disabling analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,16 @@ Host pages integrating MetaMask Connect need to allow a few origins in their [Co
 ### Required
 
 ```
-connect-src wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io;
+connect-src wss://mm-sdk-relay.api.cx.metamask.io;
 img-src data:;
 ```
 
 - `wss://mm-sdk-relay.api.cx.metamask.io` — the WebSocket URL of the MetaMask relay used for remote connections (mobile, no-extension, etc.). Unavoidable — the relay cannot be proxied or deferred from within the library, and remote connections will fail without it.
-- `https://mm-sdk-analytics.api.cx.metamask.io` — the telemetry endpoint used by `@metamask/analytics`. Required for the connection lifecycle events the SDK emits by default. You can override the host via the `METAMASK_ANALYTICS_ENDPOINT` env var at build time, but some analytics endpoint must be reachable.
 - `img-src data:` — the install/QR-code modal in `@metamask/multichain-ui` embeds the MetaMask fox SVG as a `data:` URI inside the generated QR code. Without this, the QR code will fail to render entirely.
 
 ### Also consider
 
+- **`https://mm-sdk-analytics.api.cx.metamask.io`** — telemetry endpoint used by `@metamask/analytics` when analytics are enabled. Analytics are enabled by default; set `analytics.enabled: false` to disable analytics events and omit this endpoint from `connect-src`.
 - **`style-src 'unsafe-inline'`** — `@metamask/multichain-ui` is built with [Stencil](https://stenciljs.com/), which injects component styles at runtime inside Shadow DOM. Strict CSPs without `'unsafe-inline'` (or an equivalent nonce/hash strategy) may break modal styling.
 - **RPC endpoints you pass to `api.infuraProjectId` / `api.readonlyRPCMap` / `supportedNetworks`** — e.g. `https://*.infura.io`, your own node provider, or a public RPC. These are supplied by your dApp, so add whatever `connect-src` entries match the endpoints you configure.
 - **`https://metamask.app.link` and `metamask://`** — used for mobile deeplinks / universal links. These are top-level navigations and are not normally subject to `connect-src`, but strict CSPs that use `navigate-to` or `form-action` may need to allow them.

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `analytics.disable()` to stop event collection and clear queued analytics events. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
+
 ## [0.5.0]
 
 ### Added

--- a/packages/analytics/src/analytics.test.ts
+++ b/packages/analytics/src/analytics.test.ts
@@ -103,6 +103,56 @@ t.describe('Analytics Integration', () => {
     scope.done();
   });
 
+  t.it('should stop tracking after disable is called', async () => {
+    let captured: EventV2[] = [];
+    scope = nock('http://127.0.0.4')
+      .post('/v2/events', (body) => {
+        captured = body;
+        return true;
+      })
+      .optionally()
+      .reply(
+        200,
+        { status: 'success' },
+        { 'Content-Type': 'application/json' },
+      );
+
+    analytics = new Analytics('http://127.0.0.4');
+    analytics.enable();
+    analytics.disable();
+    analytics.track('mmconnect_initialized', eventProperties);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    t.expect(captured).toEqual([]);
+    scope.done();
+  });
+
+  t.it('should clear queued events when disable is called', async () => {
+    let captured: EventV2[] = [];
+    scope = nock('http://127.0.0.5')
+      .post('/v2/events', (body) => {
+        captured = body;
+        return true;
+      })
+      .optionally()
+      .reply(
+        200,
+        { status: 'success' },
+        { 'Content-Type': 'application/json' },
+      );
+
+    analytics = new Analytics('http://127.0.0.5');
+    analytics.enable();
+    analytics.track('mmconnect_initialized', eventProperties);
+    analytics.disable();
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    t.expect(captured).toEqual([]);
+    scope.done();
+  });
+
   t.it('should merge multiple integration_types global updates', async () => {
     let captured: EventV2[] = [];
     scope = nock('http://127.0.0.3')

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -34,6 +34,14 @@ class Analytics {
     this.enabled = true;
   }
 
+  /**
+   * Disables analytics and drops queued events.
+   */
+  public disable(): void {
+    this.enabled = false;
+    this.sender.clear();
+  }
+
   public setGlobalProperty<K extends keyof MMConnectProperties>(
     key: K,
     value: MMConnectProperties[K],

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -41,6 +41,18 @@ t.describe('Sender', () => {
   });
 
   t.it(
+    'should clear queued events and cancel the scheduled flush',
+    async () => {
+      sender.enqueue('event1');
+      sender.clear();
+
+      await t.vi.advanceTimersByTimeAsync(50);
+
+      t.expect(sendFn).not.toHaveBeenCalled();
+    },
+  );
+
+  t.it(
     'should handle failure (with exponential backoff) and reset base timeout after successful send',
     async () => {
       let shouldSendFail = true;

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -39,6 +39,18 @@ class Sender<T> {
     this.schedule();
   }
 
+  /**
+   * Clears queued items and cancels the scheduled flush.
+   */
+  public clear(): void {
+    this.batch = [];
+    this.currentTimeoutMs = this.baseTimeoutMs;
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+
   private schedule(): void {
     // If the batch is not full and there is no scheduled flush, schedule a flush
     if (this.batch.length > 0 && !this.timeoutId) {

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add an `analytics.enabled` option to `createEVMClient()`. Set it to `false` to disable dapp-side analytics events and wallet correlation metadata. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
+- Add an `analytics.enabled` option to `createEVMClient()`. Consumers can set it to `false` to disable dapp-side analytics events and wallet correlation metadata. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
 
 ## [1.3.1]
 

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an `analytics.enabled` option to `createEVMClient()`. Set it to `false` to disable dapp-side analytics events and wallet correlation metadata. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
+
 ## [1.3.1]
 
 ### Fixed

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -200,9 +200,6 @@ const client = await createEVMClient({
     accountsChanged: (accounts) => console.log('Accounts:', accounts),
     chainChanged: (chainId) => console.log('Chain:', chainId),
   },
-  analytics: {
-    enabled: false,
-  },
   debug: true,
 });
 ```

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -165,21 +165,23 @@ Factory function to create a new MetaMask Connect EVM instance.
 
 #### Parameters
 
-| Option                     | Type                                          | Required | Description                                          |
-| -------------------------- | --------------------------------------------- | -------- | ---------------------------------------------------- |
-| `dapp.name`                | `string`                                      | Yes      | Name of your dApp                                    |
-| `api.supportedNetworks`    | `Record<Hex, string>`                         | Yes      | Map of hex chain IDs to RPC URLs                     |
-| `dapp.url`                 | `string`                                      | No       | URL of your dApp                                     |
-| `dapp.iconUrl`             | `string`                                      | No       | Icon URL for your dApp                               |
-| `ui.headless`              | `boolean`                                     | No       | Run without UI (for custom QR implementations)       |
-| `ui.preferExtension`       | `boolean`                                     | No       | Prefer browser extension over mobile (default: true) |
-| `ui.showInstallModal`      | `boolean`                                     | No       | Show installation modal for desktop                  |
-| `mobile.preferredOpenLink` | `(deeplink: string, target?: string) => void` | No       | Custom deeplink handler                              |
-| `mobile.useDeeplink`       | `boolean`                                     | No       | Use `metamask://` instead of universal links         |
-| `transport.extensionId`    | `string`                                      | No       | Custom extension ID                                  |
-| `transport.onNotification` | `(notification: unknown) => void`             | No       | Notification handler                                 |
-| `eventHandlers`            | `Partial<EventHandlers>`                      | No       | Event handlers for provider events                   |
-| `debug`                    | `boolean`                                     | No       | Enable debug logging                                 |
+| Option                      | Type                                          | Required | Description                                                                                                                  |
+| --------------------------- | --------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `dapp.name`                 | `string`                                      | Yes      | Name of your dApp                                                                                                            |
+| `api.supportedNetworks`     | `Record<Hex, string>`                         | Yes      | Map of hex chain IDs to RPC URLs                                                                                             |
+| `dapp.url`                  | `string`                                      | No       | URL of your dApp                                                                                                             |
+| `dapp.iconUrl`              | `string`                                      | No       | Icon URL for your dApp                                                                                                       |
+| `ui.headless`               | `boolean`                                     | No       | Run without UI (for custom QR implementations)                                                                               |
+| `ui.preferExtension`        | `boolean`                                     | No       | Prefer browser extension over mobile (default: true)                                                                         |
+| `ui.showInstallModal`       | `boolean`                                     | No       | Show installation modal for desktop                                                                                          |
+| `mobile.preferredOpenLink`  | `(deeplink: string, target?: string) => void` | No       | Custom deeplink handler                                                                                                      |
+| `mobile.useDeeplink`        | `boolean`                                     | No       | Use `metamask://` instead of universal links                                                                                 |
+| `analytics.enabled`         | `boolean`                                     | No       | Enables dapp-side analytics. Defaults to `true`; set to `false` to disable analytics events and wallet correlation metadata. |
+| `analytics.integrationType` | `string`                                      | No       | Integration type for analytics                                                                                               |
+| `transport.extensionId`     | `string`                                      | No       | Custom extension ID                                                                                                          |
+| `transport.onNotification`  | `(notification: unknown) => void`             | No       | Notification handler                                                                                                         |
+| `eventHandlers`             | `Partial<EventHandlers>`                      | No       | Event handlers for provider events                                                                                           |
+| `debug`                     | `boolean`                                     | No       | Enable debug logging                                                                                                         |
 
 #### Returns
 
@@ -197,6 +199,9 @@ const client = await createEVMClient({
   eventHandlers: {
     accountsChanged: (accounts) => console.log('Accounts:', accounts),
     chainChanged: (chainId) => console.log('Chain:', chainId),
+  },
+  analytics: {
+    enabled: false,
   },
   debug: true,
 });

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -872,14 +872,15 @@ describe('MetamaskConnectEVM', () => {
     });
 
     it('does not build wallet action analytics properties when analytics are disabled', async () => {
-      (mockCore as unknown as { options: MultichainCore['options'] }).options = {
-        dapp: {
-          name: 'Test DApp',
-          url: 'https://test.example',
-        },
-        analytics: { enabled: false, integrationType: 'direct' },
-        versions: {},
-      } as MultichainCore['options'];
+      (mockCore as unknown as { options: MultichainCore['options'] }).options =
+        {
+          dapp: {
+            name: 'Test DApp',
+            url: 'https://test.example',
+          },
+          analytics: { enabled: false, integrationType: 'direct' },
+          versions: {},
+        } as MultichainCore['options'];
       mockCore.transport.sendEip1193Message.mockResolvedValue({
         result: null,
         id: 1,

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -9,6 +9,7 @@ type MockCore = MultichainCore & {
   emit: (event: string, ...args: unknown[]) => void;
   _status: ConnectEvmStatus;
   storage: MultichainCore['storage'] & {
+    getAnonId: Mock<() => Promise<string>>;
     adapter: {
       get: Mock<(key: string) => Promise<string | null>>;
       set: Mock<(key: string, value: string) => Promise<void>>;
@@ -93,6 +94,7 @@ function createMockCore(): MockCore {
       onNotification,
     },
     storage: {
+      getAnonId: vi.fn().mockResolvedValue('anon-id'),
       adapter: {
         get: storageGet,
         set: storageSet,
@@ -867,6 +869,30 @@ describe('MetamaskConnectEVM', () => {
       );
       expect(calls).toEqual(['wallet_switchEthereumChain']);
       expect(calls).not.toContain('wallet_addEthereumChain');
+    });
+
+    it('does not build wallet action analytics properties when analytics are disabled', async () => {
+      (mockCore as unknown as { options: MultichainCore['options'] }).options = {
+        dapp: {
+          name: 'Test DApp',
+          url: 'https://test.example',
+        },
+        analytics: { enabled: false, integrationType: 'direct' },
+        versions: {},
+      } as MultichainCore['options'];
+      mockCore.transport.sendEip1193Message.mockResolvedValue({
+        result: null,
+        id: 1,
+        jsonrpc: '2.0' as const,
+      });
+
+      await client.switchChain({ chainId: '0x89' });
+
+      expect(mockCore.storage.getAnonId).not.toHaveBeenCalled();
+      expect(mockCore.transport.sendEip1193Message).toHaveBeenCalledWith({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x89' }],
+      });
     });
   });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -48,6 +48,12 @@ declare const __PACKAGE_VERSION__: string | undefined;
 const DEFAULT_CHAIN_ID = '0x1';
 const CHAIN_STORE_KEY = 'cache_eth_chainId';
 
+/**
+ * Checks whether dapp-side analytics are enabled for the multichain core.
+ *
+ * @param options - Current multichain options.
+ * @returns Whether analytics events should be collected and sent.
+ */
 function isAnalyticsEnabled(options: MultichainOptions | undefined): boolean {
   return options?.analytics?.enabled !== false;
 }

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -1008,6 +1008,7 @@ export class MetamaskConnectEVM {
  * @param options.dapp - Dapp identification and branding settings
  * @param options.api - API configuration including read-only RPC map
  * @param options.api.supportedNetworks - A map of hex chain IDs to RPC URLs for read-only requests
+ * @param [options.analytics.enabled] - Whether to enable dapp-side analytics (defaults to true)
  * @param [options.analytics.integrationType] - Integration type for analytics
  * @param [options.ui] - UI configuration options
  * @param [options.ui.headless] - Whether to run without UI
@@ -1071,6 +1072,7 @@ export async function createEVMClient(
         supportedNetworks: supportedNetworksCaipChainId,
       },
       analytics: {
+        ...(options.analytics ?? {}),
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         integrationType: options.analytics?.integrationType || 'direct',
       },

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -48,6 +48,10 @@ declare const __PACKAGE_VERSION__: string | undefined;
 const DEFAULT_CHAIN_ID = '0x1';
 const CHAIN_STORE_KEY = 'cache_eth_chainId';
 
+function isAnalyticsEnabled(options: MultichainOptions | undefined): boolean {
+  return options?.analytics?.enabled !== false;
+}
+
 /** The options for the connect method */
 type ConnectOptions = {
   /** The account to connect to */
@@ -228,6 +232,10 @@ export class MetamaskConnectEVM {
     params: unknown[],
   ): Promise<void> {
     const coreOptions = this.#getCoreOptions();
+    if (!isAnalyticsEnabled(coreOptions)) {
+      return;
+    }
+
     try {
       const invokeOptions = this.#createInvokeOptions(method, scope, params);
       const props = await getWalletActionAnalyticsProperties(
@@ -255,6 +263,10 @@ export class MetamaskConnectEVM {
     params: unknown[],
   ): Promise<void> {
     const coreOptions = this.#getCoreOptions();
+    if (!isAnalyticsEnabled(coreOptions)) {
+      return;
+    }
+
     try {
       const invokeOptions = this.#createInvokeOptions(method, scope, params);
       const props = await getWalletActionAnalyticsProperties(
@@ -284,6 +296,10 @@ export class MetamaskConnectEVM {
     error: unknown,
   ): Promise<void> {
     const coreOptions = this.#getCoreOptions();
+    if (!isAnalyticsEnabled(coreOptions)) {
+      return;
+    }
+
     try {
       const invokeOptions = this.#createInvokeOptions(method, scope, params);
       const props = await getWalletActionAnalyticsProperties(

--- a/packages/connect-evm/src/create-client.test.ts
+++ b/packages/connect-evm/src/create-client.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-shadow -- Vitest globals */
+import { createMultichainClient } from '@metamask/connect-multichain';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metamask/analytics', () => ({
+  analytics: {
+    track: vi.fn(),
+  },
+}));
+
+vi.mock('@metamask/connect-multichain', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+  enableDebug: vi.fn(),
+  EventEmitter: class {
+    #handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+    on(event: string, handler: (...args: unknown[]) => void): void {
+      this.#handlers[event] ??= [];
+      this.#handlers[event].push(handler);
+    }
+
+    off(event: string, handler: (...args: unknown[]) => void): void {
+      this.#handlers[event] =
+        this.#handlers[event]?.filter((fn) => fn !== handler) ?? [];
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      this.#handlers[event]?.forEach((handler) => handler(...args));
+    }
+
+    once(event: string, handler: (...args: unknown[]) => void): void {
+      const wrapped = (...args: unknown[]): void => {
+        this.off(event, wrapped);
+        handler(...args);
+      };
+      this.on(event, wrapped);
+    }
+
+    removeListener(event: string, handler: (...args: unknown[]) => void): void {
+      this.off(event, handler);
+    }
+
+    listenerCount(event: string): number {
+      return this.#handlers[event]?.length ?? 0;
+    }
+  },
+  RPCInvokeMethodErr: class RPCInvokeMethodErr extends Error {},
+  createMultichainClient: vi.fn(),
+  getWalletActionAnalyticsProperties: vi.fn(),
+  isRejectionError: vi.fn(),
+  TransportType: {
+    Browser: 'browser',
+    MWP: 'mwp',
+    UNKNOWN: 'unknown',
+  },
+}));
+
+describe('createEVMClient', () => {
+  const mockCore = {
+    on: vi.fn(),
+    off: vi.fn(),
+    provider: {
+      getSession: vi.fn().mockResolvedValue({ sessionScopes: {} }),
+    },
+    storage: {
+      adapter: {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    transportType: 'browser',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (createMultichainClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockCore,
+    );
+    mockCore.provider.getSession.mockResolvedValue({ sessionScopes: {} });
+  });
+
+  it('should forward analytics.enabled to createMultichainClient', async () => {
+    const { createEVMClient } = await import('./connect');
+
+    await createEVMClient({
+      dapp: {
+        name: 'Test DApp',
+        url: 'https://testdapp.com',
+      },
+      api: {
+        supportedNetworks: {
+          '0x1': 'https://mainnet.example',
+        },
+      },
+      analytics: {
+        enabled: false,
+      },
+    });
+
+    expect(createMultichainClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        analytics: { enabled: false, integrationType: 'direct' },
+      }),
+    );
+  });
+});

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an `analytics.enabled` option to `createMultichainClient()`. Set it to `false` to disable dapp-side analytics events and omit `analytics.remote_session_id` connection metadata. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
+
 ## [0.14.0]
 
 ### Added

--- a/packages/connect-multichain/README.md
+++ b/packages/connect-multichain/README.md
@@ -172,9 +172,6 @@ const client = await createMultichainClient({
       'eip155:137': 'https://polygon-mainnet.infura.io/v3/KEY',
     },
   },
-  analytics: {
-    enabled: false,
-  },
 });
 ```
 

--- a/packages/connect-multichain/README.md
+++ b/packages/connect-multichain/README.md
@@ -138,25 +138,26 @@ Factory function to create a new Multichain SDK instance.
 
 #### Parameters
 
-| Option                      | Type                                          | Required | Description                                                                                                     |
-| --------------------------- | --------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `dapp.name`                 | `string`                                      | Yes      | Name of your dApp                                                                                               |
-| `api.supportedNetworks`     | `RpcUrlsMap`                                  | Yes      | Map of [CAIP-2 chain IDs](https://chainagnostic.org/CAIPs/caip-2) to RPC URLs                                   |
-| `dapp.url`                  | `string`                                      | No       | URL of your dApp                                                                                                |
-| `dapp.iconUrl`              | `string`                                      | No       | Icon URL for your dApp                                                                                          |
-| `dapp.base64Icon`           | `string`                                      | No       | Base64-encoded icon (alternative to iconUrl)                                                                    |
-| `storage`                   | `StoreClient`                                 | No       | Custom storage adapter                                                                                          |
-| `ui.factory`                | `BaseModalFactory`                            | No       | Custom modal factory                                                                                            |
-| `ui.headless`               | `boolean`                                     | No       | Run without UI (for custom QR implementations)                                                                  |
-| `ui.preferExtension`        | `boolean`                                     | No       | Prefer browser extension (default: true)                                                                        |
-| `ui.showInstallModal`       | `boolean`                                     | No       | Show installation modal                                                                                         |
-| `mobile.preferredOpenLink`  | `(deeplink: string, target?: string) => void` | No       | Custom deeplink handler                                                                                         |
-| `mobile.useDeeplink`        | `boolean`                                     | No       | Use `metamask://` instead of universal links                                                                    |
-| `analytics.integrationType` | `string`                                      | No       | Integration type for analytics                                                                                  |
-| `transport.extensionId`     | `string`                                      | No       | Custom extension ID                                                                                             |
-| `transport.onNotification`  | `(notification: unknown) => void`             | No       | Notification handler                                                                                            |
-| `versions`                  | `Partial<ConnectVersions>`                    | No       | Internal: set automatically by `createEVMClient` / `createSolanaClient`. Consumers do not need to provide this. |
-| `debug`                     | `boolean`                                     | No       | Enable debug logging                                                                                            |
+| Option                      | Type                                          | Required | Description                                                                                                                  |
+| --------------------------- | --------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `dapp.name`                 | `string`                                      | Yes      | Name of your dApp                                                                                                            |
+| `api.supportedNetworks`     | `RpcUrlsMap`                                  | Yes      | Map of [CAIP-2 chain IDs](https://chainagnostic.org/CAIPs/caip-2) to RPC URLs                                                |
+| `dapp.url`                  | `string`                                      | No       | URL of your dApp                                                                                                             |
+| `dapp.iconUrl`              | `string`                                      | No       | Icon URL for your dApp                                                                                                       |
+| `dapp.base64Icon`           | `string`                                      | No       | Base64-encoded icon (alternative to iconUrl)                                                                                 |
+| `storage`                   | `StoreClient`                                 | No       | Custom storage adapter                                                                                                       |
+| `ui.factory`                | `BaseModalFactory`                            | No       | Custom modal factory                                                                                                         |
+| `ui.headless`               | `boolean`                                     | No       | Run without UI (for custom QR implementations)                                                                               |
+| `ui.preferExtension`        | `boolean`                                     | No       | Prefer browser extension (default: true)                                                                                     |
+| `ui.showInstallModal`       | `boolean`                                     | No       | Show installation modal                                                                                                      |
+| `mobile.preferredOpenLink`  | `(deeplink: string, target?: string) => void` | No       | Custom deeplink handler                                                                                                      |
+| `mobile.useDeeplink`        | `boolean`                                     | No       | Use `metamask://` instead of universal links                                                                                 |
+| `analytics.enabled`         | `boolean`                                     | No       | Enables dapp-side analytics. Defaults to `true`; set to `false` to disable analytics events and wallet correlation metadata. |
+| `analytics.integrationType` | `string`                                      | No       | Integration type for analytics                                                                                               |
+| `transport.extensionId`     | `string`                                      | No       | Custom extension ID                                                                                                          |
+| `transport.onNotification`  | `(notification: unknown) => void`             | No       | Notification handler                                                                                                         |
+| `versions`                  | `Partial<ConnectVersions>`                    | No       | Internal: set automatically by `createEVMClient` / `createSolanaClient`. Consumers do not need to provide this.              |
+| `debug`                     | `boolean`                                     | No       | Enable debug logging                                                                                                         |
 
 #### Returns
 
@@ -170,6 +171,9 @@ const client = await createMultichainClient({
       'eip155:1': 'https://mainnet.infura.io/v3/KEY',
       'eip155:137': 'https://polygon-mainnet.infura.io/v3/KEY',
     },
+  },
+  analytics: {
+    enabled: false,
   },
 });
 ```

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -300,27 +300,45 @@ t.describe('MultichainCore', () => {
       t.expect(opts.versions).toEqual({ 'connect-evm': '0.6.0' });
     });
 
-    t.it('merges analytics over existing values', () => {
+    t.it(
+      'merges analytics over existing values without re-enabling disabled analytics',
+      () => {
+        const base = createBaseOptions();
+        base.analytics = { enabled: false, integrationType: 'direct' };
+        const core = new MockMultichainCore(base);
+
+        core.mergeOptions({
+          analytics: { integrationType: 'wagmi' },
+        });
+
+        t.expect(core.getOptions().analytics).toEqual({
+          enabled: false,
+          integrationType: 'wagmi',
+        });
+
+        core.mergeOptions({
+          analytics: { enabled: true },
+        });
+
+        t.expect(core.getOptions().analytics).toEqual({
+          enabled: false,
+          integrationType: 'wagmi',
+        });
+      },
+    );
+
+    t.it('allows analytics to be disabled by merge options', () => {
       const base = createBaseOptions();
-      base.analytics = { enabled: false, integrationType: 'direct' };
+      base.analytics = { enabled: true, integrationType: 'direct' };
       const core = new MockMultichainCore(base);
 
       core.mergeOptions({
-        analytics: { integrationType: 'wagmi' },
+        analytics: { enabled: false },
       });
 
       t.expect(core.getOptions().analytics).toEqual({
         enabled: false,
-        integrationType: 'wagmi',
-      });
-
-      core.mergeOptions({
-        analytics: { enabled: true },
-      });
-
-      t.expect(core.getOptions().analytics).toEqual({
-        enabled: true,
-        integrationType: 'wagmi',
+        integrationType: 'direct',
       });
     });
 

--- a/packages/connect-multichain/src/domain/multichain/index.test.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.test.ts
@@ -300,6 +300,30 @@ t.describe('MultichainCore', () => {
       t.expect(opts.versions).toEqual({ 'connect-evm': '0.6.0' });
     });
 
+    t.it('merges analytics over existing values', () => {
+      const base = createBaseOptions();
+      base.analytics = { enabled: false, integrationType: 'direct' };
+      const core = new MockMultichainCore(base);
+
+      core.mergeOptions({
+        analytics: { integrationType: 'wagmi' },
+      });
+
+      t.expect(core.getOptions().analytics).toEqual({
+        enabled: false,
+        integrationType: 'wagmi',
+      });
+
+      core.mergeOptions({
+        analytics: { enabled: true },
+      });
+
+      t.expect(core.getOptions().analytics).toEqual({
+        enabled: true,
+        integrationType: 'wagmi',
+      });
+    });
+
     t.it('does not mutate dapp, storage, or analytics', () => {
       const base = createBaseOptions();
       base.analytics = { integrationType: 'direct' };

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -91,6 +91,14 @@ export abstract class MultichainCore extends EventEmitter<SDKEvents> {
    */
   mergeOptions(partial: MergeableMultichainOptions): void {
     const opts = this.options;
+    const analytics = {
+      ...opts.analytics,
+      ...(partial.analytics ?? {}),
+    };
+    if (opts.analytics?.enabled === false) {
+      analytics.enabled = false;
+    }
+
     this.options = {
       ...opts,
       api: {
@@ -105,8 +113,7 @@ export abstract class MultichainCore extends EventEmitter<SDKEvents> {
         ...(partial.versions ?? {}),
       },
       analytics: {
-        ...opts.analytics,
-        ...(partial.analytics ?? {}),
+        ...analytics,
       },
       ui: {
         ...opts.ui,

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -82,7 +82,7 @@ export abstract class MultichainCore extends EventEmitter<SDKEvents> {
 
   /**
    * Merges the given options into the current instance options.
-   * Only the mergeable keys are updated (api.supportedNetworks, versions, ui.*, mobile.*, transport.extensionId, debug).
+   * Only the mergeable keys are updated (api.supportedNetworks, analytics, versions, ui.*, mobile.*, transport.extensionId, debug).
    * The main thing to note is that the value for `dapp` is not merged as it does not make sense for
    * subsequent calls to `createMultichainClient` to have a different `dapp` value.
    * Used when createMultichainClient is called with an existing singleton.
@@ -103,6 +103,10 @@ export abstract class MultichainCore extends EventEmitter<SDKEvents> {
       versions: {
         ...opts.versions,
         ...(partial.versions ?? {}),
+      },
+      analytics: {
+        ...opts.analytics,
+        ...(partial.analytics ?? {}),
       },
       ui: {
         ...opts.ui,

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -51,6 +51,20 @@ export type ConnectVersions = { 'connect-multichain': string } & Partial<
   Record<'connect-evm' | 'connect-solana', string>
 >;
 
+export type AnalyticsOptions = {
+  /**
+   * Whether to enable analytics tracking. Defaults to `true` when omitted.
+   * Set to `false` to disable all analytics event collection.
+   */
+  enabled?: boolean;
+  /**
+   * Identifies the integration surface that instantiated the SDK (e.g. `'direct'`,
+   * `'wagmi'`). Recorded as the `integration_types` global analytics property.
+   * Defaults to `'direct'` when omitted or empty.
+   */
+  integrationType?: string;
+};
+
 /**
  * Constructor options for creating a Multichain SDK instance.
  *
@@ -67,7 +81,7 @@ export type MultichainOptions = {
     supportedNetworks: RpcUrlsMap;
   };
   /** Analytics configuration */
-  analytics?: { integrationType: string };
+  analytics?: AnalyticsOptions;
   /** Storage client for persisting SDK data */
   storage: StoreClient;
   /** UI configuration options */
@@ -112,6 +126,7 @@ export type MergeableMultichainOptions = Omit<
   MultichainOptions,
   'dapp' | 'analytics' | 'storage' | 'api' | 'ui' | 'transport' | 'versions'
 > & {
+  analytics?: AnalyticsOptions;
   api?: MultichainOptions['api'];
   ui?: Pick<
     MultichainOptions['ui'],

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -110,6 +110,35 @@ function testSuite<T extends MultichainOptions>({
     );
 
     t.it(
+      `${platform} should disable analytics when analytics.enabled is false`,
+      async () => {
+        const enableSpy = t.vi.spyOn(analytics, 'enable');
+        const disableSpy = t.vi.spyOn(analytics, 'disable');
+        const setGlobalSpy = t.vi.spyOn(analytics, 'setGlobalProperty');
+
+        sdk = await createSDK({
+          ...testOptions,
+          analytics: {
+            ...testOptions.analytics,
+            enabled: false,
+          },
+        });
+
+        t.expect(sdk).toBeDefined();
+        t.expect(enableSpy).not.toHaveBeenCalled();
+        t.expect(disableSpy).toHaveBeenCalled();
+        t.expect(setGlobalSpy).not.toHaveBeenCalledWith(
+          'anon_id',
+          t.expect.any(String),
+        );
+
+        enableSpy.mockRestore();
+        disableSpy.mockRestore();
+        setGlobalSpy.mockRestore();
+      },
+    );
+
+    t.it(
       `${platform} should call init and setupAnalytics with logger configuration`,
       async () => {
         const mockLogger = (loggerModule as any).__mockLogger;
@@ -253,6 +282,58 @@ function testSuite<T extends MultichainOptions>({
         }
 
         setGlobalSpy.mockRestore();
+      },
+    );
+
+    t.it(
+      `${platform} should keep analytics disabled when singleton merge omits analytics.enabled`,
+      async () => {
+        const enableSpy = t.vi.spyOn(analytics, 'enable');
+        const disableSpy = t.vi.spyOn(analytics, 'disable');
+
+        await createSDK({
+          ...testOptions,
+          analytics: { ...testOptions.analytics, enabled: false },
+        });
+        enableSpy.mockClear();
+        disableSpy.mockClear();
+
+        await createSDK({
+          ...testOptions,
+          analytics: { integrationType: 'wagmi' },
+        } as any);
+
+        t.expect(enableSpy).not.toHaveBeenCalled();
+        t.expect(disableSpy).toHaveBeenCalled();
+
+        enableSpy.mockRestore();
+        disableSpy.mockRestore();
+      },
+    );
+
+    t.it(
+      `${platform} should re-enable analytics when singleton merge explicitly enables it`,
+      async () => {
+        const enableSpy = t.vi.spyOn(analytics, 'enable');
+
+        await createSDK({
+          ...testOptions,
+          analytics: { ...testOptions.analytics, enabled: false },
+        });
+        enableSpy.mockClear();
+
+        await createSDK({
+          ...testOptions,
+          analytics: { ...testOptions.analytics, enabled: true },
+        } as any);
+
+        if (platform === 'web' || platform === 'web-mobile') {
+          t.expect(enableSpy).toHaveBeenCalled();
+        } else {
+          t.expect(enableSpy).not.toHaveBeenCalled();
+        }
+
+        enableSpy.mockRestore();
       },
     );
 

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -312,28 +312,28 @@ function testSuite<T extends MultichainOptions>({
     );
 
     t.it(
-      `${platform} should re-enable analytics when singleton merge explicitly enables it`,
+      `${platform} should keep analytics disabled when singleton merge explicitly enables it`,
       async () => {
         const enableSpy = t.vi.spyOn(analytics, 'enable');
+        const disableSpy = t.vi.spyOn(analytics, 'disable');
 
         await createSDK({
           ...testOptions,
           analytics: { ...testOptions.analytics, enabled: false },
         });
         enableSpy.mockClear();
+        disableSpy.mockClear();
 
         await createSDK({
           ...testOptions,
           analytics: { ...testOptions.analytics, enabled: true },
         } as any);
 
-        if (platform === 'web' || platform === 'web-mobile') {
-          t.expect(enableSpy).toHaveBeenCalled();
-        } else {
-          t.expect(enableSpy).not.toHaveBeenCalled();
-        }
+        t.expect(enableSpy).not.toHaveBeenCalled();
+        t.expect(disableSpy).toHaveBeenCalled();
 
         enableSpy.mockRestore();
+        disableSpy.mockRestore();
       },
     );
 

--- a/packages/connect-multichain/src/multichain/index.test.ts
+++ b/packages/connect-multichain/src/multichain/index.test.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-shadow -- Vitest globals */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MetaMaskConnectMultichain } from '.';
+
+const singletonKey = '__METAMASK_CONNECT_MULTICHAIN_SINGLETON__';
+
+describe('MetaMaskConnectMultichain', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>)[singletonKey];
+  });
+
+  it('uses the existing singleton analytics setup hook when reusing a compatible instance from another package copy', async () => {
+    const existingInstance = {
+      mergeOptions: vi.fn(),
+      setupAnalytics: vi.fn().mockResolvedValue(undefined),
+    };
+    (globalThis as Record<string, unknown>)[singletonKey] =
+      Promise.resolve(existingInstance);
+
+    const result = await MetaMaskConnectMultichain.create({
+      analytics: { integrationType: 'direct' },
+    } as Parameters<typeof MetaMaskConnectMultichain.create>[0]);
+
+    expect(result).toBe(existingInstance);
+    expect(existingInstance.mergeOptions).toHaveBeenCalledWith({
+      analytics: { integrationType: 'direct' },
+    });
+    expect(existingInstance.setupAnalytics).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/connect-multichain/src/multichain/index.test.ts
+++ b/packages/connect-multichain/src/multichain/index.test.ts
@@ -10,10 +10,13 @@ describe('MetaMaskConnectMultichain', () => {
     delete (globalThis as Record<string, unknown>)[singletonKey];
   });
 
-  it('uses the existing singleton analytics setup hook when reusing a compatible instance from another package copy', async () => {
+  it('uses public singleton fields instead of setupAnalytics when reusing another package copy', async () => {
+    const storage = { getAnonId: vi.fn().mockResolvedValue('anon-id') };
     const existingInstance = {
       mergeOptions: vi.fn(),
       setupAnalytics: vi.fn().mockResolvedValue(undefined),
+      options: { analytics: { integrationType: 'direct' } },
+      storage,
     };
     (globalThis as Record<string, unknown>)[singletonKey] =
       Promise.resolve(existingInstance);
@@ -26,12 +29,15 @@ describe('MetaMaskConnectMultichain', () => {
     expect(existingInstance.mergeOptions).toHaveBeenCalledWith({
       analytics: { integrationType: 'direct' },
     });
-    expect(existingInstance.setupAnalytics).toHaveBeenCalledTimes(1);
+    expect(existingInstance.setupAnalytics).not.toHaveBeenCalled();
   });
 
   it('does not require reused singleton instances from older package copies to have setupAnalytics', async () => {
+    const storage = { getAnonId: vi.fn().mockResolvedValue('anon-id') };
     const existingInstance = {
       mergeOptions: vi.fn(),
+      options: { analytics: { integrationType: 'direct' } },
+      storage,
     };
     (globalThis as Record<string, unknown>)[singletonKey] =
       Promise.resolve(existingInstance);

--- a/packages/connect-multichain/src/multichain/index.test.ts
+++ b/packages/connect-multichain/src/multichain/index.test.ts
@@ -28,4 +28,21 @@ describe('MetaMaskConnectMultichain', () => {
     });
     expect(existingInstance.setupAnalytics).toHaveBeenCalledTimes(1);
   });
+
+  it('does not require reused singleton instances from older package copies to have setupAnalytics', async () => {
+    const existingInstance = {
+      mergeOptions: vi.fn(),
+    };
+    (globalThis as Record<string, unknown>)[singletonKey] =
+      Promise.resolve(existingInstance);
+
+    const result = await MetaMaskConnectMultichain.create({
+      analytics: { integrationType: 'direct' },
+    } as Parameters<typeof MetaMaskConnectMultichain.create>[0]);
+
+    expect(result).toBe(existingInstance);
+    expect(existingInstance.mergeOptions).toHaveBeenCalledWith({
+      analytics: { integrationType: 'direct' },
+    });
+  });
 });

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -241,10 +241,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
    * Sets up analytics globals for the current SDK options.
    */
   public async setupAnalytics(): Promise<void> {
-    await this.#setupAnalytics();
-  }
-
-  async #setupAnalytics(): Promise<void> {
     if (!isAnalyticsEnabled(this.options)) {
       this.#anonId = undefined;
       analytics.disable();
@@ -386,7 +382,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   async #init(): Promise<void> {
     try {
-      await this.#setupAnalytics();
+      await this.setupAnalytics();
       await this.#setupTransport();
     } catch (error) {
       await this.storage.removeTransport();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -72,6 +72,12 @@ const logger = createLogger('metamask-sdk:core');
 
 const SINGLETON_KEY = '__METAMASK_CONNECT_MULTICHAIN_SINGLETON__';
 
+type ReusableMultichainSingleton = {
+  mergeOptions: (options: MultichainOptions) => void;
+  options: MultichainOptions;
+  storage: StoreClient;
+};
+
 /**
  * Applies analytics defaults while preserving explicitly disabled analytics.
  *
@@ -97,6 +103,54 @@ function normalizeAnalyticsOptions(
  */
 function isAnalyticsEnabled(options: MultichainOptions): boolean {
   return options.analytics?.enabled !== false;
+}
+
+/**
+ * Sets up analytics globals using only APIs available on existing singleton
+ * instances, including instances created by older bundled package copies.
+ *
+ * @param options - Current SDK options.
+ * @param storage - Storage client for retrieving the anonymous ID.
+ * @param setAnonId - Optional callback for updating the current instance anon ID.
+ */
+async function setupAnalyticsGlobals(
+  options: MultichainOptions,
+  storage: StoreClient,
+  setAnonId?: (anonId: string | undefined) => void,
+): Promise<void> {
+  if (!isAnalyticsEnabled(options)) {
+    setAnonId?.(undefined);
+    analytics.disable();
+    return;
+  }
+
+  const platform = getPlatformType();
+  const isBrowser =
+    platform === PlatformType.MetaMaskMobileWebview ||
+    platform === PlatformType.DesktopWeb ||
+    platform === PlatformType.MobileWeb;
+
+  const isReactNative = platform === PlatformType.ReactNative;
+
+  if (!isBrowser && !isReactNative) {
+    return;
+  }
+
+  const dappId = getDappId(options.dapp);
+  const anonId = await storage.getAnonId();
+  setAnonId?.(anonId);
+
+  const { integrationType } = options.analytics ?? {
+    integrationType: '',
+  };
+  analytics.setGlobalProperty('mmconnect_versions', options.versions ?? {});
+  analytics.setGlobalProperty('dapp_id', dappId);
+  analytics.setGlobalProperty('anon_id', anonId);
+  analytics.setGlobalProperty('platform', platform);
+  if (integrationType) {
+    analytics.setGlobalProperty('integration_types', [integrationType]);
+  }
+  analytics.enable();
 }
 
 export class MetaMaskConnectMultichain extends MultichainCore {
@@ -202,18 +256,20 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   ): Promise<MetaMaskConnectMultichain> {
     const globalObject = getGlobalObject();
     const existing = globalObject[SINGLETON_KEY] as
-      | Promise<MetaMaskConnectMultichain>
+      | Promise<MetaMaskConnectMultichain | ReusableMultichainSingleton>
       | undefined;
     if (existing) {
       const instance = await existing;
       instance.mergeOptions(options);
-      if (typeof instance.setupAnalytics === 'function') {
-        await instance.setupAnalytics();
+      if (instance instanceof MetaMaskConnectMultichain) {
+        await instance.#setupAnalytics();
+      } else {
+        await setupAnalyticsGlobals(instance.options, instance.storage);
       }
       if (options.debug) {
         enableDebug('metamask-sdk:*');
       }
-      return instance;
+      return instance as MetaMaskConnectMultichain;
     }
 
     const instancePromise = (async (): Promise<MetaMaskConnectMultichain> => {
@@ -242,43 +298,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   /**
    * Sets up analytics globals for the current SDK options.
    */
-  private async setupAnalytics(): Promise<void> {
-    if (!isAnalyticsEnabled(this.options)) {
-      this.#anonId = undefined;
-      analytics.disable();
-      return;
-    }
-
-    const platform = getPlatformType();
-    const isBrowser =
-      platform === PlatformType.MetaMaskMobileWebview ||
-      platform === PlatformType.DesktopWeb ||
-      platform === PlatformType.MobileWeb;
-
-    const isReactNative = platform === PlatformType.ReactNative;
-
-    if (!isBrowser && !isReactNative) {
-      return;
-    }
-
-    const dappId = getDappId(this.options.dapp);
-    const anonId = await this.storage.getAnonId();
-    this.#anonId = anonId;
-
-    const { integrationType } = this.options.analytics ?? {
-      integrationType: '',
-    };
-    analytics.setGlobalProperty(
-      'mmconnect_versions',
-      this.options.versions ?? {},
-    );
-    analytics.setGlobalProperty('dapp_id', dappId);
-    analytics.setGlobalProperty('anon_id', anonId);
-    analytics.setGlobalProperty('platform', platform);
-    if (integrationType) {
-      analytics.setGlobalProperty('integration_types', [integrationType]);
-    }
-    analytics.enable();
+  async #setupAnalytics(): Promise<void> {
+    await setupAnalyticsGlobals(this.options, this.storage, (anonId) => {
+      this.#anonId = anonId;
+    });
   }
 
   async #onTransportNotification(payload: any): Promise<void> {
@@ -384,7 +407,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   async #init(): Promise<void> {
     try {
-      await this.setupAnalytics();
+      await this.#setupAnalytics();
       await this.#setupTransport();
     } catch (error) {
       await this.storage.removeTransport();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -207,7 +207,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (existing) {
       const instance = await existing;
       instance.mergeOptions(options);
-      await instance.setupAnalytics();
+      if (typeof instance.setupAnalytics === 'function') {
+        await instance.setupAnalytics();
+      }
       if (options.debug) {
         enableDebug('metamask-sdk:*');
       }
@@ -240,7 +242,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   /**
    * Sets up analytics globals for the current SDK options.
    */
-  public async setupAnalytics(): Promise<void> {
+  private async setupAnalytics(): Promise<void> {
     if (!isAnalyticsEnabled(this.options)) {
       this.#anonId = undefined;
       analytics.disable();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -72,6 +72,33 @@ const logger = createLogger('metamask-sdk:core');
 
 const SINGLETON_KEY = '__METAMASK_CONNECT_MULTICHAIN_SINGLETON__';
 
+/**
+ * Applies analytics defaults while preserving explicitly disabled analytics.
+ *
+ * @param analyticsOptions - Partial analytics options supplied by the consumer.
+ * @returns Analytics options with defaults applied.
+ */
+function normalizeAnalyticsOptions(
+  analyticsOptions: MultichainOptions['analytics'],
+): Required<NonNullable<MultichainOptions['analytics']>> {
+  return {
+    ...(analyticsOptions ?? {}),
+    enabled: analyticsOptions?.enabled ?? true,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    integrationType: analyticsOptions?.integrationType || 'direct',
+  };
+}
+
+/**
+ * Checks whether dapp-side analytics are enabled for the SDK instance.
+ *
+ * @param options - Current SDK options.
+ * @returns Whether analytics events should be collected and sent.
+ */
+function isAnalyticsEnabled(options: MultichainOptions): boolean {
+  return options.analytics?.enabled !== false;
+}
+
 export class MetaMaskConnectMultichain extends MultichainCore {
   readonly #provider: MultichainApiClient<RPCAPI>;
 
@@ -133,8 +160,6 @@ export class MetaMaskConnectMultichain extends MultichainCore {
 
   constructor(options: MultichainOptions) {
     const withDappMetadata = setupDappMetadata(options);
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const integrationType = options.analytics?.integrationType || 'direct';
     const allOptions = {
       ...withDappMetadata,
       ui: {
@@ -143,10 +168,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         showInstallModal: withDappMetadata.ui.showInstallModal ?? false,
         headless: withDappMetadata.ui.headless ?? false,
       },
-      analytics: {
-        ...(options.analytics ?? {}),
-        integrationType,
-      },
+      analytics: normalizeAnalyticsOptions(options.analytics),
       versions: {
         // typeof guard needed: Metro (React Native) bundles TS source directly,
         // bypassing the tsup build that substitutes __PACKAGE_VERSION__.
@@ -171,9 +193,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   // Creates a singleton instance of MetaMaskConnectMultichain.
   // If the singleton already exists, it merges the incoming options with the
   // existing singleton options for the following keys: `api.supportedNetworks`,
-  // `versions`, `ui.*`, `mobile.*`, `transport.extensionId`, `debug`. Take note
-  // that the value for `dapp` is not merged as it does not make sense for
-  // subsequent calls to `createMultichainClient` to have a different `dapp` value.
+  // `analytics`, `versions`, `ui.*`, `mobile.*`, `transport.extensionId`,
+  // `debug`. Take note that the value for `dapp` is not merged as it does not
+  // make sense for subsequent calls to `createMultichainClient` to have a
+  // different `dapp` value.
   static async create(
     options: MultichainOptions,
   ): Promise<MetaMaskConnectMultichain> {
@@ -184,15 +207,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (existing) {
       const instance = await existing;
       instance.mergeOptions(options);
-      analytics.setGlobalProperty(
-        'mmconnect_versions',
-        instance.options.versions ?? {},
-      );
-      if (options.analytics?.integrationType) {
-        analytics.setGlobalProperty('integration_types', [
-          options.analytics.integrationType,
-        ]);
-      }
+      await instance.#setupAnalytics();
       if (options.debug) {
         enableDebug('metamask-sdk:*');
       }
@@ -223,6 +238,12 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   async #setupAnalytics(): Promise<void> {
+    if (!isAnalyticsEnabled(this.options)) {
+      this.#anonId = undefined;
+      analytics.disable();
+      return;
+    }
+
     const platform = getPlatformType();
     const isBrowser =
       platform === PlatformType.MetaMaskMobileWebview ||
@@ -350,7 +371,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       dapp: this.options.dapp,
       sdk: { version: getVersion(), platform: getPlatformType() },
     };
-    if (this.#anonId) {
+    if (isAnalyticsEnabled(this.options) && this.#anonId) {
       metadata.analytics = { remote_session_id: this.#anonId };
     }
     return metadata;
@@ -724,45 +745,49 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     return promise
       .then(async () => {
         this.status = 'connected';
-        try {
-          const baseProps = await getBaseAnalyticsProperties(
-            this.options,
-            this.storage,
-          );
+        if (isAnalyticsEnabled(this.options)) {
+          try {
+            const baseProps = await getBaseAnalyticsProperties(
+              this.options,
+              this.storage,
+            );
 
-          analytics.track('mmconnect_connection_established', {
-            ...baseProps,
-            transport_type: transportType,
-            user_permissioned_chains: scopes,
-          });
-        } catch (error) {
-          logger('Error tracking connection_established event', error);
+            analytics.track('mmconnect_connection_established', {
+              ...baseProps,
+              transport_type: transportType,
+              user_permissioned_chains: scopes,
+            });
+          } catch (error) {
+            logger('Error tracking connection_established event', error);
+          }
         }
         return undefined; // explicitly return `undefined` to avoid eslintpromise/always-return
       })
       .catch(async (error) => {
         this.status = 'disconnected';
-        try {
-          const baseProps = await getBaseAnalyticsProperties(
-            this.options,
-            this.storage,
-          );
-          const isRejection = isRejectionError(error);
+        if (isAnalyticsEnabled(this.options)) {
+          try {
+            const baseProps = await getBaseAnalyticsProperties(
+              this.options,
+              this.storage,
+            );
+            const isRejection = isRejectionError(error);
 
-          if (isRejection) {
-            analytics.track('mmconnect_connection_rejected', {
-              ...baseProps,
-              transport_type: transportType,
-            });
-          } else {
-            analytics.track('mmconnect_connection_failed', {
-              ...baseProps,
-              transport_type: transportType,
-              ...extractErrorDiagnostics(error),
-            });
+            if (isRejection) {
+              analytics.track('mmconnect_connection_rejected', {
+                ...baseProps,
+                transport_type: transportType,
+              });
+            } else {
+              analytics.track('mmconnect_connection_failed', {
+                ...baseProps,
+                transport_type: transportType,
+                ...extractErrorDiagnostics(error),
+              });
+            }
+          } catch {
+            logger('Error tracking connection failed/rejected event', error);
           }
-        } catch {
-          logger('Error tracking connection failed/rejected event', error);
         }
         throw error;
       });
@@ -803,23 +828,25 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       transportType = TransportType.MWP;
     }
 
-    try {
-      const baseProps = await getBaseAnalyticsProperties(
-        this.options,
-        this.storage,
-      );
-      const dappConfiguredChains = Object.keys(
-        this.options.api.supportedNetworks,
-      );
+    if (isAnalyticsEnabled(this.options)) {
+      try {
+        const baseProps = await getBaseAnalyticsProperties(
+          this.options,
+          this.storage,
+        );
+        const dappConfiguredChains = Object.keys(
+          this.options.api.supportedNetworks,
+        );
 
-      analytics.track('mmconnect_connection_initiated', {
-        ...baseProps,
-        transport_type: transportType,
-        dapp_configured_chains: dappConfiguredChains,
-        dapp_requested_chains: scopes,
-      });
-    } catch (error) {
-      logger('Error tracking connection_initiated event', error);
+        analytics.track('mmconnect_connection_initiated', {
+          ...baseProps,
+          transport_type: transportType,
+          dapp_configured_chains: dappConfiguredChains,
+          dapp_requested_chains: scopes,
+        });
+      } catch (error) {
+        logger('Error tracking connection_initiated event', error);
+      }
     }
 
     const sessionData = await this.#getCaipSession();

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -207,7 +207,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     if (existing) {
       const instance = await existing;
       instance.mergeOptions(options);
-      await instance.#setupAnalytics();
+      await instance.setupAnalytics();
       if (options.debug) {
         enableDebug('metamask-sdk:*');
       }
@@ -235,6 +235,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     });
 
     return instancePromise;
+  }
+
+  /**
+   * Sets up analytics globals for the current SDK options.
+   */
+  public async setupAnalytics(): Promise<void> {
+    await this.#setupAnalytics();
   }
 
   async #setupAnalytics(): Promise<void> {

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -111,6 +111,19 @@ t.describe('RequestRouter', () => {
         });
 
         t.it(
+          'should skip wallet action analytics when analytics is disabled',
+          async () => {
+            mockConfig.analytics = { ...mockConfig.analytics, enabled: false };
+            mockTransport.request.mockResolvedValue({ result: '0xsignature' });
+
+            await requestRouter.invokeMethod(baseOptions);
+
+            t.expect(analytics.track).not.toHaveBeenCalled();
+            t.expect(mockStorage.getAnonId).not.toHaveBeenCalled();
+          },
+        );
+
+        t.it(
           'should throw RPCInvokeMethodErr when transport request fails',
           async () => {
             mockTransport.request.mockRejectedValue(

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -32,6 +32,23 @@ import { MissingRpcEndpointErr } from './handlers/rpcClient';
 let rpcId = 1;
 
 /**
+ * Normalizes unknown invocation errors to the router error type.
+ *
+ * @param error - Unknown error thrown during method execution.
+ * @returns Error instance surfaced by invokeMethod.
+ */
+function toRPCInvokeMethodErr(error: unknown): RPCInvokeMethodErr {
+  if (error instanceof RPCInvokeMethodErr) {
+    return error;
+  }
+  const castError = error as { message?: string; code?: number };
+  return new RPCInvokeMethodErr(
+    castError.message ?? 'Unknown error',
+    castError.code,
+  );
+}
+
+/**
  * Gets the next RPC ID for request tracking.
  *
  * @returns The next unique RPC ID.
@@ -125,6 +142,14 @@ export class RequestRouter {
     options: InvokeMethodOptions,
     execute: () => Promise<Json>,
   ): Promise<Json> {
+    if (this.config.analytics?.enabled === false) {
+      try {
+        return await execute();
+      } catch (error) {
+        throw toRPCInvokeMethodErr(error);
+      }
+    }
+
     await this.#trackWalletActionRequested(options);
 
     try {
@@ -141,14 +166,7 @@ export class RequestRouter {
       } else {
         await this.#trackWalletActionFailed(options, error);
       }
-      if (error instanceof RPCInvokeMethodErr) {
-        throw error;
-      }
-      const castError = error as { message?: string; code?: number };
-      throw new RPCInvokeMethodErr(
-        castError.message ?? 'Unknown error',
-        castError.code,
-      );
+      throw toRPCInvokeMethodErr(error);
     }
   }
 

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -97,6 +97,51 @@ function testSuite<T extends MultichainOptions>({
       await afterEach(mockedData);
     });
 
+    t.it(
+      `${platform} should omit analytics metadata when analytics is disabled`,
+      async () => {
+        if (platform === 'web') {
+          return;
+        }
+
+        const scopes = ['eip155:1'] as Scope[];
+        const caipAccountIds = [
+          'eip155:1:0x1234567890abcdef1234567890abcdef12345678',
+        ] as any;
+
+        mockedData.mockSessionRequest.mockImplementation(
+          async () => mockSessionRequestData,
+        );
+        mockedData.mockWalletGetSession.mockImplementation(
+          async () => undefined as any,
+        );
+        mockedData.mockWalletCreateSession.mockImplementation(
+          async () => mockSessionData,
+        );
+
+        sdk = await createSDK({
+          ...testOptions,
+          analytics: {
+            ...testOptions.analytics,
+            enabled: false,
+          },
+        });
+
+        const createDeeplinkSpy = t.vi.spyOn(
+          (sdk as any).options.ui.factory,
+          'createConnectionDeeplink',
+        );
+
+        await sdk.connect(scopes, caipAccountIds);
+
+        t.expect(createDeeplinkSpy).toHaveBeenCalled();
+        const connectionRequest = createDeeplinkSpy.mock.calls[0]?.[0] as any;
+        t.expect(connectionRequest.metadata).not.toHaveProperty('analytics');
+
+        createDeeplinkSpy.mockRestore();
+      },
+    );
+
     t.it(`${platform} should handle session upgrades`, async () => {
       const scopes = ['eip155:1', 'eip155:137'] as Scope[];
       const caipAccountIds = [

--- a/packages/connect-multichain/tests/mocks/analytics.ts
+++ b/packages/connect-multichain/tests/mocks/analytics.ts
@@ -8,6 +8,7 @@ vitest.vi.mock('@metamask/analytics', () => ({
   analytics: {
     setGlobalProperty: vitest.vi.fn(),
     enable: vitest.vi.fn(),
+    disable: vitest.vi.fn(),
     track: vitest.vi.fn(),
   },
 }));

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an `analytics.enabled` option to `createSolanaClient()`. Set it to `false` to disable dapp-side analytics events and wallet correlation metadata. ([#303](https://github.com/MetaMask/connect-monorepo/pull/303))
+
 ## [1.1.0]
 
 ### Changed

--- a/packages/connect-solana/README.md
+++ b/packages/connect-solana/README.md
@@ -102,18 +102,32 @@ Creates a new Solana client instance. By default, the wallet is automatically re
 
 #### Parameters
 
-| Option                  | Type                      | Required | Description                                                               |
-| ----------------------- | ------------------------- | -------- | ------------------------------------------------------------------------- |
-| `dapp.name`             | `string`                  | Yes      | Name of your dApp                                                         |
-| `dapp.url`              | `string`                  | No       | URL of your dApp                                                          |
-| `dapp.iconUrl`          | `string`                  | No       | Icon URL for your dApp                                                    |
-| `api.supportedNetworks` | `SolanaSupportedNetworks` | No       | Map of network names (`mainnet`, `devnet`, `testnet`) to RPC URLs         |
-| `debug`                 | `boolean`                 | No       | Reserved for future use; not currently forwarded to the underlying client |
-| `skipAutoRegister`      | `boolean`                 | No       | Skip auto-registering the wallet during creation (defaults to `false`)    |
+| Option                      | Type                      | Required | Description                                                                                                                  |
+| --------------------------- | ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `dapp.name`                 | `string`                  | Yes      | Name of your dApp                                                                                                            |
+| `dapp.url`                  | `string`                  | No       | URL of your dApp                                                                                                             |
+| `dapp.iconUrl`              | `string`                  | No       | Icon URL for your dApp                                                                                                       |
+| `api.supportedNetworks`     | `SolanaSupportedNetworks` | No       | Map of network names (`mainnet`, `devnet`, `testnet`) to RPC URLs                                                            |
+| `analytics.enabled`         | `boolean`                 | No       | Enables dapp-side analytics. Defaults to `true`; set to `false` to disable analytics events and wallet correlation metadata. |
+| `analytics.integrationType` | `string`                  | No       | Integration type for analytics                                                                                               |
+| `debug`                     | `boolean`                 | No       | Reserved for future use; not currently forwarded to the underlying client                                                    |
+| `skipAutoRegister`          | `boolean`                 | No       | Skip auto-registering the wallet during creation (defaults to `false`)                                                       |
 
 #### Returns
 
 `Promise<SolanaClient>`
+
+```typescript
+const client = await createSolanaClient({
+  dapp: {
+    name: 'My Solana DApp',
+    url: 'https://mydapp.com',
+  },
+  analytics: {
+    enabled: false,
+  },
+});
+```
 
 ---
 

--- a/packages/connect-solana/README.md
+++ b/packages/connect-solana/README.md
@@ -123,9 +123,6 @@ const client = await createSolanaClient({
     name: 'My Solana DApp',
     url: 'https://mydapp.com',
   },
-  analytics: {
-    enabled: false,
-  },
 });
 ```
 

--- a/packages/connect-solana/src/connect.test.ts
+++ b/packages/connect-solana/src/connect.test.ts
@@ -119,6 +119,19 @@ describe('createSolanaClient', () => {
     });
   });
 
+  it('should forward analytics.enabled to createMultichainClient', async () => {
+    await createSolanaClient({
+      ...mockOptions,
+      analytics: { enabled: false, integrationType: 'wallet-standard' },
+    });
+
+    expect(createMultichainClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        analytics: { enabled: false, integrationType: 'wallet-standard' },
+      }),
+    );
+  });
+
   it('should return core instance from createMultichainClient', async () => {
     const client = await createSolanaClient(mockOptions);
 

--- a/packages/connect-solana/src/connect.ts
+++ b/packages/connect-solana/src/connect.ts
@@ -31,6 +31,7 @@ declare const __PACKAGE_VERSION__: string | undefined;
  * @param options.api - Optional API configuration with supported networks
  * @param options.api.supportedNetworks - Record mapping network names (mainnet, devnet, testnet) to RPC URLs
  * @param [options.analytics] - Analytics configuration
+ * @param [options.analytics.enabled] - Whether to enable dapp-side analytics (defaults to true)
  * @param [options.analytics.integrationType] - Integration type for analytics (defaults to 'direct')
  * @param options.debug - Enable debug logging
  * @param options.skipAutoRegister - Skip auto-registering the wallet during creation (defaults to false)
@@ -77,6 +78,7 @@ export async function createSolanaClient(
       supportedNetworks,
     },
     analytics: {
+      ...(options.analytics ?? {}),
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       integrationType: options.analytics?.integrationType || 'direct',
     },


### PR DESCRIPTION
## Explanation

Adds an `analytics.enabled` option across the public connect packages so consumers can fully disable dapp-side analytics.

Analytics remain enabled by default. When `analytics.enabled` is `false`, the SDK disables the analytics singleton, clears queued sender events, skips analytics global property setup and event tracking, and omits the MWP `analytics.remote_session_id` connection metadata.

`@metamask/connect-evm` and `@metamask/connect-solana` now forward the option to `@metamask/connect-multichain`. The package READMEs and root CSP guidance now document the option and clarify that the analytics endpoint is only needed when analytics are enabled.

## References

Closes [WAPI-1504](https://consensyssoftware.atlassian.net/browse/WAPI-1504).

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
