### PR TITLE
refactor(connect-multichain): rename storage transport type methods

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename the storage API methods for the persisted transport type from `getTransport`, `setTransport`, and `removeTransport` to `getTransportType`, `setTransportType`, and `removeTransportType`. The existing `multichain-transport` storage key is unchanged, so no persisted data migration is required. ([#307](https://github.com/MetaMask/connect-monorepo/pull/307))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/connect-multichain/src/connect.test.ts
+++ b/packages/connect-multichain/src/connect.test.ts
@@ -316,7 +316,7 @@ function testSuite<T extends MultichainOptions>({
         t.expect(sdk.storage).toBeDefined();
 
         await t
-          .expect(sdk.storage.getTransport())
+          .expect(sdk.storage.getTransportType())
           .resolves.toBe(transportString);
       },
     );
@@ -360,7 +360,7 @@ function testSuite<T extends MultichainOptions>({
         }
 
         await t
-          .expect(sdk.storage.getTransport())
+          .expect(sdk.storage.getTransportType())
           .resolves.toBe(transportString);
       },
     );
@@ -440,7 +440,7 @@ function testSuite<T extends MultichainOptions>({
         }
 
         await t
-          .expect(sdk.storage.getTransport())
+          .expect(sdk.storage.getTransportType())
           .resolves.toBe(transportString);
       },
     );

--- a/packages/connect-multichain/src/domain/store/client.ts
+++ b/packages/connect-multichain/src/domain/store/client.ts
@@ -11,11 +11,11 @@ export abstract class StoreClient {
 
   abstract setExtensionId(extensionId: string): Promise<void>;
 
-  abstract getTransport(): Promise<TransportType | null>;
+  abstract getTransportType(): Promise<TransportType | null>;
 
-  abstract setTransport(transport: TransportType): Promise<void>;
+  abstract setTransportType(transportType: TransportType): Promise<void>;
 
-  abstract removeTransport(): Promise<void>;
+  abstract removeTransportType(): Promise<void>;
 
   abstract setAnonId(anonId: string): Promise<void>;
 

--- a/packages/connect-multichain/src/init.test.ts
+++ b/packages/connect-multichain/src/init.test.ts
@@ -380,7 +380,7 @@ function testSuite<T extends MultichainOptions>({
 
         if (platform === 'node') {
           // Node: set multichain-transport in storage first, then throw when reading it
-          // getTransport() calls adapter.get('multichain-transport') which calls getItem
+          // getTransportType() calls adapter.get('multichain-transport') which calls getItem
           mockedData.nativeStorageStub.data.set(
             'multichain-transport',
             'browser',

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -327,7 +327,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
   }
 
   async #getStoredTransport(): Promise<ExtendedTransport | undefined> {
-    const transportType = await this.storage.getTransport();
+    const transportType = await this.storage.getTransportType();
     const hasExtensionInstalled = await hasExtension();
     if (transportType) {
       if (transportType === TransportType.Browser) {
@@ -356,7 +356,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         return apiTransport;
       }
 
-      await this.storage.removeTransport();
+      await this.storage.removeTransportType();
     }
 
     return undefined;
@@ -371,9 +371,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       }
       this.status = 'connected';
       if (this.#transportType === TransportType.MWP) {
-        await this.storage.setTransport(TransportType.MWP);
+        await this.storage.setTransportType(TransportType.MWP);
       } else {
-        await this.storage.setTransport(TransportType.Browser);
+        await this.storage.setTransportType(TransportType.Browser);
       }
     } else {
       this.status = 'loaded';
@@ -410,7 +410,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
       await this.#setupAnalytics();
       await this.#setupTransport();
     } catch (error) {
-      await this.storage.removeTransport();
+      await this.storage.removeTransportType();
       this.status = 'pending';
       logger('MetaMaskSDK error during initialization', error);
     }
@@ -460,13 +460,13 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     this.#listener = this.transport.onNotification(
       this.#onTransportNotification.bind(this),
     );
-    await this.storage.setTransport(TransportType.MWP);
+    await this.storage.setTransportType(TransportType.MWP);
   }
 
   async #onBeforeUnload(): Promise<void> {
     // Fixes glitch with "connecting" state when modal is still visible and we close screen or refresh
     if (this.options.ui.factory.modal?.isMounted) {
-      await this.storage.removeTransport();
+      await this.storage.removeTransportType();
     }
   }
 
@@ -528,7 +528,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
                   await this.options.ui.factory.unload();
                   this.options.ui.factory.modal?.unmount();
                   this.status = 'connected';
