### PR TITLE
fix: reject MWP response errors

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MWP-backed EIP-1193 requests now surface wallet errors through rejected promises consistently with the default transport, so `EvmClient.switchChain()` no longer has to handle returned error payloads. ([#311](https://github.com/MetaMask/connect-monorepo/pull/311))
+
 ## [1.4.0]
 
 ### Added

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -588,13 +588,6 @@ export class MetamaskConnectEVM {
         params,
       });
 
-      // When using the MWP transport, the error is returned instead of thrown,
-      // so we force it into the catch block here.
-      const resultWithError = result as { error?: { message: string } };
-      if (resultWithError?.error) {
-        throw new Error(resultWithError.error.message);
-      }
-
       await this.#trackWalletActionSucceeded(method, scope, params);
       if ((result as { result: unknown }).result === null) {
         // result is successful we eagerly call onChainChanged to update the provider's selected chain ID.

--- a/packages/connect-evm/src/utils/infura.ts
+++ b/packages/connect-evm/src/utils/infura.ts
@@ -38,7 +38,7 @@ export const getInfuraRpcUrls = ({
         return acc;
       }
       const chainId = numberToHex(parseInt(reference, 10));
-      acc[chainId] = url as string;
+      acc[chainId] = url;
       return acc;
     },
     {},

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MWPTransport.request()` and `sendEip1193Message()` now reject wallet response errors returned as `result.error`, matching `DefaultTransport` error handling and preserving wallet error codes. ([#311](https://github.com/MetaMask/connect-monorepo/pull/311))
+
 ## [0.15.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -140,45 +140,6 @@ t.describe('RequestRouter', () => {
         );
 
         t.it(
-          'should throw RPCInvokeMethodErr when response contains an error',
-          async () => {
-            mockTransport.request.mockResolvedValue({
-              error: { code: -32603, message: 'Internal error' },
-            });
-
-            await t
-              .expect(requestRouter.invokeMethod(baseOptions))
-              .rejects.toBeInstanceOf(RPCInvokeMethodErr);
-            await t
-              .expect(requestRouter.invokeMethod(baseOptions))
-              .rejects.toThrow(
-                'RPC Request failed with code -32603: Internal error',
-              );
-          },
-        );
-
-        t.it(
-          'should preserve the original RPC error code on RPCInvokeMethodErr when response contains an error',
-          async () => {
-            mockTransport.request.mockResolvedValue({
-              error: {
-                code: 4001,
-                message:
-                  'MetaMask Tx Signature: User denied transaction signature.',
-              },
-            });
-
-            await t
-              .expect(requestRouter.invokeMethod(baseOptions))
-              .rejects.toSatisfy((error: RPCInvokeMethodErr) => {
-                return (
-                  error instanceof RPCInvokeMethodErr && error.rpcCode === 4001
-                );
-              });
-          },
-        );
-
-        t.it(
           'should preserve the original RPC error code when transport rejects with a coded error',
           async () => {
             const codedError = new Error(
@@ -246,9 +207,9 @@ t.describe('RequestRouter', () => {
     t.it(
       'attaches `failure_reason: wallet_internal_error` when the wallet returns code -32603',
       async () => {
-        mockTransport.request.mockResolvedValue({
-          error: { code: -32603, message: 'Internal error' },
-        });
+        const error = new Error('Internal error') as Error & { code: number };
+        error.code = -32603;
+        mockTransport.request.mockRejectedValue(error);
 
         await t
           .expect(requestRouter.invokeMethod(baseOptions))
@@ -267,13 +228,11 @@ t.describe('RequestRouter', () => {
     );
 
     t.it('sanitises addresses out of error_message_sample', async () => {
-      mockTransport.request.mockResolvedValue({
-        error: {
-          code: -32603,
-          message:
-            'Internal error fetching balance for 0x1234567890abcdef1234567890abcdef12345678',
-        },
-      });
+      const error = new Error(
+        'Internal error fetching balance for 0x1234567890abcdef1234567890abcdef12345678',
+      ) as Error & { code: number };
+      error.code = -32603;
+      mockTransport.request.mockRejectedValue(error);
 
       await t
         .expect(requestRouter.invokeMethod(baseOptions))

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -118,15 +118,6 @@ export class RequestRouter {
       }
 
       const response = await request;
-      if (response.error) {
-        const { error } = response;
-        throw new RPCInvokeMethodErr(
-          `RPC Request failed with code ${error.code}: ${error.message}`,
-          error.code,
-          error.message,
-        );
-      }
-
       return response.result as Json;
     });
   }

--- a/packages/connect-multichain/src/multichain/transports/default/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable id-length -- vitest alias */
+import type * as multichainApiClient from '@metamask/multichain-api-client';
 import * as t from 'vitest';
 
 const mocks = t.vi.hoisted(() => ({
@@ -12,8 +13,7 @@ const mocks = t.vi.hoisted(() => ({
 }));
 
 t.vi.mock('@metamask/multichain-api-client', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@metamask/multichain-api-client')>();
+  const actual = await importOriginal<typeof multichainApiClient>();
 
   return {
     ...actual,

--- a/packages/connect-multichain/src/multichain/transports/default/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable id-length -- vitest alias */
+import * as t from 'vitest';
+
+const mocks = t.vi.hoisted(() => ({
+  innerTransport: {
+    connect: t.vi.fn(),
+    disconnect: t.vi.fn(),
+    isConnected: t.vi.fn(),
+    onNotification: t.vi.fn(),
+    request: t.vi.fn(),
+  },
+}));
+
+t.vi.mock('@metamask/multichain-api-client', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@metamask/multichain-api-client')>();
+
+  return {
+    ...actual,
+    getDefaultTransport: t.vi.fn(() => mocks.innerTransport),
+  };
+});
+
+const { DefaultTransport } = await import('.');
+
+t.describe('DefaultTransport', () => {
+  t.afterEach(() => {
+    t.vi.clearAllMocks();
+  });
+
+  t.describe('request', () => {
+    t.it(
+      'rejects when the inner transport resolves a wallet error response',
+      async () => {
+        mocks.innerTransport.request.mockResolvedValue({
+          id: '1',
+          jsonrpc: '2.0',
+          error: {
+            code: 4001,
+            message: 'User rejected the request',
+          },
+        });
+
+        const transport = new DefaultTransport();
+
+        await t
+          .expect(
+            transport.request({
+              method: 'wallet_invokeMethod',
+              params: {
+                scope: 'eip155:1',
+                request: { method: 'personal_sign', params: [] },
+              },
+            } as never),
+          )
+          .rejects.toMatchObject({
+            code: 4001,
+            message: 'User rejected the request',
+          });
+      },
+    );
+  });
+});

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -314,7 +314,7 @@ export class DefaultTransport implements ExtendedTransport {
       throw this.#parseWalletError(response.error);
     }
 
-    return response;
+    return response as TResponse;
   }
 
   onNotification(callback: (data: unknown) => void): () => void {

--- a/packages/connect-multichain/src/multichain/transports/default/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/default/index.ts
@@ -55,6 +55,21 @@ export class DefaultTransport implements ExtendedTransport {
     }
   }
 
+  #parseWalletError(errorPayload: unknown): Error {
+    const errorData = errorPayload as Record<string, unknown>;
+    const error = new Error(
+      typeof errorData.message === 'string'
+        ? errorData.message
+        : 'Request failed',
+    ) as Error & { code?: number };
+
+    if (typeof errorData.code === 'number') {
+      error.code = errorData.code;
+    }
+
+    return error;
+  }
+
   #isMetamaskProviderEvent(event: MessageEvent): boolean {
     return (
       event?.data?.data?.name === 'metamask-provider' &&
@@ -94,16 +109,7 @@ export class DefaultTransport implements ExtendedTransport {
 
         const response = responseData as TransportResponse;
         if ('error' in response && response.error) {
-          // Attach the numeric RPC code so it survives the transport boundary
-          // and can be re-surfaced as an EIP-1193 error by higher layers.
-          // This path is exercised by sendEip1193Message callers.
-          const error = new Error(
-            response.error.message || 'Request failed',
-          ) as Error & { code?: number };
-          if (typeof response.error.code === 'number') {
-            error.code = response.error.code;
-          }
-          pendingRequest.reject(error);
+          pendingRequest.reject(this.#parseWalletError(response.error));
         } else {
           pendingRequest.resolve(response);
         }
@@ -302,7 +308,13 @@ export class DefaultTransport implements ExtendedTransport {
     request: TRequest,
     options: { timeout?: number } = this.#defaultRequestOptions,
   ): Promise<TResponse> {
-    return this.#transport.request(request, options);
+    const response = await this.#transport.request(request, options);
+
+    if (response.error) {
+      throw this.#parseWalletError(response.error);
+    }
+
+    return response;
   }
 
   onNotification(callback: (data: unknown) => void): () => void {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -580,6 +580,44 @@ t.describe('MWPTransport', () => {
         );
 
         t.it(
+          'rejects when wallet_createSession returns a response-shaped error',
+          async () => {
+            mockGetPlatformType.mockReturnValue(platform);
+
+            const connectPromise = transport.connect({
+              scopes: [],
+              caipAccountIds: [],
+            });
+
+            await t.vi.waitFor(() => {
+              t.expect(mockDappClient.sendRequest).toHaveBeenCalledTimes(1);
+            });
+
+            const sendRequestArgs = mockDappClient.sendRequest.mock.calls[0][0];
+            const initialHandler = getInitialConnectionMessageHandler();
+            t.expect(initialHandler).toBeDefined();
+
+            await initialHandler?.({
+              data: {
+                id: sendRequestArgs.data.id,
+                jsonrpc: '2.0',
+                result: {
+                  error: {
+                    code: 4001,
+                    message: 'User rejected the request',
+                  },
+                },
+              },
+            });
+
+            await t.expect(connectPromise).rejects.toMatchObject({
+              code: 4001,
+              message: 'User rejected the request',
+            });
+          },
+        );
+
+        t.it(
           'when dappClient.connect() rejects, sendRequest() is NOT called and the connect promise rejects',
           async () => {
             mockGetPlatformType.mockReturnValue(platform);
@@ -647,6 +685,44 @@ t.describe('MWPTransport', () => {
               },
             });
             await connectPromise;
+          },
+        );
+
+        t.it(
+          'rejects when inline wallet_createSession returns a response-shaped error',
+          async () => {
+            mockGetPlatformType.mockReturnValue(platform);
+
+            const connectPromise = transport.connect({
+              scopes: [],
+              caipAccountIds: [],
+            });
+
+            await t.vi.waitFor(() => {
+              t.expect(mockDappClient.connect).toHaveBeenCalledTimes(1);
+            });
+
+            const connectArgs = mockDappClient.connect.mock.calls[0][0];
+            const initialHandler = getInitialConnectionMessageHandler();
+            t.expect(initialHandler).toBeDefined();
+
+            await initialHandler?.({
+              data: {
+                id: connectArgs.initialPayload.data.id,
+                jsonrpc: '2.0',
+                result: {
+                  error: {
+                    code: 4001,
+                    message: 'User rejected the request',
+                  },
+                },
+              },
+            });
+
+            await t.expect(connectPromise).rejects.toMatchObject({
+              code: 4001,
+              message: 'User rejected the request',
+            });
           },
         );
       },

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -46,6 +46,12 @@ t.describe('MWPTransport', () => {
     t.vi.clearAllMocks();
   });
 
+  const getMessageHandler = ():
+    | ((message: unknown) => Promise<void> | void)
+    | undefined =>
+    mockDappClient.on.mock.calls.find((call: any[]) => call[0] === 'message')
+      ?.[1];
+
   t.describe('handleMessage error handling', () => {
     t.it(
       'should reject promise when WebSocket message contains error',
@@ -364,6 +370,82 @@ t.describe('MWPTransport', () => {
         resolve();
       });
     });
+
+    t.it('request rejects when the wallet resolves a response-shaped error', async () => {
+      mockDappClient.state = 'CONNECTED';
+
+      const requestPromise = transport.request({
+        method: 'wallet_invokeMethod',
+        params: {
+          scope: 'eip155:1',
+          request: { method: 'personal_sign', params: [] },
+        },
+      } as never);
+
+      await t.vi.waitFor(() => {
+        t.expect(mockDappClient.sendRequest).toHaveBeenCalledTimes(1);
+      });
+
+      const sendRequestPayload = mockDappClient.sendRequest.mock.calls[0][0];
+      const requestId = sendRequestPayload.data.id;
+      const messageHandler = getMessageHandler();
+
+      messageHandler?.({
+        data: {
+          id: requestId,
+          jsonrpc: '2.0',
+          result: {
+            error: {
+              code: 4001,
+              message: 'User rejected the request',
+            },
+          },
+        },
+      });
+
+      await t.expect(requestPromise).rejects.toMatchObject({
+        code: 4001,
+        message: 'User rejected the request',
+      });
+      t.expect(transport.pendingRequests.has(requestId)).toBe(false);
+    });
+
+    t.it(
+      'sendEip1193Message rejects when the wallet resolves a response-shaped error',
+      async () => {
+        const requestPromise = transport.sendEip1193Message({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: '0x89' }],
+        } as never);
+
+        await t.vi.waitFor(() => {
+          t.expect(mockDappClient.sendRequest).toHaveBeenCalledTimes(1);
+        });
+
+        const sendRequestPayload = mockDappClient.sendRequest.mock.calls[0][0];
+        const requestId = sendRequestPayload.data.id;
+        const messageHandler = getMessageHandler();
+
+        messageHandler?.({
+          data: {
+            id: requestId,
+            jsonrpc: '2.0',
+            result: {
+              error: {
+                code: 4902,
+                message: 'Unrecognized chain ID 0x89',
+              },
+            },
+          },
+        });
+
+        await t.expect(requestPromise).rejects.toMatchObject({
+          code: 4902,
+          message: 'Unrecognized chain ID 0x89',
+        });
+        t.expect(transport.pendingRequests.has(requestId)).toBe(false);
+      },
+    );
   });
 
   t.describe('connect() initialPayload platform branching', () => {

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -49,8 +49,9 @@ t.describe('MWPTransport', () => {
   const getMessageHandler = ():
     | ((message: unknown) => Promise<void> | void)
     | undefined =>
-    mockDappClient.on.mock.calls.find((call: any[]) => call[0] === 'message')
-      ?.[1];
+    mockDappClient.on.mock.calls.find(
+      (call: any[]) => call[0] === 'message',
+    )?.[1];
 
   t.describe('handleMessage error handling', () => {
     t.it(
@@ -371,44 +372,47 @@ t.describe('MWPTransport', () => {
       });
     });
 
-    t.it('request rejects when the wallet resolves a response-shaped error', async () => {
-      mockDappClient.state = 'CONNECTED';
+    t.it(
+      'request rejects when the wallet resolves a response-shaped error',
+      async () => {
+        mockDappClient.state = 'CONNECTED';
 
-      const requestPromise = transport.request({
-        method: 'wallet_invokeMethod',
-        params: {
-          scope: 'eip155:1',
-          request: { method: 'personal_sign', params: [] },
-        },
-      } as never);
+        const requestPromise = transport.request({
+          method: 'wallet_invokeMethod',
+          params: {
+            scope: 'eip155:1',
+            request: { method: 'personal_sign', params: [] },
+          },
+        } as never);
 
-      await t.vi.waitFor(() => {
-        t.expect(mockDappClient.sendRequest).toHaveBeenCalledTimes(1);
-      });
+        await t.vi.waitFor(() => {
+          t.expect(mockDappClient.sendRequest).toHaveBeenCalledTimes(1);
+        });
 
-      const sendRequestPayload = mockDappClient.sendRequest.mock.calls[0][0];
-      const requestId = sendRequestPayload.data.id;
-      const messageHandler = getMessageHandler();
+        const sendRequestPayload = mockDappClient.sendRequest.mock.calls[0][0];
+        const requestId = sendRequestPayload.data.id;
+        const messageHandler = getMessageHandler();
 
-      messageHandler?.({
-        data: {
-          id: requestId,
-          jsonrpc: '2.0',
-          result: {
-            error: {
-              code: 4001,
-              message: 'User rejected the request',
+        await messageHandler?.({
+          data: {
+            id: requestId,
+            jsonrpc: '2.0',
+            result: {
+              error: {
+                code: 4001,
+                message: 'User rejected the request',
+              },
             },
           },
-        },
-      });
+        });
 
-      await t.expect(requestPromise).rejects.toMatchObject({
-        code: 4001,
-        message: 'User rejected the request',
-      });
-      t.expect(transport.pendingRequests.has(requestId)).toBe(false);
-    });
+        await t.expect(requestPromise).rejects.toMatchObject({
+          code: 4001,
+          message: 'User rejected the request',
+        });
+        t.expect(transport.pendingRequests.has(requestId)).toBe(false);
+      },
+    );
 
     t.it(
       'sendEip1193Message rejects when the wallet resolves a response-shaped error',
@@ -426,7 +430,7 @@ t.describe('MWPTransport', () => {
         const requestId = sendRequestPayload.data.id;
         const messageHandler = getMessageHandler();
 
-        messageHandler?.({
+        await messageHandler?.({
           data: {
             id: requestId,
             jsonrpc: '2.0',

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -539,10 +539,12 @@ export class MWPTransport implements ExtendedTransport {
                 return;
               }
 
+              const responseError = this.getResponseError(messagePayload);
+
               // Handle error response (e.g., user rejected the connection)
-              if (messagePayload.error) {
+              if (responseError) {
                 return rejectConnection(
-                  this.parseWalletError(messagePayload.error),
+                  this.parseWalletError(responseError),
                 );
               }
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -210,6 +210,37 @@ export class MWPTransport implements ExtendedTransport {
     return rpcErrors.internal({ message });
   }
 
+  private getResponseError(messagePayload: Record<string, unknown>): unknown {
+    if ('error' in messagePayload && messagePayload.error) {
+      return messagePayload.error;
+    }
+
+    const { result } = messagePayload;
+    if (
+      typeof result === 'object' &&
+      result !== null &&
+      'error' in result &&
+      result.error &&
+      this.isErrorPayload(result.error)
+    ) {
+      return result.error;
+    }
+
+    return undefined;
+  }
+
+  private isErrorPayload(errorPayload: unknown): boolean {
+    if (errorPayload instanceof Error) {
+      return true;
+    }
+
+    const errorData = errorPayload as Record<string, unknown>;
+    return (
+      typeof errorData?.code === 'number' &&
+      typeof errorData?.message === 'string'
+    );
+  }
+
   private handleMessage(message: unknown): void {
     if (typeof message === 'object' && message !== null) {
       if ('data' in message) {
@@ -221,10 +252,11 @@ export class MWPTransport implements ExtendedTransport {
           if (request) {
             clearTimeout(request.timeout);
 
-            // Check if the message contains an error (e.g., user rejected)
-            if ('error' in messagePayload && messagePayload.error) {
+            const responseError = this.getResponseError(messagePayload);
+
+            if (responseError) {
               this.pendingRequests.delete(messagePayload.id);
-              request.reject(this.parseWalletError(messagePayload.error));
+              request.reject(this.parseWalletError(responseError));
               return;
             }
 

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -543,9 +543,7 @@ export class MWPTransport implements ExtendedTransport {
 
               // Handle error response (e.g., user rejected the connection)
               if (responseError) {
-                return rejectConnection(
-                  this.parseWalletError(responseError),
-                );
+                return rejectConnection(this.parseWalletError(responseError));
               }
 
               // Success case - store session, notify, and resolve

--- a/packages/connect-multichain/src/ui/ModalFactory.ts
+++ b/packages/connect-multichain/src/ui/ModalFactory.ts
@@ -176,7 +176,11 @@ export abstract class BaseModalFactory<
         this.displayUriCallback?.(newLink);
         return newLink;
       },
-      onClose: this.onCloseModal.bind(this),
+      onClose: (shouldTerminate?: boolean) => {
+        this.onCloseModal(shouldTerminate).catch((error) => {
+          console.error('Failed to close modal:', error);
+        });
+      },
       startDesktopOnboarding: this.onStartDesktopOnboarding.bind(this),
       createConnectionRequest,
       onDisplayUri: this.displayUriCallback,

--- a/packages/connect-multichain/src/ui/index.ts
+++ b/packages/connect-multichain/src/ui/index.ts
@@ -17,7 +17,7 @@ export async function preload(): Promise<void> {
     const { defineCustomElements } = await import(
       '@metamask/multichain-ui/loader'
     );
-    await defineCustomElements();
+    defineCustomElements();
   } catch (error) {
     console.error('Failed to load customElements:', error);
   }

--- a/packages/connect-multichain/src/ui/modals/web/install.ts
+++ b/packages/connect-multichain/src/ui/modals/web/install.ts
@@ -10,9 +10,7 @@ export class InstallModal extends AbstractInstallModal {
 
   mount(): void {
     const { options } = this;
-    const modal = document.createElement(
-      'mm-install-modal',
-    ) as HTMLMmInstallModalElement;
+    const modal = document.createElement('mm-install-modal');
 
     modal.showInstallModal = options.showInstallModal;
     modal.addEventListener('close', (ev: Event) => {


### PR DESCRIPTION
## Explanation

DefaultTransport rejects wallet errors, while MWPTransport could resolve response-shaped wallet errors nested under result.error. That forced ecosystem clients to handle both thrown and returned error forms.

This normalizes MWP pending request handling so response-shaped wallet errors reject with the parsed wallet error, preserving numeric wallet error codes. It also removes downstream returned-error checks from RequestRouter and connect-evm switchChain so callers consume one transport contract: success resolves, failure rejects.

## References

- WAPI-1520

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (not applicable: no consumer breaking changes)

## Test Plan

- [x] yarn workspace @metamask/connect-multichain test:unit
- [x] yarn workspace @metamask/connect-multichain build
- [x] yarn workspace @metamask/connect-evm test:unit
- [x] yarn workspace @metamask/connect-evm build
- [x] yarn workspace @metamask/connect-multichain changelog:validate
- [x] yarn workspace @metamask/connect-evm changelog:validate