### PR TITLE
refactor: cleanup deeply nested event callback promises

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename the storage API methods for the persisted transport type from `getTransport`, `setTransport`, and `removeTransport` to `getTransportType`, `setTransportType`, and `removeTransportType`. The existing `multichain-transport` storage key is unchanged, so no persisted data migration is required. ([#307](https://github.com/MetaMask/connect-monorepo/pull/307))
 - Refactor `MWPTransport.connect()` and other internals to replace deeply nested `new Promise()` and event-callback patterns with deferred promises, reducing nesting and breaking `connect()` into smaller helpers. No behavior change. ([#305](https://github.com/MetaMask/connect-monorepo/pull/305))
 
-
 ### Fixed
 
 - Failed `createMultichainClient()` singleton initialization now rethrows after clearing the stored singleton promise, preventing the cleanup path from resolving to `undefined` and preserving retry behavior. ([#306](https://github.com/MetaMask/connect-monorepo/pull/306))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor `MWPTransport.connect()` and other internals to replace deeply nested `new Promise()` and event-callback patterns with deferred promises, reducing nesting and breaking `connect()` into smaller helpers. No behavior change. ([#305](https://github.com/MetaMask/connect-monorepo/pull/305))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -19,6 +19,8 @@ import {
   METAMASK_DEEPLINK_BASE,
   MWP_RELAY_URL,
 } from '../config';
+import { createDeferredPromise } from '@metamask/utils';
+
 import {
   getVersion,
   type InvokeMethodOptions,
@@ -446,83 +448,83 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     caipAccountIds: CaipAccountId[],
     sessionProperties?: SessionProperties,
   ): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      // Use Connection Modal
-      this.options.ui.factory
-        .renderInstallModal(
-          desktopPreferred,
-          async () => {
-            if (
-              this.dappClient.state === 'CONNECTED' ||
-              this.dappClient.state === 'CONNECTING'
-            ) {
-              await this.dappClient.disconnect();
-            }
-            return new Promise<ConnectionRequest>((_resolve) => {
-              this.dappClient.on(
-                'session_request',
-                (sessionRequest: SessionRequest) => {
-                  _resolve({
-                    sessionRequest,
-                    metadata: this.#buildConnectionMetadata(),
-                  });
-                },
-              );
+    const completion = createDeferredPromise<void>();
 
-              (async (): Promise<void> => {
-                try {
-                  await this.transport.connect({
-                    scopes,
-                    caipAccountIds,
-                    sessionProperties,
-                  });
-                  await this.options.ui.factory.unload();
-                  this.options.ui.factory.modal?.unmount();
-                  this.status = 'connected';
-                  await this.storage.setTransport(TransportType.MWP);
-                } catch (error) {
-                  const { ProtocolError, ErrorCode } = await import(
-                    '@metamask/mobile-wallet-protocol-core'
-                  );
-                  if (error instanceof ProtocolError) {
-                    if (error.code !== ErrorCode.REQUEST_EXPIRED) {
-                      this.status = 'disconnected';
-                      // Close the modal on error
-                      await this.options.ui.factory.unload(error);
-                      reject(error);
-                    }
-                    // If request is expires, the QRCode will automatically be regenerated we can ignore this case
-                  } else {
-                    this.status = 'disconnected';
-                    const normalizedError =
-                      error instanceof Error ? error : new Error(String(error));
-                    // Close the modal on error
-                    await this.options.ui.factory.unload(normalizedError);
-                    reject(normalizedError);
-                  }
-                }
-              })().catch(() => {
-                // Error already handled in the async function
-              });
-            });
-          },
-          async (error?: Error) => {
-            if (error) {
-              await this.storage.removeTransport();
-              reject(error);
-            } else {
-              await this.storage.setTransport(TransportType.MWP);
-              resolve();
-            }
-          },
-          (uri: string) => {
-            this.emit('display_uri', uri);
-          },
-        )
-        .catch((error) => {
-          reject(error instanceof Error ? error : new Error(String(error)));
+    const createConnectionRequest = async (): Promise<ConnectionRequest> => {
+      if (
+        this.dappClient.state === 'CONNECTED' ||
+        this.dappClient.state === 'CONNECTING'
+      ) {
+        await this.dappClient.disconnect();
+      }
+
+      // The session_request event carries the pending request needed to build
+      // the deeplink / QR code. We resolve this deferred when it fires.
+      const sessionRequestDeferred = createDeferredPromise<ConnectionRequest>();
+      this.dappClient.on('session_request', (sessionRequest: SessionRequest) => {
+        sessionRequestDeferred.resolve({
+          sessionRequest,
+          metadata: this.#buildConnectionMetadata(),
         });
-    });
+      });
+
+      // Start the connection flow in the background — it will eventually emit
+      // session_request (resolving sessionRequestDeferred) and then either
+      // succeed (handled by the successCallback below) or fail (rejecting
+      // the outer completion deferred).
+      this.transport
+        .connect({ scopes, caipAccountIds, sessionProperties })
+        .then(async () => {
+          await this.options.ui.factory.unload();
+          this.options.ui.factory.modal?.unmount();
+          this.status = 'connected';
+          await this.storage.setTransport(TransportType.MWP);
+        })
+        .catch(async (error) => {
+          const { ProtocolError, ErrorCode } = await import(
+            '@metamask/mobile-wallet-protocol-core'
+          );
+          if (error instanceof ProtocolError) {
+            if (error.code !== ErrorCode.REQUEST_EXPIRED) {
+              this.status = 'disconnected';
+              await this.options.ui.factory.unload(error);
+              completion.reject(error);
+            }
+            // If the request is expired the QR code is automatically regenerated — ignore this case
+          } else {
+            this.status = 'disconnected';
+            const normalizedError =
+              error instanceof Error ? error : new Error(String(error));
+            await this.options.ui.factory.unload(normalizedError);
+            completion.reject(normalizedError);
+          }
+        });
+
+      return sessionRequestDeferred.promise;
+    };
+
+    this.options.ui.factory
+      .renderInstallModal(
+        desktopPreferred,
+        createConnectionRequest,
+        async (error?: Error) => {
+          if (error) {
+            await this.storage.removeTransport();
+            completion.reject(error);
+          } else {
+            await this.storage.setTransport(TransportType.MWP);
+            completion.resolve();
+          }
+        },
+        (uri: string) => {
+          this.emit('display_uri', uri);
+        },
+      )
+      .catch((error) => {
+        completion.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+
+    return completion.promise;
   }
 
   async #showInstallModal(
@@ -560,57 +562,40 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     caipAccountIds: CaipAccountId[],
     sessionProperties?: SessionProperties,
   ): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      if (
-        this.dappClient.state === 'CONNECTED' ||
-        this.dappClient.state === 'CONNECTING'
-      ) {
-        this.dappClient.disconnect().catch(() => {
-          // Ignore disconnect errors
-        });
-      }
+    if (
+      this.dappClient.state === 'CONNECTED' ||
+      this.dappClient.state === 'CONNECTING'
+    ) {
+      await this.dappClient.disconnect().catch(() => undefined);
+    }
 
-      // Listen for session_request to generate and emit the QR code link
-      this.dappClient.on(
-        'session_request',
-        (sessionRequest: SessionRequest) => {
-          const connectionRequest: ConnectionRequest = {
-            sessionRequest,
-            metadata: this.#buildConnectionMetadata(),
-          };
-
-          // Generate and emit the QR code link
-          const deeplink =
-            this.options.ui.factory.createConnectionDeeplink(connectionRequest);
-          this.emit('display_uri', deeplink);
-        },
-      );
-
-      // Start the connection
-      this.transport
-        .connect({ scopes, caipAccountIds, sessionProperties })
-        .then(async () => {
-          this.status = 'connected';
-          await this.storage.setTransport(TransportType.MWP);
-          resolve();
-        })
-        .catch(async (error) => {
-          const { ProtocolError } = await import(
-            '@metamask/mobile-wallet-protocol-core'
-          );
-          if (error instanceof ProtocolError) {
-            // In headless mode, we don't auto-regenerate QR codes
-            // since there's no modal to display them
-            this.status = 'disconnected';
-            await this.storage.removeTransport();
-            reject(error);
-          } else {
-            this.status = 'disconnected';
-            await this.storage.removeTransport();
-            reject(error instanceof Error ? error : new Error(String(error)));
-          }
-        });
+    // Listen for session_request to generate and emit the QR code link
+    this.dappClient.on('session_request', (sessionRequest: SessionRequest) => {
+      const connectionRequest: ConnectionRequest = {
+        sessionRequest,
+        metadata: this.#buildConnectionMetadata(),
+      };
+      const deeplink =
+        this.options.ui.factory.createConnectionDeeplink(connectionRequest);
+      this.emit('display_uri', deeplink);
     });
+
+    try {
+      await this.transport.connect({ scopes, caipAccountIds, sessionProperties });
+      this.status = 'connected';
+      await this.storage.setTransport(TransportType.MWP);
+    } catch (error) {
+      const { ProtocolError } = await import(
+        '@metamask/mobile-wallet-protocol-core'
+      );
+      this.status = 'disconnected';
+      await this.storage.removeTransport();
+      // In headless mode, we don't auto-regenerate QR codes since there's no modal to display them
+      if (error instanceof ProtocolError || error instanceof Error) {
+        throw error;
+      }
+      throw new Error(String(error));
+    }
   }
 
   async #setupDefaultTransport(

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -13,14 +13,13 @@ import {
   type SessionData,
 } from '@metamask/multichain-api-client';
 import type { CaipAccountId, Json } from '@metamask/utils';
+import { createDeferredPromise } from '@metamask/utils';
 
 import {
   METAMASK_CONNECT_BASE_URL,
   METAMASK_DEEPLINK_BASE,
   MWP_RELAY_URL,
 } from '../config';
-import { createDeferredPromise } from '@metamask/utils';
-
 import {
   getVersion,
   type InvokeMethodOptions,
@@ -448,7 +447,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     caipAccountIds: CaipAccountId[],
     sessionProperties?: SessionProperties,
   ): Promise<void> {
-    const completion = createDeferredPromise<void>();
+    const completion = createDeferredPromise();
 
     const createConnectionRequest = async (): Promise<ConnectionRequest> => {
       if (
@@ -461,12 +460,15 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       // The session_request event carries the pending request needed to build
       // the deeplink / QR code. We resolve this deferred when it fires.
       const sessionRequestDeferred = createDeferredPromise<ConnectionRequest>();
-      this.dappClient.on('session_request', (sessionRequest: SessionRequest) => {
-        sessionRequestDeferred.resolve({
-          sessionRequest,
-          metadata: this.#buildConnectionMetadata(),
-        });
-      });
+      this.dappClient.on(
+        'session_request',
+        (sessionRequest: SessionRequest) => {
+          sessionRequestDeferred.resolve({
+            sessionRequest,
+            metadata: this.#buildConnectionMetadata(),
+          });
+        },
+      );
 
       // Start the connection flow in the background — it will eventually emit
       // session_request (resolving sessionRequestDeferred) and then either
@@ -521,7 +523,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         },
       )
       .catch((error) => {
-        completion.reject(error instanceof Error ? error : new Error(String(error)));
+        completion.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        );
       });
 
     return completion.promise;
@@ -581,7 +585,11 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     });
 
     try {
-      await this.transport.connect({ scopes, caipAccountIds, sessionProperties });
+      await this.transport.connect({
+        scopes,
+        caipAccountIds,
+        sessionProperties,
+      });
       this.status = 'connected';
       await this.storage.setTransport(TransportType.MWP);
     } catch (error) {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -11,7 +11,6 @@
 /* eslint-disable @typescript-eslint/prefer-readonly */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable no-async-promise-executor -- Async promise executor needed for complex flow */
 import type {
   Session,
   SessionRequest,
@@ -26,6 +25,8 @@ import {
 } from '@metamask/multichain-api-client';
 import { JsonRpcError, providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { CaipAccountId } from '@metamask/utils';
+
+import { createDeferredPromise } from '@metamask/utils';
 
 import {
   createLogger,
@@ -304,82 +305,73 @@ export class MWPTransport implements ExtendedTransport {
     }
   }
 
-  private async onResumeSuccess(
-    resumeResolve: () => void,
-    resumeReject: (err: Error) => void,
-    options?: {
-      scopes: Scope[];
-      caipAccountIds: CaipAccountId[];
-      forceRequest?: boolean;
-    },
-  ): Promise<void> {
-    try {
-      await this.waitForWalletSessionIfNotCached();
-      const sessionRequest = await this.request({
-        method: 'wallet_getSession',
-      });
-      // TODO: verify if this branching logic can ever be hit
-      if (sessionRequest.error) {
-        return resumeReject(new Error(sessionRequest.error.message));
-      }
-      let walletSession = sessionRequest.result as SessionData;
-      if (walletSession && options) {
-        const currentScopes = Object.keys(
-          walletSession?.sessionScopes ?? {},
-        ) as Scope[];
-        const proposedScopes = options?.scopes ?? [];
-        const proposedCaipAccountIds = options?.caipAccountIds ?? [];
-        const hasSameScopesAndAccounts = isSameScopesAndAccounts(
-          currentScopes,
-          proposedScopes,
-          walletSession,
-          proposedCaipAccountIds,
-        );
-        if (options.forceRequest || !hasSameScopesAndAccounts) {
-          const optionalScopes = addValidAccounts(
-            getOptionalScopes(options?.scopes ?? []),
-            getValidAccounts(options?.caipAccountIds ?? []),
-          );
-          const sessionRequest: CreateSessionParams<RPCAPI> = {
-            optionalScopes,
-          };
-          const response = await this.request({
-            method: 'wallet_createSession',
-            params: sessionRequest,
-          });
-          if (response.error) {
-            return resumeReject(new Error(response.error.message));
-          }
-          // TODO: Maybe find a better way to revoke sessions on wallet without triggering an empty notification
-          // Issue of this is it will send a session update event with an empty session and right after we may get the session recovered
-          // await this.request({ method: 'wallet_revokeSession', params: walletSession });
-          walletSession = response.result as SessionData;
-        }
-      } else if (!walletSession) {
-        // TODO: verify if this branching logic can ever be hit
+  private async onResumeSuccess(options?: {
+    scopes: Scope[];
+    caipAccountIds: CaipAccountId[];
+    forceRequest?: boolean;
+  }): Promise<void> {
+    await this.waitForWalletSessionIfNotCached();
+    const sessionResponse = await this.request({ method: 'wallet_getSession' });
+    // TODO: verify if this branching logic can ever be hit
+    if (sessionResponse.error) {
+      throw new Error(sessionResponse.error.message);
+    }
+    let walletSession = sessionResponse.result as SessionData;
+    if (walletSession && options) {
+      const currentScopes = Object.keys(
+        walletSession?.sessionScopes ?? {},
+      ) as Scope[];
+      const proposedScopes = options?.scopes ?? [];
+      const proposedCaipAccountIds = options?.caipAccountIds ?? [];
+      const hasSameScopesAndAccounts = isSameScopesAndAccounts(
+        currentScopes,
+        proposedScopes,
+        walletSession,
+        proposedCaipAccountIds,
+      );
+      if (options.forceRequest || !hasSameScopesAndAccounts) {
         const optionalScopes = addValidAccounts(
           getOptionalScopes(options?.scopes ?? []),
           getValidAccounts(options?.caipAccountIds ?? []),
         );
-        const sessionRequest: CreateSessionParams<RPCAPI> = { optionalScopes };
+        const createSessionRequest: CreateSessionParams<RPCAPI> = {
+          optionalScopes,
+        };
         const response = await this.request({
           method: 'wallet_createSession',
-          params: sessionRequest,
+          params: createSessionRequest,
         });
         if (response.error) {
-          return resumeReject(new Error(response.error.message));
+          throw new Error(response.error.message);
         }
+        // TODO: Maybe find a better way to revoke sessions on wallet without triggering an empty notification
+        // Issue of this is it will send a session update event with an empty session and right after we may get the session recovered
+        // await this.request({ method: 'wallet_revokeSession', params: walletSession });
         walletSession = response.result as SessionData;
       }
-      await this.removeStoredPendingSessionRequest();
-      this.notifyCallbacks({
-        method: 'wallet_sessionChanged',
-        params: walletSession,
+    } else if (!walletSession) {
+      // TODO: verify if this branching logic can ever be hit
+      const optionalScopes = addValidAccounts(
+        getOptionalScopes(options?.scopes ?? []),
+        getValidAccounts(options?.caipAccountIds ?? []),
+      );
+      const createSessionRequest: CreateSessionParams<RPCAPI> = {
+        optionalScopes,
+      };
+      const response = await this.request({
+        method: 'wallet_createSession',
+        params: createSessionRequest,
       });
-      return resumeResolve();
-    } catch (err) {
-      return resumeReject(err as Error);
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+      walletSession = response.result as SessionData;
     }
+    await this.removeStoredPendingSessionRequest();
+    this.notifyCallbacks({
+      method: 'wallet_sessionChanged',
+      params: walletSession,
+    });
   }
 
   async init(): Promise<void> {
@@ -448,132 +440,128 @@ export class MWPTransport implements ExtendedTransport {
     const storedSessionRequestBeforeConnectionAttempt =
       await this.getStoredPendingSessionRequest();
 
-    let timeout: NodeJS.Timeout;
     let initialConnectionMessageHandler:
       | ((message: unknown) => Promise<void>)
       | undefined;
-    const connectionPromise = new Promise<void>(async (resolve, reject) => {
-      let connection: Promise<void>;
-      if (session) {
-        connection = new Promise<void>((resumeResolve, resumeReject) => {
-          if (this.dappClient.state === 'CONNECTED') {
-            this.onResumeSuccess(resumeResolve, resumeReject, options);
-          } else {
-            this.dappClient.once('connected', async () => {
-              this.onResumeSuccess(resumeResolve, resumeReject, options);
-            });
-            dappClient.resume(session?.id ?? '');
-          }
-        });
+
+    let connection: Promise<void>;
+    if (session) {
+      if (this.dappClient.state === 'CONNECTED') {
+        connection = this.onResumeSuccess(options);
       } else {
-        connection = new Promise<void>(
-          (resolveConnection, rejectConnection) => {
-            const optionalScopes = addValidAccounts(
-              getOptionalScopes(options?.scopes ?? []),
-              getValidAccounts(options?.caipAccountIds ?? []),
-            );
-            const sessionRequest: CreateSessionParams<RPCAPI> = {
-              optionalScopes,
-              sessionProperties: options?.sessionProperties,
-            };
-            const request = {
-              jsonrpc: '2.0',
-              id: String(getUniqueRequestId()),
-              method: 'wallet_createSession',
-              params: sessionRequest,
-            };
-
-            // Handler for initial connection messages - checks for error responses
-            // and properly rejects the connection promise with EIP-1193 error codes
-            initialConnectionMessageHandler = async (
-              message: unknown,
-            ): Promise<void> => {
-              if (typeof message !== 'object' || message === null) {
-                return;
-              }
-              if (!('data' in message)) {
-                return;
-              }
-
-              const messagePayload = message.data as Record<string, unknown>;
-
-              // Match by ID (preferred) or by method (backward compatibility for notifications without ID)
-              const isMatchingId = messagePayload.id === request.id;
-              const isMatchingMethod =
-                messagePayload.method === 'wallet_createSession' ||
-                messagePayload.method === 'wallet_sessionChanged';
-
-              if (!isMatchingId && !isMatchingMethod) {
-                return;
-              }
-
-              // Handle error response (e.g., user rejected the connection)
-              if (messagePayload.error) {
-                return rejectConnection(
-                  this.parseWalletError(messagePayload.error),
-                );
-              }
-
-              // Success case - store session, notify, and resolve
-              await this.storeWalletSession(
-                request,
-                messagePayload as TransportResponse,
-              );
-              await this.removeStoredPendingSessionRequest();
-              this.notifyCallbacks(messagePayload);
-              return resolveConnection();
-            };
-
-            this.dappClient.on('message', initialConnectionMessageHandler);
-
-            const platformType = getPlatformType();
-            const isQRCodeFlow = [
-              PlatformType.DesktopWeb,
-              PlatformType.NonBrowser,
-            ].includes(platformType);
-
-            const initialPayload = {
-              name: MULTICHAIN_PROVIDER_STREAM_NAME,
-              data: request,
-            };
-
-            dappClient
-              .connect({
-                mode: 'trusted',
-                initialPayload: isQRCodeFlow ? undefined : initialPayload,
-              })
-              .then(async () => {
-                if (isQRCodeFlow) {
-                  return dappClient.sendRequest(initialPayload);
-                }
-                return undefined;
-              })
-              .catch((error) => {
-                if (initialConnectionMessageHandler) {
-                  this.dappClient.off(
-                    'message',
-                    initialConnectionMessageHandler,
-                  );
-                }
-                rejectConnection(error);
-              });
-          },
-        );
+        const resumeDeferred = createDeferredPromise<void>();
+        this.dappClient.once('connected', () => {
+          void this.onResumeSuccess(options).then(
+            resumeDeferred.resolve,
+            resumeDeferred.reject,
+          );
+        });
+        dappClient.resume(session.id ?? '');
+        connection = resumeDeferred.promise;
       }
+    } else {
+      const connDeferred = createDeferredPromise<void>();
 
-      timeout = setTimeout(
-        () => {
-          reject(new TransportTimeoutError());
-        },
-        storedSessionRequestBeforeConnectionAttempt
-          ? this.options.resumeTimeout
-          : this.options.connectionTimeout,
+      const optionalScopes = addValidAccounts(
+        getOptionalScopes(options?.scopes ?? []),
+        getValidAccounts(options?.caipAccountIds ?? []),
       );
+      const sessionRequest: CreateSessionParams<RPCAPI> = {
+        optionalScopes,
+        sessionProperties: options?.sessionProperties,
+      };
+      const request = {
+        jsonrpc: '2.0',
+        id: String(getUniqueRequestId()),
+        method: 'wallet_createSession',
+        params: sessionRequest,
+      };
 
-      connection.then(resolve).catch(reject);
-    });
+      // Handler for initial connection messages — checks for error responses
+      // and properly rejects the connection promise with EIP-1193 error codes
+      initialConnectionMessageHandler = async (
+        message: unknown,
+      ): Promise<void> => {
+        if (typeof message !== 'object' || message === null) {
+          return;
+        }
+        if (!('data' in message)) {
+          return;
+        }
 
-    return connectionPromise
+        const messagePayload = message.data as Record<string, unknown>;
+
+        // Match by ID (preferred) or by method (backward compatibility for notifications without ID)
+        const isMatchingId = messagePayload.id === request.id;
+        const isMatchingMethod =
+          messagePayload.method === 'wallet_createSession' ||
+          messagePayload.method === 'wallet_sessionChanged';
+
+        if (!isMatchingId && !isMatchingMethod) {
+          return;
+        }
+
+        // Handle error response (e.g., user rejected the connection)
+        if (messagePayload.error) {
+          connDeferred.reject(this.parseWalletError(messagePayload.error));
+          return;
+        }
+
+        // Success case — store session, notify, and resolve
+        await this.storeWalletSession(
+          request,
+          messagePayload as TransportResponse,
+        );
+        await this.removeStoredPendingSessionRequest();
+        this.notifyCallbacks(messagePayload);
+        connDeferred.resolve();
+      };
+
+      this.dappClient.on('message', initialConnectionMessageHandler);
+
+      const platformType = getPlatformType();
+      const isQRCodeFlow = [
+        PlatformType.DesktopWeb,
+        PlatformType.NonBrowser,
+      ].includes(platformType);
+
+      const initialPayload = {
+        name: MULTICHAIN_PROVIDER_STREAM_NAME,
+        data: request,
+      };
+
+      dappClient
+        .connect({
+          mode: 'trusted',
+          initialPayload: isQRCodeFlow ? undefined : initialPayload,
+        })
+        .then(async () => {
+          if (isQRCodeFlow) {
+            return dappClient.sendRequest(initialPayload);
+          }
+          return undefined;
+        })
+        .catch((error) => {
+          if (initialConnectionMessageHandler) {
+            this.dappClient.off('message', initialConnectionMessageHandler);
+          }
+          connDeferred.reject(error);
+        });
+
+      connection = connDeferred.promise;
+    }
+
+    // Race the connection against a timeout so the caller gets a clear error
+    // if the wallet never responds, rather than hanging forever.
+    const timeoutDeferred = createDeferredPromise<never>();
+    const timeout = setTimeout(
+      () => timeoutDeferred.reject(new TransportTimeoutError()),
+      storedSessionRequestBeforeConnectionAttempt
+        ? this.options.resumeTimeout
+        : this.options.connectionTimeout,
+    );
+
+    return Promise.race([connection, timeoutDeferred.promise])
       .catch(async (error) => {
         // Clean up the MWP session from the KVStore so stale sessions
         // don't cause subsequent connect attempts to enter the resume path
@@ -581,9 +569,7 @@ export class MWPTransport implements ExtendedTransport {
         throw error;
       })
       .finally(() => {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
+        clearTimeout(timeout);
         if (initialConnectionMessageHandler) {
           this.dappClient.off('message', initialConnectionMessageHandler);
           initialConnectionMessageHandler = undefined;

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -1,7 +1,5 @@
 /* eslint-disable consistent-return */
-
 /* eslint-disable @typescript-eslint/no-misused-promises */
-
 /* eslint-disable id-denylist */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable no-restricted-globals */

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -334,12 +334,12 @@ export class MWPTransport implements ExtendedTransport {
           getOptionalScopes(options?.scopes ?? []),
           getValidAccounts(options?.caipAccountIds ?? []),
         );
-        const createSessionRequest: CreateSessionParams<RPCAPI> = {
+        const sessionRequest: CreateSessionParams<RPCAPI> = {
           optionalScopes,
         };
         const response = await this.request({
           method: 'wallet_createSession',
-          params: createSessionRequest,
+          params: sessionRequest,
         });
         if (response.error) {
           throw new Error(response.error.message);
@@ -355,12 +355,12 @@ export class MWPTransport implements ExtendedTransport {
         getOptionalScopes(options?.scopes ?? []),
         getValidAccounts(options?.caipAccountIds ?? []),
       );
-      const createSessionRequest: CreateSessionParams<RPCAPI> = {
+      const sessionRequest: CreateSessionParams<RPCAPI> = {
         optionalScopes,
       };
       const response = await this.request({
         method: 'wallet_createSession',
-        params: createSessionRequest,
+        params: sessionRequest,
       });
       if (response.error) {
         throw new Error(response.error.message);

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -391,7 +391,9 @@ export class MWPTransport implements ExtendedTransport {
       runOnResumeHandler();
     } else {
       this.dappClient.once('connected', runOnResumeHandler);
-      this.dappClient.resume(session.id ?? '').catch((err) => resumeDeferred.reject(err));
+      this.dappClient
+        .resume(session.id ?? '')
+        .catch((err) => resumeDeferred.reject(err));
     }
 
     const timeoutDeferred = createDeferredPromise<never>();

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -400,10 +400,12 @@ export class MWPTransport implements ExtendedTransport {
       this.options.resumeTimeout,
     );
 
+   const cleanup = () => this.dappClient.off('connected', runOnResumeHandler);
+
     return Promise.race([
       resumeDeferred.promise,
       timeoutDeferred.promise,
-    ]).finally(() => clearTimeout(timeout));
+    ]).finally(() => { clearTimeout(timeout); cleanup(); } );
   }
 
   /**

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -412,6 +412,12 @@ export class MWPTransport implements ExtendedTransport {
       forceRequest?: boolean;
     },
   ): Promise<void> {
+    // Captured before any work begins so that a `session_request` event fired
+    // during resume (e.g. when the resume path falls through to
+    // `wallet_createSession`) doesn't skew the timeout decision.
+    const isContinuingPriorAttempt =
+      (await this.getStoredPendingSessionRequest()) !== null;
+
     const resumeDeferred = createDeferredPromise();
     const runOnResumeHandler = async (): Promise<void> => {
       try {
@@ -430,10 +436,17 @@ export class MWPTransport implements ExtendedTransport {
         .catch((err) => resumeDeferred.reject(err));
     }
 
+    // The resume path can fall through to `wallet_createSession` (forceRequest,
+    // recovery from a missing wallet session, or a scope/account change), which
+    // requires a human to approve in the wallet. Use the longer
+    // `connectionTimeout` for those flows; only use the shorter `resumeTimeout`
+    // when we're continuing an in-flight prior attempt.
     const timeoutDeferred = createDeferredPromise<never>();
     const timeout = setTimeout(
       () => timeoutDeferred.reject(new TransportTimeoutError()),
-      this.options.resumeTimeout,
+      isContinuingPriorAttempt
+        ? this.options.resumeTimeout
+        : this.options.connectionTimeout,
     );
 
     const cleanup = () => this.dappClient.off('connected', runOnResumeHandler);

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -305,7 +305,7 @@ export class MWPTransport implements ExtendedTransport {
     }
   }
 
-  private async onResumeSuccess(options?: {
+  private async onResumeHandler(options?: {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
     forceRequest?: boolean;
@@ -383,17 +383,17 @@ export class MWPTransport implements ExtendedTransport {
     },
   ): Promise<void> {
     const resumeDeferred = createDeferredPromise<void>();
-    const runOnResumeSuccess = (): void => {
-      void this.onResumeSuccess(options).then(
+    const onResumeHandler = (): void => {
+      void this.onResumeHandler(options).then(
         resumeDeferred.resolve,
         resumeDeferred.reject,
       );
     };
 
     if (this.dappClient.state === 'CONNECTED') {
-      runOnResumeSuccess();
+      onResumeHandler();
     } else {
-      this.dappClient.once('connected', runOnResumeSuccess);
+      this.dappClient.once('connected', onResumeHandler);
       this.dappClient.resume(session.id ?? '');
     }
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -381,7 +381,7 @@ export class MWPTransport implements ExtendedTransport {
     const resumeDeferred = createDeferredPromise();
     const runOnResumeHandler = async (): Promise<void> => {
       try {
-        resumeDeferred.resolve(await this.onResumeHandler(options));
+        resumeDeferred.resolve(await this.#onResumeHandler(options));
       } catch (err) {
         resumeDeferred.reject(err);
       }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -391,7 +391,7 @@ export class MWPTransport implements ExtendedTransport {
       runOnResumeHandler();
     } else {
       this.dappClient.once('connected', runOnResumeHandler);
-      this.dappClient.resume(session.id ?? '');
+      this.dappClient.resume(session.id ?? '').catch((err) => resumeDeferred.reject(err));
     }
 
     const timeoutDeferred = createDeferredPromise<never>();

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -340,7 +340,6 @@ export class MWPTransport implements ExtendedTransport {
   }): Promise<void> {
     await this.waitForWalletSessionIfNotCached();
     const sessionResponse = await this.request({ method: 'wallet_getSession' });
-    // TODO: verify if this branching logic can ever be hit
     if (sessionResponse.error) {
       throw new Error(sessionResponse.error.message);
     }
@@ -378,7 +377,10 @@ export class MWPTransport implements ExtendedTransport {
         walletSession = response.result as SessionData;
       }
     } else if (!walletSession) {
-      // TODO: verify if this branching logic can ever be hit
+      // Hitting this branch implies that the MWP session was established,
+      // but the user has not yet accepted the initial wallet_createSession approval,
+      // but the page has refreshed and we've lost that previous context and so we
+      // are trying to recover by making a new wallet_createSession request.
       const optionalScopes = addValidAccounts(
         getOptionalScopes(options?.scopes ?? []),
         getValidAccounts(options?.caipAccountIds ?? []),

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -400,10 +400,15 @@ export class MWPTransport implements ExtendedTransport {
       this.options.resumeTimeout,
     );
 
+    const cleanup = () => this.dappClient.off('connected', runOnResumeHandler);
+
     return Promise.race([
       resumeDeferred.promise,
       timeoutDeferred.promise,
-    ]).finally(() => clearTimeout(timeout));
+    ]).finally(() => {
+      clearTimeout(timeout);
+      cleanup();
+    });
   }
 
   /**

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -374,6 +374,171 @@ export class MWPTransport implements ExtendedTransport {
     });
   }
 
+  async #resumeSession(
+    session: Session,
+    options?: {
+      scopes: Scope[];
+      caipAccountIds: CaipAccountId[];
+      forceRequest?: boolean;
+    },
+  ): Promise<void> {
+    const resumeDeferred = createDeferredPromise<void>();
+    const runOnResumeSuccess = (): void => {
+      void this.onResumeSuccess(options).then(
+        resumeDeferred.resolve,
+        resumeDeferred.reject,
+      );
+    };
+
+    if (this.dappClient.state === 'CONNECTED') {
+      runOnResumeSuccess();
+    } else {
+      this.dappClient.once('connected', runOnResumeSuccess);
+      this.dappClient.resume(session.id ?? '');
+    }
+
+    const timeoutDeferred = createDeferredPromise<never>();
+    const timeout = setTimeout(
+      () => timeoutDeferred.reject(new TransportTimeoutError()),
+      this.options.resumeTimeout,
+    );
+
+    return Promise.race([resumeDeferred.promise, timeoutDeferred.promise])
+      .finally(() => clearTimeout(timeout));
+  }
+
+  /**
+   * Starts a brand-new MWP session via `wallet_createSession`. Registers a
+   * one-shot message handler that resolves on the wallet's response, races
+   * the result against an internal timeout, and always tears down the
+   * message listener when settled.
+   *
+   * If a prior connection attempt is still pending in storage (e.g. across a
+   * page reload) the shorter `resumeTimeout` is used, since we're continuing
+   * that in-flight attempt rather than starting from scratch.
+   *
+   * @param options - The session options.
+   * @returns A promise that resolves when the wallet acknowledges the session,
+   * or rejects on error / timeout.
+   */
+  async #startSession(options?: {
+    scopes: Scope[];
+    caipAccountIds: CaipAccountId[];
+    sessionProperties?: SessionProperties;
+    forceRequest?: boolean;
+  }): Promise<void> {
+    const { dappClient } = this;
+
+    // Captured before any work begins so that the session_request event fired
+    // by `dappClient.connect()` (which overwrites the stored value) doesn't
+    // skew the timeout decision.
+    const isContinuingPriorAttempt =
+      (await this.getStoredPendingSessionRequest()) !== null;
+
+    const connDeferred = createDeferredPromise<void>();
+
+    const optionalScopes = addValidAccounts(
+      getOptionalScopes(options?.scopes ?? []),
+      getValidAccounts(options?.caipAccountIds ?? []),
+    );
+    const sessionRequest: CreateSessionParams<RPCAPI> = {
+      optionalScopes,
+      sessionProperties: options?.sessionProperties,
+    };
+    const request = {
+      jsonrpc: '2.0',
+      id: String(getUniqueRequestId()),
+      method: 'wallet_createSession',
+      params: sessionRequest,
+    };
+
+    let handler: ((message: unknown) => Promise<void>) | undefined;
+    const removeHandler = (): void => {
+      if (handler) {
+        this.dappClient.off('message', handler);
+        handler = undefined;
+      }
+    };
+
+    // Handler for initial connection messages — checks for error responses
+    // and properly rejects the connection promise with EIP-1193 error codes
+    handler = async (message: unknown): Promise<void> => {
+      if (typeof message !== 'object' || message === null) {
+        return;
+      }
+      if (!('data' in message)) {
+        return;
+      }
+
+      const messagePayload = message.data as Record<string, unknown>;
+
+      // Match by ID (preferred) or by method (backward compatibility for notifications without ID)
+      const isMatchingId = messagePayload.id === request.id;
+      const isMatchingMethod =
+        messagePayload.method === 'wallet_createSession' ||
+        messagePayload.method === 'wallet_sessionChanged';
+
+      if (!isMatchingId && !isMatchingMethod) {
+        return;
+      }
+
+      // Handle error response (e.g., user rejected the connection)
+      if (messagePayload.error) {
+        connDeferred.reject(this.parseWalletError(messagePayload.error));
+        return;
+      }
+
+      // Success case — store session, notify, and resolve
+      await this.storeWalletSession(
+        request,
+        messagePayload as TransportResponse,
+      );
+      await this.removeStoredPendingSessionRequest();
+      this.notifyCallbacks(messagePayload);
+      connDeferred.resolve();
+    };
+
+    this.dappClient.on('message', handler);
+
+    const platformType = getPlatformType();
+    const isQRCodeFlow = [
+      PlatformType.DesktopWeb,
+      PlatformType.NonBrowser,
+    ].includes(platformType);
+
+    const initialPayload = {
+      name: MULTICHAIN_PROVIDER_STREAM_NAME,
+      data: request,
+    };
+
+    dappClient
+      .connect({
+        mode: 'trusted',
+        initialPayload: isQRCodeFlow ? undefined : initialPayload,
+      })
+      .then(async () => {
+        if (isQRCodeFlow) {
+          return dappClient.sendRequest(initialPayload);
+        }
+        return undefined;
+      })
+      .catch((error) => connDeferred.reject(error));
+
+    const timeoutDeferred = createDeferredPromise<never>();
+    const timeout = setTimeout(
+      () => timeoutDeferred.reject(new TransportTimeoutError()),
+      isContinuingPriorAttempt
+        ? this.options.resumeTimeout
+        : this.options.connectionTimeout,
+    );
+
+    return Promise.race([connDeferred.promise, timeoutDeferred.promise])
+      .finally(() => {
+        clearTimeout(timeout);
+        removeHandler();
+      });
+  }
+
   async init(): Promise<void> {
     // no-op for MWP — passive init is only relevant for DefaultTransport
   }
@@ -426,8 +591,6 @@ export class MWPTransport implements ExtendedTransport {
     sessionProperties?: SessionProperties;
     forceRequest?: boolean;
   }): Promise<void> {
-    const { dappClient } = this;
-
     const session = await this.getActiveSession();
     if (session) {
       logger('active session found', {
@@ -437,131 +600,11 @@ export class MWPTransport implements ExtendedTransport {
       });
     }
 
-    const storedSessionRequestBeforeConnectionAttempt =
-      await this.getStoredPendingSessionRequest();
+    const connection = session
+      ? this.#resumeSession(session, options)
+      : this.#startSession(options);
 
-    let initialConnectionMessageHandler:
-      | ((message: unknown) => Promise<void>)
-      | undefined;
-
-    let connection: Promise<void>;
-    if (session) {
-      if (this.dappClient.state === 'CONNECTED') {
-        connection = this.onResumeSuccess(options);
-      } else {
-        const resumeDeferred = createDeferredPromise<void>();
-        this.dappClient.once('connected', () => {
-          void this.onResumeSuccess(options).then(
-            resumeDeferred.resolve,
-            resumeDeferred.reject,
-          );
-        });
-        dappClient.resume(session.id ?? '');
-        connection = resumeDeferred.promise;
-      }
-    } else {
-      const connDeferred = createDeferredPromise<void>();
-
-      const optionalScopes = addValidAccounts(
-        getOptionalScopes(options?.scopes ?? []),
-        getValidAccounts(options?.caipAccountIds ?? []),
-      );
-      const sessionRequest: CreateSessionParams<RPCAPI> = {
-        optionalScopes,
-        sessionProperties: options?.sessionProperties,
-      };
-      const request = {
-        jsonrpc: '2.0',
-        id: String(getUniqueRequestId()),
-        method: 'wallet_createSession',
-        params: sessionRequest,
-      };
-
-      // Handler for initial connection messages — checks for error responses
-      // and properly rejects the connection promise with EIP-1193 error codes
-      initialConnectionMessageHandler = async (
-        message: unknown,
-      ): Promise<void> => {
-        if (typeof message !== 'object' || message === null) {
-          return;
-        }
-        if (!('data' in message)) {
-          return;
-        }
-
-        const messagePayload = message.data as Record<string, unknown>;
-
-        // Match by ID (preferred) or by method (backward compatibility for notifications without ID)
-        const isMatchingId = messagePayload.id === request.id;
-        const isMatchingMethod =
-          messagePayload.method === 'wallet_createSession' ||
-          messagePayload.method === 'wallet_sessionChanged';
-
-        if (!isMatchingId && !isMatchingMethod) {
-          return;
-        }
-
-        // Handle error response (e.g., user rejected the connection)
-        if (messagePayload.error) {
-          connDeferred.reject(this.parseWalletError(messagePayload.error));
-          return;
-        }
-
-        // Success case — store session, notify, and resolve
-        await this.storeWalletSession(
-          request,
-          messagePayload as TransportResponse,
-        );
-        await this.removeStoredPendingSessionRequest();
-        this.notifyCallbacks(messagePayload);
-        connDeferred.resolve();
-      };
-
-      this.dappClient.on('message', initialConnectionMessageHandler);
-
-      const platformType = getPlatformType();
-      const isQRCodeFlow = [
-        PlatformType.DesktopWeb,
-        PlatformType.NonBrowser,
-      ].includes(platformType);
-
-      const initialPayload = {
-        name: MULTICHAIN_PROVIDER_STREAM_NAME,
-        data: request,
-      };
-
-      dappClient
-        .connect({
-          mode: 'trusted',
-          initialPayload: isQRCodeFlow ? undefined : initialPayload,
-        })
-        .then(async () => {
-          if (isQRCodeFlow) {
-            return dappClient.sendRequest(initialPayload);
-          }
-          return undefined;
-        })
-        .catch((error) => {
-          if (initialConnectionMessageHandler) {
-            this.dappClient.off('message', initialConnectionMessageHandler);
-          }
-          connDeferred.reject(error);
-        });
-
-      connection = connDeferred.promise;
-    }
-
-    // Race the connection against a timeout so the caller gets a clear error
-    // if the wallet never responds, rather than hanging forever.
-    const timeoutDeferred = createDeferredPromise<never>();
-    const timeout = setTimeout(
-      () => timeoutDeferred.reject(new TransportTimeoutError()),
-      storedSessionRequestBeforeConnectionAttempt
-        ? this.options.resumeTimeout
-        : this.options.connectionTimeout,
-    );
-
-    return Promise.race([connection, timeoutDeferred.promise])
+    return connection
       .catch(async (error) => {
         // Clean up the MWP session from the KVStore so stale sessions
         // don't cause subsequent connect attempts to enter the resume path
@@ -569,11 +612,6 @@ export class MWPTransport implements ExtendedTransport {
         throw error;
       })
       .finally(() => {
-        clearTimeout(timeout);
-        if (initialConnectionMessageHandler) {
-          this.dappClient.off('message', initialConnectionMessageHandler);
-          initialConnectionMessageHandler = undefined;
-        }
         this.removeStoredPendingSessionRequest();
       });
   }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 /* eslint-disable consistent-return */
-/* eslint-disable promise/param-names */
+
 /* eslint-disable @typescript-eslint/no-misused-promises */
-/* eslint-disable @typescript-eslint/no-shadow */
+
 /* eslint-disable id-denylist */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable no-restricted-globals */
@@ -25,7 +24,6 @@ import {
 } from '@metamask/multichain-api-client';
 import { JsonRpcError, providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { CaipAccountId } from '@metamask/utils';
-
 import { createDeferredPromise } from '@metamask/utils';
 
 import {
@@ -382,18 +380,19 @@ export class MWPTransport implements ExtendedTransport {
       forceRequest?: boolean;
     },
   ): Promise<void> {
-    const resumeDeferred = createDeferredPromise<void>();
-    const onResumeHandler = (): void => {
-      void this.onResumeHandler(options).then(
-        resumeDeferred.resolve,
-        resumeDeferred.reject,
-      );
+    const resumeDeferred = createDeferredPromise();
+    const runOnResumeHandler = async (): Promise<void> => {
+      try {
+        resumeDeferred.resolve(await this.onResumeHandler(options));
+      } catch (err) {
+        resumeDeferred.reject(err);
+      }
     };
 
     if (this.dappClient.state === 'CONNECTED') {
-      onResumeHandler();
+      runOnResumeHandler();
     } else {
-      this.dappClient.once('connected', onResumeHandler);
+      this.dappClient.once('connected', runOnResumeHandler);
       this.dappClient.resume(session.id ?? '');
     }
 
@@ -403,8 +402,10 @@ export class MWPTransport implements ExtendedTransport {
       this.options.resumeTimeout,
     );
 
-    return Promise.race([resumeDeferred.promise, timeoutDeferred.promise])
-      .finally(() => clearTimeout(timeout));
+    return Promise.race([
+      resumeDeferred.promise,
+      timeoutDeferred.promise,
+    ]).finally(() => clearTimeout(timeout));
   }
 
   /**
@@ -418,6 +419,9 @@ export class MWPTransport implements ExtendedTransport {
    * that in-flight attempt rather than starting from scratch.
    *
    * @param options - The session options.
+   * @param options.scopes - The CAIP-2 scopes requested for the new session.
+   * @param options.caipAccountIds - The CAIP-10 account IDs to associate with the session.
+   * @param options.sessionProperties - Optional MWP session properties forwarded to the wallet.
    * @returns A promise that resolves when the wallet acknowledges the session,
    * or rejects on error / timeout.
    */
@@ -425,7 +429,6 @@ export class MWPTransport implements ExtendedTransport {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
     sessionProperties?: SessionProperties;
-    forceRequest?: boolean;
   }): Promise<void> {
     const { dappClient } = this;
 
@@ -435,7 +438,7 @@ export class MWPTransport implements ExtendedTransport {
     const isContinuingPriorAttempt =
       (await this.getStoredPendingSessionRequest()) !== null;
 
-    const connDeferred = createDeferredPromise<void>();
+    const connDeferred = createDeferredPromise();
 
     const optionalScopes = addValidAccounts(
       getOptionalScopes(options?.scopes ?? []),
@@ -532,11 +535,13 @@ export class MWPTransport implements ExtendedTransport {
         : this.options.connectionTimeout,
     );
 
-    return Promise.race([connDeferred.promise, timeoutDeferred.promise])
-      .finally(() => {
-        clearTimeout(timeout);
-        removeHandler();
-      });
+    return Promise.race([
+      connDeferred.promise,
+      timeoutDeferred.promise,
+    ]).finally(() => {
+      clearTimeout(timeout);
+      removeHandler();
+    });
   }
 
   async init(): Promise<void> {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -303,7 +303,7 @@ export class MWPTransport implements ExtendedTransport {
     }
   }
 
-  private async onResumeHandler(options?: {
+  async #onResumeHandler(options?: {
     scopes: Scope[];
     caipAccountIds: CaipAccountId[];
     forceRequest?: boolean;

--- a/packages/connect-multichain/tests/fixtures.test.ts
+++ b/packages/connect-multichain/tests/fixtures.test.ts
@@ -318,7 +318,7 @@ export const createTest: CreateTestFN = ({
           await mockDappClient.sendRequest({
             name: MULTICHAIN_PROVIDER_STREAM_NAME,
             data: {
-              id: `${this.__reqId++}`,
+              id: `${requestId++}`,
               jsonrpc: '2.0',
               method: 'wallet_getSession',
               params: [],


### PR DESCRIPTION
## Explanation

Refactors several offenders of the `new Promise()` and event callback soup pattern. This PR replaces that pattern with a deferred promise to reduce the amount of nesting and by breaking down `MWPTransport.connect()` into smaller methods. 

Extension and Mobile E2E tests are passing.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