-                  await this.storage.setTransport(TransportType.MWP);
+                  await this.storage.setTransportType(TransportType.MWP);
                 } catch (error) {
                   const { ProtocolError, ErrorCode } = await import(
                     '@metamask/mobile-wallet-protocol-core'
@@ -557,10 +557,10 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           },
           async (error?: Error) => {
             if (error) {
-              await this.storage.removeTransport();
+              await this.storage.removeTransportType();
               reject(error);
             } else {
-              await this.storage.setTransport(TransportType.MWP);
+              await this.storage.setTransportType(TransportType.MWP);
               resolve();
             }
           },
@@ -640,7 +640,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         .connect({ scopes, caipAccountIds, sessionProperties })
         .then(async () => {
           this.status = 'connected';
-          await this.storage.setTransport(TransportType.MWP);
+          await this.storage.setTransportType(TransportType.MWP);
           resolve();
         })
         .catch(async (error) => {
@@ -651,11 +651,11 @@ export class MetaMaskConnectMultichain extends MultichainCore {
             // In headless mode, we don't auto-regenerate QR codes
             // since there's no modal to display them
             this.status = 'disconnected';
-            await this.storage.removeTransport();
+            await this.storage.removeTransportType();
             reject(error);
           } else {
             this.status = 'disconnected';
-            await this.storage.removeTransport();
+            await this.storage.removeTransportType();
             reject(error instanceof Error ? error : new Error(String(error)));
           }
         });
@@ -670,7 +670,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     }
 
     if (options?.persist) {
-      await this.storage.setTransport(TransportType.Browser);
+      await this.storage.setTransportType(TransportType.Browser);
     }
     const transport = new DefaultTransport();
     this.#listener = transport.onNotification(
@@ -752,7 +752,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         .connect({ scopes, caipAccountIds, sessionProperties })
         .then(resolve)
         .catch(async (error) => {
-          await this.storage.removeTransport();
+          await this.storage.removeTransportType();
           this.dappClient.off('message', dappClientMessageHandler);
           reject(error instanceof Error ? error : new Error(String(error)));
         })
@@ -904,9 +904,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
           })
           .then(async () => {
             if (this.#transportType === TransportType.MWP) {
-              return this.storage.setTransport(TransportType.MWP);
+              return this.storage.setTransportType(TransportType.MWP);
             }
-            return this.storage.setTransport(TransportType.Browser);
+            return this.storage.setTransportType(TransportType.Browser);
           }),
         scopes,
         transportType,
