### PR TITLE
chore(connect-multichain): drop unnecessary any cast in MWPTransport.isConnected

### DIFF
--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -677,8 +677,7 @@ export class MWPTransport implements ExtendedTransport {
    * @returns True if transport is connected, false otherwise
    */
   isConnected(): boolean {
-    // biome-ignore lint/suspicious/noExplicitAny:  required if state is not made public in dappClient
-    return (this.dappClient as any).state === 'CONNECTED';
+    return this.dappClient.state === 'CONNECTED';
   }
 
   /**


### PR DESCRIPTION
## Summary

`DappClient` (via `BaseClient`) exposes a public `state` getter, so the `as any` cast and its `biome-ignore` comment in `MWPTransport.isConnected` are no longer needed. Pure cleanup, no behavior change.

```ts
isConnected(): boolean {
  return this.dappClient.state === 'CONNECTED';
}
```

## Test plan

- [ ] CI green (typecheck + lint)