### PR TITLE
fix(connect-multichain): remove session_request listener after #headlessConnect settles

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Failed `createMultichainClient()` singleton initialization now rethrows after clearing the stored singleton promise, preventing the cleanup path from resolving to `undefined` and preserving retry behavior. ([#306](https://github.com/MetaMask/connect-monorepo/pull/306))
 - `MWPTransport.request()` and `sendEip1193Message()` now reject wallet response errors returned as `result.error`, matching `DefaultTransport` error handling and preserving wallet error codes. ([#311](https://github.com/MetaMask/connect-monorepo/pull/311))
+- `MetaMaskConnectMultichain.#headlessConnect()` now removes the `dappClient` `session_request` listener once the connection settles, preventing each headless `connect()` call from leaking a listener that would re-emit `display_uri` with stale deeplinks for every subsequent session request. ([#314](https://github.com/MetaMask/connect-monorepo/pull/314))
 
 ## [0.15.0]
 

--- a/packages/connect-multichain/src/multichain/index.ts
+++ b/packages/connect-multichain/src/multichain/index.ts
@@ -618,21 +618,22 @@ export class MetaMaskConnectMultichain extends MultichainCore {
         });
       }
 
-      // Listen for session_request to generate and emit the QR code link
-      this.dappClient.on(
-        'session_request',
-        (sessionRequest: SessionRequest) => {
-          const connectionRequest: ConnectionRequest = {
-            sessionRequest,
-            metadata: this.#buildConnectionMetadata(),
-          };
+      // Listen for session_request to generate and emit the QR code link.
+      // Captured as a named ref so the listener can be removed when the
+      // connection settles — otherwise each #headlessConnect() call would leak
+      // a listener that re-emits `display_uri` for every future session_request.
+      const onSessionRequest = (sessionRequest: SessionRequest): void => {
+        const connectionRequest: ConnectionRequest = {
+          sessionRequest,
+          metadata: this.#buildConnectionMetadata(),
+        };
 
-          // Generate and emit the QR code link
-          const deeplink =
-            this.options.ui.factory.createConnectionDeeplink(connectionRequest);
-          this.emit('display_uri', deeplink);
-        },
-      );
+        // Generate and emit the QR code link
+        const deeplink =
+          this.options.ui.factory.createConnectionDeeplink(connectionRequest);
+        this.emit('display_uri', deeplink);
+      };
+      this.dappClient.on('session_request', onSessionRequest);
 
       // Start the connection
       this.transport
@@ -657,6 +658,9 @@ export class MetaMaskConnectMultichain extends MultichainCore {
             await this.storage.removeTransportType();
             reject(error instanceof Error ? error : new Error(String(error)));
           }
+        })
+        .finally(() => {
+          this.dappClient.off('session_request', onSessionRequest);
         });
     });
   }

--- a/packages/connect-multichain/tests/fixtures.test.ts
+++ b/packages/connect-multichain/tests/fixtures.test.ts
@@ -14,7 +14,6 @@
 /* eslint-disable @typescript-eslint/prefer-promise-reject-errors -- Test rejection patterns */
 
 /* eslint-disable no-plusplus -- Test loops */
-/* eslint-disable no-invalid-this -- Test context */
 /* eslint-disable no-useless-catch -- Test error handling */
 
 /** biome-ignore-all lint/suspicious/noAsyncPromiseExecutor: ok for tests */


### PR DESCRIPTION
## Explanation

Address review feedback from #305 in a separate PR.

The `session_request` listener registered in `MetaMaskConnectMultichain.#headlessConnect()` is added via `dappClient.on()` but never removed. Each subsequent `connect()` call (e.g. retry, account switch, or scope change) layers on another copy that will re-emit `display_uri` with stale deeplinks for every future `session_request` until the `dappClient` is GC'd.

Capture the handler as a named ref and `.off()` it in a `.finally()` so the listener is torn down on success, error, and timeout.

## References

- Review comment: https://github.com/MetaMask/connect-monorepo/pull/305#discussion_r3322023025

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - No new tests — this is a leak fix; existing tests still pass.
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
  - Will add changelog entry once PR number is known.
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


Made with [Cursor](https://cursor.com)