@@ -1016,7 +1016,7 @@ export class MetaMaskConnectMultichain extends MultichainCore {
     await this.#transport?.disconnect(scopes);
 
     if (remainingScopes.length === 0) {
-      await this.storage.removeTransport();
+      await this.storage.removeTransportType();
 
       // We want to leave the DefaultTransport instance connected so that we can
       // still listen for wallet_sessionChanged events.

--- a/packages/connect-multichain/src/session.test.ts
+++ b/packages/connect-multichain/src/session.test.ts
@@ -198,7 +198,9 @@ function testSuite<T extends MultichainOptions>({
       t.expect(sdk.transport).toBeDefined();
       t.expect(sdk.provider).toBeDefined();
       t.expect(sdk.storage).toBeDefined();
-      await t.expect(sdk.storage.getTransport()).resolves.toBe(transportString);
+      await t
+        .expect(sdk.storage.getTransportType())
+        .resolves.toBe(transportString);
 
       mockedData.mockDefaultTransport.request.mockClear();
       mockedData.mockDappClient.sendRequest.mockClear();

--- a/packages/connect-multichain/src/store/index.test.ts
+++ b/packages/connect-multichain/src/store/index.test.ts
@@ -152,61 +152,61 @@ function createStoreTests(
     });
   });
 
-  t.describe(`${adapterName} getTransport`, () => {
+  t.describe(`${adapterName} getTransportType`, () => {
     t.it(
-      'should return the transport value when it exists - Browser',
+      'should return the transport type when it exists - Browser',
       async () => {
         await adapter.set('multichain-transport', 'browser');
-        const result = await store.getTransport();
+        const result = await store.getTransportType();
         t.expect(result).toBe(TransportType.Browser);
       },
     );
 
-    t.it('should return the transport value when it exists - MPW', async () => {
+    t.it('should return the transport type when it exists - MWP', async () => {
       await adapter.set('multichain-transport', 'mwp');
-      const result = await store.getTransport();
+      const result = await store.getTransportType();
       t.expect(result).toBe(TransportType.MWP);
     });
 
     t.it('should return UNKNOWN for unknown transport types', async () => {
       await adapter.set('multichain-transport', 'unknown-transport');
-      const result = await store.getTransport();
+      const result = await store.getTransportType();
       t.expect(result).toBe(TransportType.UNKNOWN);
     });
 
     t.it('should return null when transport does not exist', async () => {
-      const result = await store.getTransport();
+      const result = await store.getTransportType();
       t.expect(result).toBeNull();
     });
   });
 
-  t.describe(`${adapterName} setTransport`, () => {
-    t.it('should set the transport successfully - Browser', async () => {
-      await store.setTransport(TransportType.Browser);
+  t.describe(`${adapterName} setTransportType`, () => {
+    t.it('should set the transport type successfully - Browser', async () => {
+      await store.setTransportType(TransportType.Browser);
       const result = await adapter.get('multichain-transport');
       t.expect(result).toBe('browser');
     });
 
-    t.it('should set the transport successfully - MWP', async () => {
-      await store.setTransport(TransportType.MWP);
+    t.it('should set the transport type successfully - MWP', async () => {
+      await store.setTransportType(TransportType.MWP);
       const result = await adapter.get('multichain-transport');
       t.expect(result).toBe('mwp');
     });
 
-    t.it('should set the transport successfully - UNKNOWN', async () => {
-      await store.setTransport(TransportType.UNKNOWN);
+    t.it('should set the transport type successfully - UNKNOWN', async () => {
+      await store.setTransportType(TransportType.UNKNOWN);
       const result = await adapter.get('multichain-transport');
       t.expect(result).toBe('unknown');
     });
   });
 
-  t.describe(`${adapterName} removeTransport`, () => {
-    t.it('should remove the transport successfully', async () => {
+  t.describe(`${adapterName} removeTransportType`, () => {
+    t.it('should remove the transport type successfully', async () => {
       await adapter.set('multichain-transport', 'browser');
       const beforeRemove = await adapter.get('multichain-transport');
       t.expect(beforeRemove).toBe('browser');
 
-      await store.removeTransport();
+      await store.removeTransportType();
       const afterRemove = await adapter.get('multichain-transport');
       t.expect(afterRemove).toBeNull();
     });
@@ -223,7 +223,7 @@ function createStoreTests(
         .rejects.toBeInstanceOf(StorageGetErr);
       await t.expect(store.getDebug()).rejects.toBeInstanceOf(StorageGetErr);
       await t
-        .expect(store.getTransport())
+        .expect(store.getTransportType())
         .rejects.toBeInstanceOf(StorageGetErr);
     });
 
@@ -235,7 +235,7 @@ function createStoreTests(
         .expect(store.setExtensionId('test-id'))
         .rejects.toThrow(StorageSetErr);
       await t
-        .expect(store.setTransport(TransportType.Browser))
+        .expect(store.setTransportType(TransportType.Browser))
         .rejects.toThrow(StorageSetErr);
     });
 
@@ -251,7 +251,7 @@ function createStoreTests(
           .expect(store.removeExtensionId())
           .rejects.toThrow(StorageDeleteErr);
         await t
-          .expect(store.removeTransport())
+          .expect(store.removeTransportType())
           .rejects.toThrow(StorageDeleteErr);
       },
     );

--- a/packages/connect-multichain/src/store/index.ts
+++ b/packages/connect-multichain/src/store/index.ts
@@ -8,7 +8,7 @@ import {
   StorageGetErr,
   StorageSetErr,
 } from '../domain/errors/storage';
-import { getTransportType } from '../domain/multichain';
+import { getTransportType as parseTransportType } from '../domain/multichain';
 import { StoreClient } from '../domain/store/client';
 
 export class Store extends StoreClient {
@@ -16,13 +16,13 @@ export class Store extends StoreClient {
     super();
   }
 
-  async getTransport(): Promise<TransportType | null> {
+  async getTransportType(): Promise<TransportType | null> {
     try {
-      const transport = await this.adapter.get('multichain-transport');
-      if (!transport) {
+      const transportType = await this.adapter.get('multichain-transport');
+      if (!transportType) {
         return null;
       }
-      return getTransportType(transport);
+      return parseTransportType(transportType);
     } catch (err) {
       throw new StorageGetErr(
         this.adapter.platform,
@@ -32,9 +32,9 @@ export class Store extends StoreClient {
     }
   }
 
-  async setTransport(transport: TransportType): Promise<void> {
+  async setTransportType(transportType: TransportType): Promise<void> {
     try {
-      await this.adapter.set('multichain-transport', transport);
+      await this.adapter.set('multichain-transport', transportType);
     } catch (err) {
       throw new StorageSetErr(
         this.adapter.platform,
@@ -44,7 +44,7 @@ export class Store extends StoreClient {
     }
   }
 
-  async removeTransport(): Promise<void> {
+  async removeTransportType(): Promise<void> {
     try {
       await this.adapter.delete('multichain-transport');
     } catch (err) {


### PR DESCRIPTION
https://consensyssoftware.atlassian.net/browse/WAPI-1527

## Summary
- Rename the Store API for persisted transport values from get/set/removeTransport to get/set/removeTransportType.
- Update MetaMaskConnectMultichain call sites and related tests to use the clearer transport type method names.
- Preserve the existing multichain-transport storage key, so no persisted data migration is needed.
- Add the connect-multichain changelog entry required for the exported API rename.

## Acceptance Notes
- The renamed API describes the stored value as a transport type string instead of implying a transport instance.
- All production call sites and tests now use getTransportType, setTransportType, and removeTransportType.
- A search for the old method calls only finds the backlog context file, which is untracked and not part of this PR.

## Test Plan
- [x] yarn workspace @metamask/connect-multichain build
- [x] yarn test:unit (from packages/connect-multichain)
- [x] yarn workspace @metamask/connect-multichain changelog:validate
