### PR TITLE
fix(connect-multichain): rethrow singleton initialization cleanup errors

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Failed `createMultichainClient()` singleton initialization now rethrows after clearing the stored singleton promise, preventing the cleanup path from resolving to `undefined` and preserving retry behavior. ([#306](https://github.com/MetaMask/connect-monorepo/pull/306))
+
 ## [0.14.0]
 
 ### Added

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -20,6 +20,8 @@ import { analytics } from '@metamask/analytics';
 import * as loggerModule from './domain/logger';
 import { mockSessionData, mockSessionRequestData } from '../tests/data';
 import type { TestSuiteOptions, MockedData } from '../tests/types';
+import { MetaMaskConnectMultichain } from './multichain';
+import { getGlobalObject } from './multichain/utils';
 
 /**
  *
@@ -279,6 +281,82 @@ function testSuite<T extends MultichainOptions>({
         }
 
         setGlobalSpy.mockRestore();
+      },
+    );
+
+    t.it(
+      `${platform} should rethrow singleton initialization errors after cleanup and allow retry`,
+      async () => {
+        const testError = new Error('Debug storage unavailable');
+        t.vi.mocked(loggerModule.isEnabled).mockRejectedValueOnce(testError);
+        const consoleErrorSpy = t.vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => undefined);
+        const getDebug = t.vi.fn(async () => null);
+        const storage = {
+          adapter: {
+            platform,
+          },
+          getAnonId: t.vi.fn(async () => 'anon-id'),
+          getExtensionId: t.vi.fn(async () => null),
+          setExtensionId: t.vi.fn(async () => undefined),
+          getTransport: t.vi.fn(async () => null),
+          setTransport: t.vi.fn(async () => undefined),
+          removeTransport: t.vi.fn(async () => undefined),
+          setAnonId: t.vi.fn(async () => undefined),
+          removeExtensionId: t.vi.fn(async () => undefined),
+          removeAnonId: t.vi.fn(async () => undefined),
+          getDebug,
+        };
+        const createOptions = {
+          ...testOptions,
+          storage,
+          ui: {
+            factory: {
+              createConnectionDeeplink: t.vi.fn(),
+              createConnectionUniversalLink: t.vi.fn(),
+            },
+            headless: true,
+            preferExtension: false,
+            showInstallModal: false,
+          },
+        } as any;
+        const callOriginalCatch = async (
+          promise: Promise<unknown>,
+          onRejected?: Parameters<Promise<unknown>['catch']>[0],
+        ): Promise<unknown> => promise.then(undefined, onRejected);
+        let cleanupPromise: Promise<unknown> | undefined;
+        const catchSpy = t.vi
+          .spyOn(Promise.prototype, 'catch')
+          .mockImplementation(async function catchImplementation(
+            this: Promise<unknown>,
+            onRejected?: Parameters<Promise<unknown>['catch']>[0],
+          ) {
+            cleanupPromise = callOriginalCatch(this, onRejected);
+            return cleanupPromise;
+          });
+
+        try {
+          const createPromise = MetaMaskConnectMultichain.create(createOptions);
+          catchSpy.mockRestore();
+
+          await t.expect(createPromise).rejects.toBe(testError);
+          await t.expect(cleanupPromise).rejects.toBe(testError);
+          t.expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error initializing MetaMaskConnectMultichain',
+            testError,
+          );
+          t.expect(
+            getGlobalObject().__METAMASK_CONNECT_MULTICHAIN_SINGLETON__,
+          ).toBeUndefined();
+
+          await t
+            .expect(MetaMaskConnectMultichain.create(createOptions))
+            .resolves.toBeDefined();
+        } finally {
+          catchSpy.mockRestore();
+          consoleErrorSpy.mockRestore();
+        }
       },
     );
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -210,14 +210,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       }
       await instance.#init();
       return instance;
-    })();
-
-    globalObject[SINGLETON_KEY] = instancePromise;
-
-    instancePromise.catch((error) => {
+    })().catch((error) => {
       globalObject[SINGLETON_KEY] = undefined;
       console.error('Error initializing MetaMaskConnectMultichain', error);
+      throw error;
     });
+
+    globalObject[SINGLETON_KEY] = instancePromise;
 
     return instancePromise;
   }


### PR DESCRIPTION
https://consensyssoftware.atlassian.net/browse/WAPI-1528

## Summary

- Rethrows singleton initialization failures after clearing the stored singleton promise.
- Keeps retry behavior intact after a failed initialization attempt.
- Adds regression coverage for the cleanup promise and retry path.

## Testing

- `yarn workspace @metamask/connect-multichain vitest run src/init.test.ts -t "should rethrow singleton initialization errors after cleanup and allow retry"`