### PR TITLE
chore: improve package documentation and add architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are two ways to integrate, depending on how much you want to adopt:
 
 ### Option A: Ecosystem-Specific Clients (drop-in)
 
-Use `[@metamask/connect-evm](packages/connect-evm)` and/or `[@metamask/connect-solana](packages/connect-solana)` for a familiar developer experience with minimal changes to your existing code.
+Use [`@metamask/connect-evm`](packages/connect-evm) and/or [`@metamask/connect-solana`](packages/connect-solana) for a familiar developer experience with minimal changes to your existing code.
 
 #### EVM
 
@@ -93,7 +93,7 @@ If your dApp supports EVM and Solana, you can use both clients. They share the s
 
 ### Option B: Multichain Client (full API)
 
-Use `[@metamask/connect-multichain](packages/connect-multichain)` directly for the full Multichain API experience. This is more powerful but requires adapting your dApp to work with scopes and `wallet_invokeMethod` rather than traditional per-chain RPC.
+Use [`@metamask/connect-multichain`](packages/connect-multichain) directly for the full Multichain API experience. This is more powerful but requires adapting your dApp to work with scopes and `wallet_invokeMethod` rather than traditional per-chain RPC.
 
 ```typescript
 import { createMultichainClient } from '@metamask/connect-multichain';
@@ -149,6 +149,33 @@ You can also **start with Option A and migrate to Option B** incrementally. The 
 4. **E2E encryption** — Relay connections are end-to-end encrypted (ECIES). The relay server never sees message content.
 5. **Session persistence** — Session survives reloads. User doesn't need to re-approve on page refresh.
 
+## Architecture
+
+MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 core that manages
+the session and negotiates transports, the EVM and Solana adapters wrap it for ecosystem-specific
+APIs, and `@metamask/connect` re-exports the core (default) and the EVM adapter (`/evm`). At
+connect time the core detects the platform and selects a transport — direct messaging to the
+extension, or the Mobile Wallet Protocol relay for QR/deeplink connections to MetaMask Mobile:
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
+graph TD;
+  start(["createMultichainClient()"]) --> detect{"Platform detection +<br/>EIP-6963 extension presence"};
+  detect -->|"in-app webview, OR<br/>desktop web + extension + preferExtension"| direct["DefaultTransport<br/>window.postMessage"];
+  detect -->|"otherwise (no extension,<br/>mobile, node)"| mwp["MWPTransport<br/>DappClient"];
+  direct --> ext["MetaMask Extension"];
+  mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
+  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io"];
+  ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
+  relay <-->|"E2E encrypted (ECIES)"| mobile;
+  direct --> wrapper["MultichainApiClientWrapperTransport"];
+  mwp --> wrapper;
+  wrapper --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+```
+
+See [`docs/architecture.md`](./docs/architecture.md) for the full package topology and a
+detailed walk-through of transport selection, session persistence, and headless mode.
+
 ## Getting Started
 
 ```bash
@@ -197,22 +224,40 @@ See [`playground/browser-playground/public/index.html`](./playground/browser-pla
 
 ## Packages
 
-| Package                                                       | npm                                                               | Description                                                           |
-| ------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `[@metamask/connect-multichain](packages/connect-multichain)` | [npm](https://www.npmjs.com/package/@metamask/connect-multichain) | Core — CAIP Multichain API, session management, transport negotiation |
-| `[@metamask/connect-evm](packages/connect-evm)`               | [npm](https://www.npmjs.com/package/@metamask/connect-evm)        | EVM adapter — EIP-1193 provider wrapping the multichain core          |
-| `[@metamask/connect-solana](packages/connect-solana)`         | [npm](https://www.npmjs.com/package/@metamask/connect-solana)     | Solana adapter — Wallet Standard integration via the multichain core  |
-| `[@metamask/multichain-ui](packages/multichain-ui)`           | [npm](https://www.npmjs.com/package/@metamask/multichain-ui)      | Connection UI — install modals, OTP modals, QR codes                  |
-| `[@metamask/analytics](packages/analytics)`                   | [npm](https://www.npmjs.com/package/@metamask/analytics)          | Telemetry — batched event tracking for the connection lifecycle       |
+The published libraries under `packages/`. This table is generated from the workspace
+metadata — run `yarn update-readme-content` to regenerate it.
+
+<!-- start package list -->
+
+| Package                                                       | npm                                                               | Description                                                                                                    |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [`@metamask/analytics`](packages/analytics)                   | [npm](https://www.npmjs.com/package/@metamask/analytics)          | MetaMask Connect telemetry — batched connection-lifecycle events                                               |
+| [`@metamask/connect`](packages/connect)                       | [npm](https://www.npmjs.com/package/@metamask/connect)            | Unified entry point for MetaMask Connect — re-exports the multichain core (default) and the EVM adapter (/evm) |
+| [`@metamask/connect-evm`](packages/connect-evm)               | [npm](https://www.npmjs.com/package/@metamask/connect-evm)        | MetaMask Connect EVM adapter — EIP-1193 provider over the multichain core                                      |
+| [`@metamask/connect-multichain`](packages/connect-multichain) | [npm](https://www.npmjs.com/package/@metamask/connect-multichain) | MetaMask Connect core — CAIP multichain API, session management, and transport negotiation                     |
+| [`@metamask/connect-solana`](packages/connect-solana)         | [npm](https://www.npmjs.com/package/@metamask/connect-solana)     | MetaMask Connect Solana adapter — Wallet Standard integration over the multichain core                         |
+| [`@metamask/multichain-ui`](packages/multichain-ui)           | [npm](https://www.npmjs.com/package/@metamask/multichain-ui)      | MetaMask Connect UI — install modal, OTP modal, and QR codes                                                   |
+
+<!-- end package list -->
 
 ### Playgrounds
 
+Local test apps (not published). Maintained by hand.
+
 | Package                                                                   | Description                                                         |
 | ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `[@metamask/browser-playground](playground/browser-playground)`           | Browser test dApp — React app for multichain, legacy EVM, and wagmi |
-| `[@metamask/node-playground](playground/node-playground)`                 | Node.js CLI playground — Inquirer-based with terminal QR codes      |
-| `[@metamask/playground-ui](playground/playground-ui)`                     | Shared playground logic — constants, helpers, and types             |
-| `[@metamask/react-native-playground](playground/react-native-playground)` | React Native test dApp — Expo app for mobile testing                |
+| [`@metamask/browser-playground`](playground/browser-playground)           | Browser test dApp — React app for multichain, legacy EVM, and wagmi |
+| [`@metamask/node-playground`](playground/node-playground)                 | Node.js CLI playground — Inquirer-based with terminal QR codes      |
+| [`@metamask/playground-ui`](playground/playground-ui)                     | Shared playground logic — constants, helpers, and types             |
+| [`@metamask/react-native-playground`](playground/react-native-playground) | React Native test dApp — Expo app for mobile testing                |
+
+### Dependency graph
+
+Generated from the published-package workspace dependencies (run
+`yarn update-readme-content` to regenerate). For the full topology including the
+playgrounds and transports, see [`docs/architecture.md`](./docs/architecture.md).
+
+<!-- start dependency graph -->
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
@@ -224,10 +269,6 @@ linkStyle default opacity:0.5
   connect_multichain(["@metamask/connect-multichain"]);
   connect_solana(["@metamask/connect-solana"]);
   multichain_ui(["@metamask/multichain-ui"]);
-  browser_playground(["@metamask/browser-playground"]);
-  node_playground(["@metamask/node-playground"]);
-  playground_ui(["@metamask/playground-ui"]);
-  react_native_playground(["@metamask/react-native-playground"]);
   connect --> connect_evm;
   connect --> connect_multichain;
   connect_evm --> analytics;
@@ -235,18 +276,9 @@ linkStyle default opacity:0.5
   connect_multichain --> analytics;
   connect_multichain --> multichain_ui;
   connect_solana --> connect_multichain;
-  browser_playground --> connect_evm;
-  browser_playground --> connect_multichain;
-  browser_playground --> playground_ui;
-  node_playground --> connect_evm;
-  node_playground --> connect_multichain;
-  node_playground --> connect_solana;
-  react_native_playground --> connect_evm;
-  react_native_playground --> connect_multichain;
-  react_native_playground --> playground_ui;
 ```
 
-(This section may be regenerated at any time by running `yarn update-readme-content`.)
+<!-- end dependency graph -->
 
 ## Security Audits
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ You can also **start with Option A and migrate to Option B** incrementally. The 
 
 ## Architecture
 
-MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 client that manages
-the session and negotiates transports, the EVM and Solana adapters wrap it for ecosystem-specific
-APIs, and `@metamask/connect` re-exports the client (default) and the EVM adapter (`/evm`). At
-connect time the client detects the platform and selects a transport — direct messaging to the
-extension, or the Mobile Wallet Protocol relay for QR/deeplink connections to MetaMask Mobile:
+MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 client that
+manages the session and negotiates transports, and the EVM and Solana adapters wrap it for
+ecosystem-specific APIs. At connect time the client detects the platform and selects a
+transport — direct messaging to the extension, or the Mobile Wallet Protocol relay for
+QR/deeplink connections to MetaMask Mobile:
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%

--- a/README.md
+++ b/README.md
@@ -168,9 +168,8 @@ graph TD;
   mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket"];
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
-  direct --> wrapper["MultichainApiClientWrapperTransport"];
-  mwp --> wrapper;
-  wrapper --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+  direct --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+  mwp --> session;
 ```
 
 See [`docs/architecture.md`](./docs/architecture.md) for the full package topology and a

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ You can also **start with Option A and migrate to Option B** incrementally. The 
 
 ## Architecture
 
-MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 core that manages
+MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 client that manages
 the session and negotiates transports, the EVM and Solana adapters wrap it for ecosystem-specific
-APIs, and `@metamask/connect` re-exports the core (default) and the EVM adapter (`/evm`). At
-connect time the core detects the platform and selects a transport — direct messaging to the
+APIs, and `@metamask/connect` re-exports the client (default) and the EVM adapter (`/evm`). At
+connect time the client detects the platform and selects a transport — direct messaging to the
 extension, or the Mobile Wallet Protocol relay for QR/deeplink connections to MetaMask Mobile:
 
 ```mermaid
@@ -165,7 +165,7 @@ graph TD;
   detect -->|"otherwise (no extension,<br/>mobile, node)"| mwp["MWPTransport<br/>DappClient"];
   direct --> ext["MetaMask Extension"];
   mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
-  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io"];
+  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket"];
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
   direct --> wrapper["MultichainApiClientWrapperTransport"];
@@ -229,14 +229,14 @@ metadata — run `yarn update-readme-content` to regenerate it.
 
 <!-- start package list -->
 
-| Package                                                       | npm                                                               | Description                                                                                                    |
-| ------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [`@metamask/analytics`](packages/analytics)                   | [npm](https://www.npmjs.com/package/@metamask/analytics)          | MetaMask Connect telemetry — batched connection-lifecycle events                                               |
-| [`@metamask/connect`](packages/connect)                       | [npm](https://www.npmjs.com/package/@metamask/connect)            | Unified entry point for MetaMask Connect — re-exports the multichain core (default) and the EVM adapter (/evm) |
-| [`@metamask/connect-evm`](packages/connect-evm)               | [npm](https://www.npmjs.com/package/@metamask/connect-evm)        | MetaMask Connect EVM adapter — EIP-1193 provider over the multichain core                                      |
-| [`@metamask/connect-multichain`](packages/connect-multichain) | [npm](https://www.npmjs.com/package/@metamask/connect-multichain) | MetaMask Connect core — CAIP multichain API, session management, and transport negotiation                     |
-| [`@metamask/connect-solana`](packages/connect-solana)         | [npm](https://www.npmjs.com/package/@metamask/connect-solana)     | MetaMask Connect Solana adapter — Wallet Standard integration over the multichain core                         |
-| [`@metamask/multichain-ui`](packages/multichain-ui)           | [npm](https://www.npmjs.com/package/@metamask/multichain-ui)      | MetaMask Connect UI — install modal, OTP modal, and QR codes                                                   |
+| Package                                                       | npm                                                               | Description                                                                                                      |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`@metamask/analytics`](packages/analytics)                   | [npm](https://www.npmjs.com/package/@metamask/analytics)          | MetaMask Connect telemetry — batched connection-lifecycle events                                                 |
+| [`@metamask/connect`](packages/connect)                       | [npm](https://www.npmjs.com/package/@metamask/connect)            | Unified entry point for MetaMask Connect — re-exports the multichain client (default) and the EVM adapter (/evm) |
+| [`@metamask/connect-evm`](packages/connect-evm)               | [npm](https://www.npmjs.com/package/@metamask/connect-evm)        | MetaMask Connect EVM adapter — EIP-1193 provider over the multichain client                                      |
+| [`@metamask/connect-multichain`](packages/connect-multichain) | [npm](https://www.npmjs.com/package/@metamask/connect-multichain) | MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation          |
+| [`@metamask/connect-solana`](packages/connect-solana)         | [npm](https://www.npmjs.com/package/@metamask/connect-solana)     | MetaMask Connect Solana adapter — Wallet Standard integration over the multichain client                         |
+| [`@metamask/multichain-ui`](packages/multichain-ui)           | [npm](https://www.npmjs.com/package/@metamask/multichain-ui)      | MetaMask Connect UI — install modal, OTP modal, and QR codes                                                     |
 
 <!-- end package list -->
 

--- a/README.md
+++ b/README.md
@@ -155,25 +155,11 @@ MetaMask Connect is layered: `@metamask/connect-multichain` is the CAIP-25 clien
 manages the session and negotiates transports, and the EVM and Solana adapters wrap it for
 ecosystem-specific APIs. At connect time the client detects the platform and selects a
 transport — direct messaging to the extension, or the Mobile Wallet Protocol relay for
-QR/deeplink connections to MetaMask Mobile:
+QR/deeplink connections to MetaMask Mobile.
 
-```mermaid
-%%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
-graph TD;
-  start(["createMultichainClient()"]) --> detect{"Platform detection +<br/>EIP-6963 extension presence"};
-  detect -->|"in-app webview, OR<br/>desktop web + extension + preferExtension"| direct["DefaultTransport<br/>window.postMessage"];
-  detect -->|"otherwise (no extension,<br/>mobile, node)"| mwp["MWPTransport<br/>DappClient"];
-  direct --> ext["MetaMask Extension"];
-  mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
-  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket"];
-  ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
-  relay <-->|"E2E encrypted (ECIES)"| mobile;
-  direct --> session["CAIP-25 session<br/>wallet_invokeMethod"];
-  mwp --> session;
-```
-
-See [`docs/architecture.md`](./docs/architecture.md) for the full package topology and a
-detailed walk-through of transport selection, session persistence, and headless mode.
+See [`docs/architecture.md`](./docs/architecture.md) for the package topology and transport
+diagrams, plus a detailed walk-through of transport selection, session persistence, and
+headless mode.
 
 ## Getting Started
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,15 @@
 # Architecture
 
-This document describes how the packages in `connect-monorepo` fit together and how
-`@metamask/connect` composes its sub-packages and transports. For per-package API details,
-see each package's own README.
+This document describes how the packages in `connect-monorepo` fit together — how the
+multichain client, the ecosystem adapters, and the transports compose. For per-package API
+details, see each package's own README.
 
 ## Package topology
 
 MetaMask Connect is layered. `@metamask/connect-multichain` is the client: it speaks the
 CAIP-25 Multichain API, manages the session, and negotiates transports. The ecosystem
 adapters (`connect-evm`, `connect-solana`) wrap the client to expose familiar,
-ecosystem-specific surfaces (EIP-1193 and Wallet Standard). `@metamask/connect` is a thin
-unified entry point that re-exports the client (default) and the EVM adapter (`/evm`).
+ecosystem-specific surfaces (EIP-1193 and Wallet Standard).
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,10 @@ graph TD;
   ext --> session["CAIP-25 session<br/>wallet_invokeMethod"];
   mobile --> session;
 
-  store[("StoreAdapter<br/>web / RN / node")] -.->|"restores transport type on reload"| start;
-  session -.->|"persists transport type (+ MWP session)"| store;
+  store[("StoreAdapter / KV store<br/>web / RN / node")];
+  session -.->|"persists transport type"| store;
+  mwp -.->|"persists MWP pairing session<br/>(relay channel + ECIES keypair)"| store;
+  store -.->|"restores transport type +<br/>MWP session on reload"| start;
 ```
 
 Notes:
@@ -100,11 +102,13 @@ Notes:
   `index.native.ts`, `index.node.ts` — that differ only in their UI modals
   (`web` / `rn` / `node`) and storage adapter (`localStorage` / AsyncStorage / filesystem).
 - **Resumption.** The selected transport *type* is persisted via the platform
-  `StoreAdapter`. The MWP session is persisted separately by the Mobile Wallet Protocol
-  `SessionStore` (through the same adapter); on the extension path the session lives in the
-  wallet and is re-fetched via `wallet_getSession`. On load the client restores the stored
-  transport type (and, for the extension path, re-verifies extension presence) before
-  resuming, so a connection survives page reloads without re-prompting.
+  `StoreAdapter`. For MWP, the pairing session — the relay channel and the dapp's ECIES
+  keypair — is persisted in the same KV store by the Mobile Wallet Protocol `SessionStore`,
+  so the encrypted channel resumes across reloads without re-scanning. The CAIP-25 session
+  itself (scopes + accounts) lives in the wallet and is re-fetched via `wallet_getSession`.
+  On load the client restores the stored transport type (and, for the extension path,
+  re-verifies extension presence) before resuming, so a connection survives page reloads
+  without re-prompting.
 - **Headless mode.** With `ui.headless: true`, the client skips `multichain-ui` and emits
   `display_uri` events so the dapp can render its own QR code.
 - **Telemetry.** Connection events are reported through `@metamask/analytics` with a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,137 @@
+# Architecture
+
+This document describes how the packages in `connect-monorepo` fit together and how
+`@metamask/connect` composes its sub-packages and transports. For per-package API details,
+see each package's own README.
+
+## Package topology
+
+MetaMask Connect is layered. `@metamask/connect-multichain` is the core: it speaks the
+CAIP-25 Multichain API, manages the session, and negotiates transports. The ecosystem
+adapters (`connect-evm`, `connect-solana`) wrap the core to expose familiar,
+ecosystem-specific surfaces (EIP-1193 and Wallet Standard). `@metamask/connect` is a thin
+unified entry point that re-exports the core (default) and the EVM adapter (`/evm`).
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
+graph TD;
+  subgraph Unified["Unified entry point"]
+    connect(["@metamask/connect"]);
+  end
+  subgraph Adapters["Ecosystem adapters"]
+    connect_evm(["@metamask/connect-evm<br/>(EIP-1193)"]);
+    connect_solana(["@metamask/connect-solana<br/>(Wallet Standard)"]);
+  end
+  subgraph Core["Core"]
+    connect_multichain(["@metamask/connect-multichain<br/>(CAIP-25 Multichain API)"]);
+  end
+  subgraph Support["Support packages"]
+    multichain_ui(["@metamask/multichain-ui<br/>(connection UI)"]);
+    analytics(["@metamask/analytics<br/>(telemetry)"]);
+  end
+  subgraph Playgrounds["Playgrounds (private, for testing)"]
+    browser_playground(["@metamask/browser-playground"]);
+    node_playground(["@metamask/node-playground"]);
+    react_native_playground(["@metamask/react-native-playground"]);
+    playground_ui(["@metamask/playground-ui"]);
+  end
+
+  connect -->|default| connect_multichain;
+  connect -->|/evm| connect_evm;
+  connect_evm --> connect_multichain;
+  connect_solana --> connect_multichain;
+  connect_evm --> analytics;
+  connect_multichain --> analytics;
+  connect_multichain --> multichain_ui;
+
+  browser_playground --> connect_evm;
+  browser_playground --> connect_multichain;
+  browser_playground --> playground_ui;
+  node_playground --> connect_evm;
+  node_playground --> connect_multichain;
+  node_playground --> connect_solana;
+  react_native_playground --> connect_evm;
+  react_native_playground --> connect_multichain;
+  react_native_playground --> playground_ui;
+```
+
+> The canonical, auto-generated dependency graph of the **published** packages lives in the
+> [root README](../README.md#packages). This diagram adds the private playgrounds and the
+> conceptual layering for context.
+
+Key points:
+
+- **One session, many ecosystems.** The EVM and Solana adapters both drive the same
+  underlying `MultichainCore` instance, so a dapp using both shares a single CAIP-25
+  session — the user approves once. `createMultichainClient` is a singleton per global
+  context.
+- **Adapters are optional.** A dapp can use `@metamask/connect-multichain` directly for the
+  full scope-based API, or an adapter for a drop-in EIP-1193 / Wallet Standard experience.
+- **Support packages are internal.** `multichain-ui` (connection UI) and `analytics`
+  (telemetry) are pulled in transitively by the core; dapps rarely import them directly.
+
+## Transport selection and composition
+
+When a dapp calls `connect()`, the multichain core detects the platform, picks a transport,
+and routes all RPC through a uniform wrapper. Two concrete transports exist:
+
+- **`DefaultTransport`** — direct messaging to the MetaMask **extension** via
+  `window.postMessage` (the `metamask-contentscript` channel). Used when the extension is
+  present (or inside the MetaMask mobile in-app browser).
+- **`MWPTransport`** — remote connection to **MetaMask Mobile** over the Mobile Wallet
+  Protocol. A `DappClient` connects through the relay
+  (`wss://mm-sdk-relay.api.cx.metamask.io`); the dapp shows a QR code (desktop) or deeplink
+  (mobile web / React Native) via `multichain-ui`, the wallet scans/opens it, and an
+  end-to-end encrypted session is established.
+
+Both are fronted by `MultichainApiClientWrapperTransport`, which exposes the
+`wallet_createSession` / `wallet_getSession` / `wallet_revokeSession` / `wallet_invokeMethod`
+surface to the rest of the SDK.
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
+graph TD;
+  start(["createMultichainClient()"]) --> detect{"Platform detection<br/>isReactNative / isMetaMaskMobileWebView /<br/>isMobile + EIP-6963 extension presence"};
+
+  detect -->|"in-app webview, OR<br/>desktop web + extension + preferExtension"| direct["DefaultTransport<br/>window.postMessage"];
+  detect -->|"otherwise (no extension,<br/>mobile, node)"| mwp["MWPTransport<br/>DappClient"];
+
+  direct --> ext["MetaMask Extension"];
+
+  mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
+  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io"];
+  ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
+  relay <-->|"E2E encrypted (ECIES)"| mobile;
+
+  direct --> wrapper["MultichainApiClientWrapperTransport"];
+  mwp --> wrapper;
+  wrapper --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+
+  store[("StoreAdapter<br/>web / RN / node")] -.->|"persists transport + session"| start;
+  session -.->|"caches session/accounts/chainId"| store;
+```
+
+Notes:
+
+- **Platform entry points.** The core ships three builds — `index.browser.ts`,
+  `index.native.ts`, `index.node.ts` — that differ only in their UI modals
+  (`web` / `rn` / `node`) and storage adapter (`localStorage` / AsyncStorage / filesystem).
+- **Resumption.** The selected transport type and session data are persisted via the
+  platform `StoreAdapter`, so a connection survives page reloads without re-prompting. On
+  load the core checks the stored transport (and, for the extension path, re-verifies
+  extension presence) before resuming.
+- **Headless mode.** With `ui.headless: true`, the core skips `multichain-ui` and emits
+  `display_uri` events so the dapp can render its own QR code.
+- **Telemetry.** Connection events are reported through `@metamask/analytics` with a
+  `transport_type` of `direct` (extension), `websocket`, or `deeplink` — unless
+  `analytics.enabled` is `false`.
+
+## Further reading
+
+- [Root README](../README.md) — integration options, getting started, CSP requirements.
+- [`@metamask/connect-multichain`](../packages/connect-multichain/README.md) — core API and
+  the CAIP standards it implements.
+- [`@metamask/connect-evm`](../packages/connect-evm/README.md) /
+  [`@metamask/connect-solana`](../packages/connect-solana/README.md) — adapter APIs.
+- [`@metamask/multichain-ui`](../packages/multichain-ui/README.md) — connection UI components.
+- [`@metamask/analytics`](../packages/analytics/README.md) — telemetry.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ and routes all RPC through a uniform wrapper. Two concrete transports exist:
   present (or inside the MetaMask mobile in-app browser).
 - **`MWPTransport`** — remote connection to **MetaMask Mobile** over the Mobile Wallet
   Protocol. A `DappClient` connects through the relay
-  (`wss://mm-sdk-relay.api.cx.metamask.io`); the dapp shows a QR code (desktop) or deeplink
+  (`wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket`); the dapp shows a QR code (desktop) or deeplink
   (mobile web / React Native) via `multichain-ui`, the wallet scans/opens it, and an
   end-to-end encrypted session is established.
 
@@ -123,7 +123,7 @@ Notes:
 - **Headless mode.** With `ui.headless: true`, the core skips `multichain-ui` and emits
   `display_uri` events so the dapp can render its own QR code.
 - **Telemetry.** Connection events are reported through `@metamask/analytics` with a
-  `transport_type` of `direct` (extension), `websocket`, or `deeplink` — unless
+  `transport_type` of `browser` (extension), `mwp`, or `unknown` — unless
   `analytics.enabled` is `false`.
 
 ## Further reading

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,25 +63,24 @@ Key points:
 
 - **One session, many ecosystems.** The EVM and Solana adapters both drive the same
   underlying `MultichainCore` instance, so a dapp using both shares a single CAIP-25
-  session — the user approves once. `createMultichainClient` is a singleton per global
-  context.
+  session. `createMultichainClient` is a singleton per global context.
 - **Adapters are optional.** A dapp can use `@metamask/connect-multichain` directly for the
   full scope-based API, or an adapter for a drop-in EIP-1193 / Wallet Standard experience.
 - **Support packages are internal.** `multichain-ui` (connection UI) and `analytics`
-  (telemetry) are pulled in transitively by the client; dapps rarely import them directly.
+  (telemetry) are pulled in transitively through `@metamask/connect-multichain`; dapps
+  aren't intended to import them directly.
 
 ## Transport selection and composition
 
 When a dapp calls `connect()`, the multichain client detects the platform and picks a
 transport. Two concrete transports exist:
 
-- **`DefaultTransport`** — direct messaging to the MetaMask **extension** via
-  `window.postMessage` (the `metamask-contentscript` channel). Used when the extension is
-  present (or inside the MetaMask mobile in-app browser).
+- **`DefaultTransport`** — direct messaging to the MetaMask **extension** and **mobile
+  in-app browser** via `window.postMessage` (the `metamask-contentscript` channel).
 - **`MWPTransport`** — remote connection to **MetaMask Mobile** over the Mobile Wallet
   Protocol. A `DappClient` connects through the relay
   (`wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket`); the dapp shows a QR code (desktop) or deeplink
-  (mobile web / React Native) via `multichain-ui`, the wallet scans/opens it, and an
+  (mobile native web / React Native) via `multichain-ui`, the wallet scans/opens it, and an
   end-to-end encrypted session is established.
 
 Once a transport is connected, the client owns the CAIP-25 session and routes all RPC

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ Notes:
 - **Platform entry points.** The client ships three builds — `index.browser.ts`,
   `index.native.ts`, `index.node.ts` — that differ only in their UI modals
   (`web` / `rn` / `node`) and storage adapter (`localStorage` / AsyncStorage / filesystem).
-- **Resumption.** The selected transport *type* is persisted via the platform
+- **Resumption.** The selected transport _type_ is persisted via the platform
   `StoreAdapter`. For MWP, the pairing session — the relay channel and the dapp's ECIES
   keypair — is persisted in the same KV store by the Mobile Wallet Protocol `SessionStore`,
   so the encrypted channel resumes across reloads without re-scanning. The CAIP-25 session

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,11 @@ see each package's own README.
 
 ## Package topology
 
-MetaMask Connect is layered. `@metamask/connect-multichain` is the core: it speaks the
+MetaMask Connect is layered. `@metamask/connect-multichain` is the client: it speaks the
 CAIP-25 Multichain API, manages the session, and negotiates transports. The ecosystem
-adapters (`connect-evm`, `connect-solana`) wrap the core to expose familiar,
+adapters (`connect-evm`, `connect-solana`) wrap the client to expose familiar,
 ecosystem-specific surfaces (EIP-1193 and Wallet Standard). `@metamask/connect` is a thin
-unified entry point that re-exports the core (default) and the EVM adapter (`/evm`).
+unified entry point that re-exports the client (default) and the EVM adapter (`/evm`).
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
@@ -22,7 +22,7 @@ graph TD;
     connect_evm(["@metamask/connect-evm<br/>(EIP-1193)"]);
     connect_solana(["@metamask/connect-solana<br/>(Wallet Standard)"]);
   end
-  subgraph Core["Core"]
+  subgraph Core["Client"]
     connect_multichain(["@metamask/connect-multichain<br/>(CAIP-25 Multichain API)"]);
   end
   subgraph Support["Support packages"]
@@ -68,11 +68,11 @@ Key points:
 - **Adapters are optional.** A dapp can use `@metamask/connect-multichain` directly for the
   full scope-based API, or an adapter for a drop-in EIP-1193 / Wallet Standard experience.
 - **Support packages are internal.** `multichain-ui` (connection UI) and `analytics`
-  (telemetry) are pulled in transitively by the core; dapps rarely import them directly.
+  (telemetry) are pulled in transitively by the client; dapps rarely import them directly.
 
 ## Transport selection and composition
 
-When a dapp calls `connect()`, the multichain core detects the platform, picks a transport,
+When a dapp calls `connect()`, the multichain client detects the platform, picks a transport,
 and routes all RPC through a uniform wrapper. Two concrete transports exist:
 
 - **`DefaultTransport`** — direct messaging to the MetaMask **extension** via
@@ -99,7 +99,7 @@ graph TD;
   direct --> ext["MetaMask Extension"];
 
   mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
-  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io"];
+  mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket"];
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
 
@@ -113,14 +113,14 @@ graph TD;
 
 Notes:
 
-- **Platform entry points.** The core ships three builds — `index.browser.ts`,
+- **Platform entry points.** The client ships three builds — `index.browser.ts`,
   `index.native.ts`, `index.node.ts` — that differ only in their UI modals
   (`web` / `rn` / `node`) and storage adapter (`localStorage` / AsyncStorage / filesystem).
 - **Resumption.** The selected transport type and session data are persisted via the
   platform `StoreAdapter`, so a connection survives page reloads without re-prompting. On
-  load the core checks the stored transport (and, for the extension path, re-verifies
+  load the client checks the stored transport (and, for the extension path, re-verifies
   extension presence) before resuming.
-- **Headless mode.** With `ui.headless: true`, the core skips `multichain-ui` and emits
+- **Headless mode.** With `ui.headless: true`, the client skips `multichain-ui` and emits
   `display_uri` events so the dapp can render its own QR code.
 - **Telemetry.** Connection events are reported through `@metamask/analytics` with a
   `transport_type` of `browser` (extension), `mwp`, or `unknown` — unless
@@ -129,7 +129,7 @@ Notes:
 ## Further reading
 
 - [Root README](../README.md) — integration options, getting started, CSP requirements.
-- [`@metamask/connect-multichain`](../packages/connect-multichain/README.md) — core API and
+- [`@metamask/connect-multichain`](../packages/connect-multichain/README.md) — client API and
   the CAIP standards it implements.
 - [`@metamask/connect-evm`](../packages/connect-evm/README.md) /
   [`@metamask/connect-solana`](../packages/connect-solana/README.md) — adapter APIs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ graph TD;
     connect_evm(["@metamask/connect-evm<br/>(EIP-1193)"]);
     connect_solana(["@metamask/connect-solana<br/>(Wallet Standard)"]);
   end
-  subgraph Client["Client"]
+  subgraph Client["Multichain client"]
     connect_multichain(["@metamask/connect-multichain<br/>(CAIP-25 Multichain API)"]);
   end
   subgraph Support["Support packages"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,9 +80,9 @@ graph TD;
   detect -->|"in-app webview, OR<br/>desktop web + extension + preferExtension"| direct["DefaultTransport<br/>window.postMessage"];
   detect -->|"otherwise (no extension,<br/>mobile, node)"| mwp["MWPTransport<br/>DappClient"];
 
-  direct --> ext["MetaMask Extension"];
+  direct --> ext["MetaMask Extension /<br/>Mobile in-app browser"];
 
-  mwp --> ui["multichain-ui<br/>install modal / QR / deeplink"];
+  mwp -.->|"shows QR / deeplink"| ui["multichain-ui<br/>install modal / QR / deeplink"];
   mwp --> relay["Relay<br/>wss://mm-sdk-relay.api.cx.metamask.io/connection/websocket"];
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
@@ -90,8 +90,8 @@ graph TD;
   ext --> session["CAIP-25 session<br/>wallet_invokeMethod"];
   mobile --> session;
 
-  store[("StoreAdapter<br/>web / RN / node")] -.->|"persists transport + session"| start;
-  session -.->|"caches session/accounts/chainId"| store;
+  store[("StoreAdapter<br/>web / RN / node")] -.->|"restores transport type on reload"| start;
+  session -.->|"persists transport type (+ MWP session)"| store;
 ```
 
 Notes:
@@ -99,10 +99,12 @@ Notes:
 - **Platform entry points.** The client ships three builds — `index.browser.ts`,
   `index.native.ts`, `index.node.ts` — that differ only in their UI modals
   (`web` / `rn` / `node`) and storage adapter (`localStorage` / AsyncStorage / filesystem).
-- **Resumption.** The selected transport type and session data are persisted via the
-  platform `StoreAdapter`, so a connection survives page reloads without re-prompting. On
-  load the client checks the stored transport (and, for the extension path, re-verifies
-  extension presence) before resuming.
+- **Resumption.** The selected transport *type* is persisted via the platform
+  `StoreAdapter`. The MWP session is persisted separately by the Mobile Wallet Protocol
+  `SessionStore` (through the same adapter); on the extension path the session lives in the
+  wallet and is re-fetched via `wallet_getSession`. On load the client restores the stored
+  transport type (and, for the extension path, re-verifies extension presence) before
+  resuming, so a connection survives page reloads without re-prompting.
 - **Headless mode.** With `ui.headless: true`, the client skips `multichain-ui` and emits
   `display_uri` events so the dapp can render its own QR code.
 - **Telemetry.** Connection events are reported through `@metamask/analytics` with a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,44 +14,28 @@ ecosystem-specific surfaces (EIP-1193 and Wallet Standard).
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
 graph TD;
-  subgraph Unified["Unified entry point"]
-    connect(["@metamask/connect"]);
-  end
   subgraph Adapters["Ecosystem adapters"]
     connect_evm(["@metamask/connect-evm<br/>(EIP-1193)"]);
     connect_solana(["@metamask/connect-solana<br/>(Wallet Standard)"]);
   end
-  subgraph Core["Client"]
+  subgraph Client["Client"]
     connect_multichain(["@metamask/connect-multichain<br/>(CAIP-25 Multichain API)"]);
   end
   subgraph Support["Support packages"]
     multichain_ui(["@metamask/multichain-ui<br/>(connection UI)"]);
     analytics(["@metamask/analytics<br/>(telemetry)"]);
   end
-  subgraph Playgrounds["Playgrounds (private, for testing)"]
-    browser_playground(["@metamask/browser-playground"]);
-    node_playground(["@metamask/node-playground"]);
-    react_native_playground(["@metamask/react-native-playground"]);
-    playground_ui(["@metamask/playground-ui"]);
-  end
 
-  connect -->|default| connect_multichain;
-  connect -->|/evm| connect_evm;
   connect_evm --> connect_multichain;
   connect_solana --> connect_multichain;
   connect_evm --> analytics;
   connect_multichain --> analytics;
   connect_multichain --> multichain_ui;
 
-  browser_playground --> connect_evm;
-  browser_playground --> connect_multichain;
-  browser_playground --> playground_ui;
-  node_playground --> connect_evm;
-  node_playground --> connect_multichain;
-  node_playground --> connect_solana;
-  react_native_playground --> connect_evm;
-  react_native_playground --> connect_multichain;
-  react_native_playground --> playground_ui;
+  playgrounds(["Playgrounds<br/>(private, for testing)"]);
+  playgrounds -.-> connect_evm;
+  playgrounds -.-> connect_solana;
+  playgrounds -.-> connect_multichain;
 ```
 
 > The canonical, auto-generated dependency graph of the **published** packages lives in the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,8 +72,8 @@ Key points:
 
 ## Transport selection and composition
 
-When a dapp calls `connect()`, the multichain client detects the platform, picks a transport,
-and routes all RPC through a uniform wrapper. Two concrete transports exist:
+When a dapp calls `connect()`, the multichain client detects the platform and picks a
+transport. Two concrete transports exist:
 
 - **`DefaultTransport`** — direct messaging to the MetaMask **extension** via
   `window.postMessage` (the `metamask-contentscript` channel). Used when the extension is
@@ -84,9 +84,11 @@ and routes all RPC through a uniform wrapper. Two concrete transports exist:
   (mobile web / React Native) via `multichain-ui`, the wallet scans/opens it, and an
   end-to-end encrypted session is established.
 
-Both are fronted by `MultichainApiClientWrapperTransport`, which exposes the
-`wallet_createSession` / `wallet_getSession` / `wallet_revokeSession` / `wallet_invokeMethod`
-surface to the rest of the SDK.
+Once a transport is connected, the client owns the CAIP-25 session and routes all RPC
+through `wallet_invokeMethod`. The Multichain API is exposed two equivalent ways: directly
+on the client (`connect` / `disconnect` / `invokeMethod`), and as a standard
+[`@metamask/multichain-api-client`](https://www.npmjs.com/package/@metamask/multichain-api-client)
+provider at `client.provider` (wired to the client by an internal adapter).
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
@@ -103,9 +105,8 @@ graph TD;
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
 
-  direct --> wrapper["MultichainApiClientWrapperTransport"];
-  mwp --> wrapper;
-  wrapper --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+  direct --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+  mwp --> session;
 
   store[("StoreAdapter<br/>web / RN / node")] -.->|"persists transport + session"| start;
   session -.->|"caches session/accounts/chainId"| store;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,8 +87,8 @@ graph TD;
   ui -.->|"QR scan / deeplink open"| mobile["MetaMask Mobile"];
   relay <-->|"E2E encrypted (ECIES)"| mobile;
 
-  direct --> session["CAIP-25 session<br/>wallet_invokeMethod"];
-  mwp --> session;
+  ext --> session["CAIP-25 session<br/>wallet_invokeMethod"];
+  mobile --> session;
 
   store[("StoreAdapter<br/>web / RN / node")] -.->|"persists transport + session"| start;
   session -.->|"caches session/accounts/chainId"| store;

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,15 +1,127 @@
 # `@metamask/analytics`
 
-analytics
+> Internal telemetry for the MetaMask Connect SDK.
+
+This package collects anonymous, aggregate telemetry about the connection lifecycle
+(initialization, connection attempts, RPC actions) so the MetaMask team can monitor SDK
+health and reliability. It is a **dependency of the connect packages**, not a
+general-purpose analytics library — dapps do not normally install or import it directly.
+It is consumed internally by [`@metamask/connect-multichain`](../connect-multichain) and
+the [`@metamask/connect-evm`](../connect-evm) / [`@metamask/connect-solana`](../connect-solana)
+adapters.
+
+Telemetry is controlled by the `analytics.enabled` option on the connect clients
+(defaults to `true`). Set `analytics.enabled: false` to disable all events and the
+wallet-correlation metadata they carry.
 
 ## Installation
 
-`yarn add @metamask/analytics`
+```bash
+yarn add @metamask/analytics
+```
 
 or
 
-`npm install @metamask/analytics`
+```bash
+npm install @metamask/analytics
+```
+
+## How it works
+
+The package exports a single shared `analytics` instance. Events are queued in memory and
+flushed in batches to the MetaMask analytics endpoint, with exponential backoff on failure.
+Nothing is sent until analytics are explicitly enabled.
+
+```typescript
+import { analytics } from '@metamask/analytics';
+
+// Telemetry is a no-op until enabled (the connect clients call this for you
+// when `analytics.enabled` is true).
+analytics.enable();
+
+// Properties merged into every subsequent event.
+analytics.setGlobalProperty('anon_id', anonId);
+analytics.setGlobalProperty('integration_types', ['wagmi']);
+
+analytics.track('sdk_initialized', { platform: 'web-desktop' });
+```
+
+### Endpoint
+
+The default endpoint is `https://mm-sdk-analytics.api.cx.metamask.io/`. It can be overridden
+at build time via the `METAMASK_ANALYTICS_ENDPOINT` or `NEXT_PUBLIC_METAMASK_ANALYTICS_ENDPOINT`
+environment variables (resolved when the module is first loaded).
+
+### Batching
+
+Events are batched by an internal `Sender` (batch size `100`, base flush window `200ms`).
+On a failed `POST /v2/events`, the failed batch is re-queued and the flush interval backs
+off exponentially up to `30s`, resetting on the next success.
+
+## API
+
+The default export is the singleton `analytics` (an instance of the internal `Analytics`
+class).
+
+### `analytics.enable()`
+
+Enables telemetry. Until this is called, `track()` is a no-op.
+
+### `analytics.disable()`
+
+Disables telemetry and **drops any queued events** (cancels the pending flush).
+
+### `analytics.setGlobalProperty(key, value)`
+
+Sets a property that is merged into every event emitted afterwards.
+
+`integration_types` is special-cased: values are merged and de-duplicated across calls
+rather than overwritten, so multiple integrations (for example `wagmi` plus a manual
+integration) accumulate.
+
+### `analytics.track(eventName, properties)`
+
+Queues an event for sending. No-op while disabled. Each event is wrapped with the
+`metamask/connect` namespace and the accumulated global properties before being enqueued.
+
+## Events
+
+`track()` accepts one of the following event names (see `src/schema.ts` for the full
+payload shape of each):
+
+| Group      | Events                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| Lifecycle  | `sdk_initialized`, `sdk_used_chain`                                                                          |
+| Connection | `sdk_connection_initiated`, `sdk_connection_established`, `sdk_connection_rejected`, `sdk_connection_failed` |
+| Wallet     | `wallet_connection_request_received`, `wallet_connection_user_approved`, `wallet_connection_user_rejected`   |
+| Actions    | `sdk_action_requested`, `sdk_action_succeeded`, `sdk_action_failed`, `sdk_action_rejected`                   |
+| Wallet     | `wallet_action_received`, `wallet_action_user_approved`, `wallet_action_user_rejected`                       |
+
+Connection events carry a `transport_type` of `direct` (extension), `websocket`, or
+`deeplink`, reflecting the transport selected by the multichain core.
+
+## Content Security Policy
+
+When analytics are enabled, the host page must allow the analytics endpoint:
+
+```
+connect-src https://mm-sdk-analytics.api.cx.metamask.io;
+```
+
+This is unnecessary when consumers set `analytics.enabled: false`. See the
+[monorepo README](https://github.com/MetaMask/connect-monorepo#readme) for the full CSP
+guidance.
+
+## TypeScript
+
+This package is written in TypeScript and includes full type definitions. No additional
+`@types` package is required.
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme).
+This package is part of a monorepo. Instructions for contributing can be found in the
+[monorepo README](https://github.com/MetaMask/connect-monorepo#readme).
+
+## License
+
+MIT

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -42,8 +42,6 @@ analytics.enable();
 // Properties merged into every subsequent event.
 analytics.setGlobalProperty('anon_id', anonId);
 analytics.setGlobalProperty('integration_types', ['wagmi']);
-
-analytics.track('sdk_initialized', { platform: 'web-desktop' });
 ```
 
 ### Endpoint
@@ -60,7 +58,7 @@ off exponentially up to `30s`, resetting on the next success.
 
 ## API
 
-The default export is the singleton `analytics` (an instance of the internal `Analytics`
+The package exports a singleton `analytics` (an instance of the internal `Analytics`
 class).
 
 ### `analytics.enable()`
@@ -89,16 +87,13 @@ Queues an event for sending. No-op while disabled. Each event is wrapped with th
 `track()` accepts one of the following event names (see `src/schema.ts` for the full
 payload shape of each):
 
-| Group      | Events                                                                                                       |
-| ---------- | ------------------------------------------------------------------------------------------------------------ |
-| Lifecycle  | `sdk_initialized`, `sdk_used_chain`                                                                          |
-| Connection | `sdk_connection_initiated`, `sdk_connection_established`, `sdk_connection_rejected`, `sdk_connection_failed` |
-| Wallet     | `wallet_connection_request_received`, `wallet_connection_user_approved`, `wallet_connection_user_rejected`   |
-| Actions    | `sdk_action_requested`, `sdk_action_succeeded`, `sdk_action_failed`, `sdk_action_rejected`                   |
-| Wallet     | `wallet_action_received`, `wallet_action_user_approved`, `wallet_action_user_rejected`                       |
+| Group      | Events                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Connection | `mmconnect_connection_initiated`, `mmconnect_connection_established`, `mmconnect_connection_rejected`, `mmconnect_connection_failed`           |
+| Action     | `mmconnect_wallet_action_requested`, `mmconnect_wallet_action_succeeded`, `mmconnect_wallet_action_failed`, `mmconnect_wallet_action_rejected` |
 
-Connection events carry a `transport_type` of `direct` (extension), `websocket`, or
-`deeplink`, reflecting the transport selected by the multichain core.
+Connection events carry a `transport_type` of `browser` (extension), `mwp`, or
+`unknown`, reflecting the transport selected by the multichain core.
 
 ## Content Security Policy
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -93,7 +93,7 @@ payload shape of each):
 | Action     | `mmconnect_wallet_action_requested`, `mmconnect_wallet_action_succeeded`, `mmconnect_wallet_action_failed`, `mmconnect_wallet_action_rejected` |
 
 Connection events carry a `transport_type` of `browser` (extension), `mwp`, or
-`unknown`, reflecting the transport selected by the multichain core.
+`unknown`, reflecting the transport selected by the multichain client.
 
 ## Content Security Policy
 

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/analytics",
   "version": "0.6.0",
-  "description": "Analytics package for MetaMask Connect",
+  "description": "MetaMask Connect telemetry — batched connection-lifecycle events",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-evm",
   "version": "1.4.0",
-  "description": "EVM Layer for MetaMask Connect",
+  "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain core",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-evm",
   "version": "1.4.0",
-  "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain core",
+  "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain client",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-multichain",
   "version": "0.15.0",
-  "description": "Multichain package for MetaMask Connect",
+  "description": "MetaMask Connect core — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-multichain",
   "version": "0.15.0",
-  "description": "MetaMask Connect core — CAIP multichain API, session management, and transport negotiation",
+  "description": "MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-solana",
   "version": "1.2.0",
-  "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain core",
+  "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain client",
   "keywords": [
     "MetaMask",
     "Solana"

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect-solana",
   "version": "1.2.0",
-  "description": "Solana Layer for MetaMask Connect",
+  "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain core",
   "keywords": [
     "MetaMask",
     "Solana"

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -134,10 +134,10 @@ See [@metamask/connect-multichain](../connect-multichain/README.md) for detailed
 
 ## When to Use Which
 
-| Use Case                                           | Import Path                    |
-| -------------------------------------------------- | ------------------------------ |
-| Ethereum/EVM dApps with standard EIP-1193 provider | `@metamask/connect/evm`        |
-| Multi-chain dApps (Ethereum + Solana, etc.)        | `@metamask/connect`            |
+| Use Case                                           | Import Path             |
+| -------------------------------------------------- | ----------------------- |
+| Ethereum/EVM dApps with standard EIP-1193 provider | `@metamask/connect/evm` |
+| Multi-chain dApps (Ethereum + Solana, etc.)        | `@metamask/connect`     |
 
 ## Contributing
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -61,8 +61,11 @@ const balance = await provider.request({
 
 ### Multichain Connections
 
+Multichain functionality is the package's default export, so import it directly from
+`@metamask/connect`:
+
 ```typescript
-import { createMultichainClient } from '@metamask/connect/multichain';
+import { createMultichainClient } from '@metamask/connect';
 
 const client = await createMultichainClient({
   dapp: {
@@ -122,17 +125,19 @@ See [@metamask/connect-multichain](../connect-multichain/README.md) for detailed
 ## Package Structure
 
 ```
-@metamask/connect
-├── /           → Re-exports from @metamask/connect-multichain
-└── /evm        → Re-exports from @metamask/connect-evm
+@metamask/connect          → Re-exports from @metamask/connect-multichain (default export)
+@metamask/connect/evm      → Re-exports from @metamask/connect-evm
 ```
+
+> These are the only two entry points. There is no `@metamask/connect/multichain` subpath —
+> the multichain API is the default export at `@metamask/connect`.
 
 ## When to Use Which
 
 | Use Case                                           | Import Path                    |
 | -------------------------------------------------- | ------------------------------ |
 | Ethereum/EVM dApps with standard EIP-1193 provider | `@metamask/connect/evm`        |
-| Multi-chain dApps (Ethereum + Solana, etc.)        | `@metamask/connect/multichain` |
+| Multi-chain dApps (Ethereum + Solana, etc.)        | `@metamask/connect`            |
 
 ## Contributing
 

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect",
   "version": "0.2.0",
-  "description": "Easily connect to MetaMask and its ecosystem from any application and platform",
+  "description": "Unified entry point for MetaMask Connect — re-exports the multichain core (default) and the EVM adapter (/evm)",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/connect",
   "version": "0.2.0",
-  "description": "Unified entry point for MetaMask Connect — re-exports the multichain core (default) and the EVM adapter (/evm)",
+  "description": "Unified entry point for MetaMask Connect — re-exports the multichain client (default) and the EVM adapter (/evm)",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/packages/multichain-ui/README.md
+++ b/packages/multichain-ui/README.md
@@ -1,25 +1,101 @@
 # `@metamask/multichain-ui`
 
-Install modal web package for multichain, renders and uses the new mobile wallet protocol ConnectionRequest QRCodes.
+> Connection UI for the MetaMask Connect SDK — install prompt, QR code, and OTP modals.
 
-This package includes the fully functional InstallModal web used in the Multichain SDK for Trusted flows.
+This package provides the web UI shown during a remote (mobile) connection: the install
+modal with the Mobile Wallet Protocol connection QR code / deeplink, and the OTP modal. It
+is built with [Stencil](https://stenciljs.com/) and ships the UI as framework-agnostic
+**custom elements** (Web Components).
 
-Untrusted flows use the OTPModal which exists but is not yet fully supported.
+It is consumed internally by [`@metamask/connect-multichain`](../connect-multichain), which
+mounts and drives these elements through its `ModalFactory`. Most dapps never import this
+package directly — it is pulled in transitively by the connect packages. Import it yourself
+only if you are building a custom UI host or registering the elements manually.
 
-## Development
+## Components
+
+| Custom element        | Purpose                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `<mm-install-modal>`  | Prompts the user to install/open MetaMask and renders the connection QR code / deeplink for mobile flows |
+| `<mm-otp-modal>`      | Renders the one-time-passcode entry flow used during connection                                          |
+
+`<mm-install-modal>` props: `link` (deeplink/QR payload), `expiresIn`, `showInstallModal`.
+It emits `close`, `startDesktopOnboarding`, `updateLink`, and `updateExpiresIn` events.
+`<mm-otp-modal>` props: `otpCode`, `displayOTP`; it emits `close`, `disconnect`, and
+`updateOTPCode`.
+
+## Installation
 
 ```bash
-yarn dev
+yarn add @metamask/multichain-ui
 ```
 
 or
 
 ```bash
-yarn start
+npm install @metamask/multichain-ui
 ```
 
-## Building locally
+## Usage
+
+Because the UI ships as Stencil custom elements, the package's main entry point
+(`@metamask/multichain-ui`) exposes **types only** — the `Components`, `JSX`,
+`MmInstallModalCustomEvent`, and `MmOtpModalCustomEvent` typings for typed usage in your
+own components. The components themselves are consumed as custom elements.
+
+Register the elements with the Stencil lazy-loader from the `./loader` entry, then use the
+tags like any other element:
+
+```typescript
+import { defineCustomElements } from '@metamask/multichain-ui/loader';
+
+// Registers <mm-install-modal> and <mm-otp-modal> with the browser.
+defineCustomElements(window);
+```
+
+```html
+<mm-install-modal show-install-modal="true"></mm-install-modal>
+```
+
+For typed event handling in TypeScript:
+
+```typescript
+import type { MmInstallModalCustomEvent } from '@metamask/multichain-ui';
+
+el.addEventListener('close', (event: MmInstallModalCustomEvent<{ shouldTerminate?: boolean }>) => {
+  // ...
+});
+```
+
+## Development
 
 ```bash
+# Dev server with live reload
+yarn dev
+
+# Production build (Stencil dist + www output targets)
 yarn build
 ```
+
+The Stencil namespace is `sdk-install-modal-web`. Components render inside Shadow DOM with
+styles injected at runtime.
+
+## Content Security Policy
+
+Host pages that render these modals may need to relax their
+[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP):
+
+- `style-src 'unsafe-inline'` — Stencil injects component styles at runtime inside Shadow DOM.
+- `img-src data:` — the MetaMask fox is embedded as a `data:` URI inside the generated QR code.
+
+See the [monorepo README](https://github.com/MetaMask/connect-monorepo#readme) for the full
+CSP guidance.
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the
+[monorepo README](https://github.com/MetaMask/connect-monorepo#readme).
+
+## License
+
+MIT

--- a/packages/multichain-ui/README.md
+++ b/packages/multichain-ui/README.md
@@ -62,9 +62,12 @@ For typed event handling in TypeScript:
 ```typescript
 import type { MmInstallModalCustomEvent } from '@metamask/multichain-ui';
 
-el.addEventListener('close', (event: MmInstallModalCustomEvent<{ shouldTerminate?: boolean }>) => {
-  // ...
-});
+el.addEventListener(
+  'close',
+  (event: MmInstallModalCustomEvent<{ shouldTerminate?: boolean }>) => {
+    // ...
+  },
+);
 ```
 
 ## Development

--- a/packages/multichain-ui/README.md
+++ b/packages/multichain-ui/README.md
@@ -14,10 +14,10 @@ only if you are building a custom UI host or registering the elements manually.
 
 ## Components
 
-| Custom element        | Purpose                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------------------- |
-| `<mm-install-modal>`  | Prompts the user to install/open MetaMask and renders the connection QR code / deeplink for mobile flows |
-| `<mm-otp-modal>`      | Renders the one-time-passcode entry flow used during connection                                          |
+| Custom element       | Purpose                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `<mm-install-modal>` | Prompts the user to install/open MetaMask and renders the connection QR code / deeplink for mobile flows |
+| `<mm-otp-modal>`     | Renders the one-time-passcode entry flow used during connection                                          |
 
 `<mm-install-modal>` props: `link` (deeplink/QR payload), `expiresIn`, `showInstallModal`.
 It emits `close`, `startDesktopOnboarding`, `updateLink`, and `updateExpiresIn` events.

--- a/packages/multichain-ui/package.json
+++ b/packages/multichain-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/multichain-ui",
   "version": "0.4.1",
-  "description": "MetaMask Connect Install Modal for Web",
+  "description": "MetaMask Connect UI — install modal, OTP modal, and QR codes",
   "keywords": [
     "MetaMask",
     "Ethereum"

--- a/scripts/update-readme-content.ts
+++ b/scripts/update-readme-content.ts
@@ -8,6 +8,7 @@ type Workspace = {
   location: string;
   name: string;
   workspaceDependencies: string[];
+  description: string;
 };
 
 const DEPENDENCY_GRAPH_START_MARKER = '<!-- start dependency graph -->';
@@ -33,9 +34,15 @@ main().catch((error) => {
  */
 async function main(): Promise<void> {
   const workspaces = await retrieveWorkspaces();
+  // Only the published libraries under `packages/` drive the auto-generated
+  // sections. Playgrounds and other non-private workspaces are documented by
+  // hand in the README (Playgrounds table) and in docs/architecture.md.
+  const publishedPackages = workspaces.filter((workspace) =>
+    workspace.location.startsWith('packages/'),
+  );
   await updateReadme(
-    getDependencyGraph(workspaces),
-    getPackageList(workspaces),
+    getDependencyGraph(publishedPackages),
+    getPackageList(publishedPackages),
   );
   console.log('README content updated.');
 }
@@ -56,7 +63,17 @@ async function retrieveWorkspaces(): Promise<Workspace[]> {
     '--verbose',
   ]);
 
-  return stdout.split('\n').map((line) => JSON.parse(line));
+  return stdout.split('\n').map((line) => {
+    const workspace = JSON.parse(line) as Omit<Workspace, 'description'>;
+    const manifestPath = path.resolve(
+      __dirname,
+      '..',
+      workspace.location,
+      'package.json',
+    );
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return { ...workspace, description: manifest.description ?? '' };
+  });
 }
 
 /**
@@ -146,10 +163,33 @@ function assembleMermaidMarkdownFragment(
  * @returns The new package list Markdown fragment.
  */
 function getPackageList(workspaces: Workspace[]): string {
-  return workspaces
+  const rows = workspaces
     .sort((a, b) => a.name.localeCompare(b.name))
-    .map((workspace) => `- [\`${workspace.name}\`](${workspace.location})`)
-    .join('\n');
+    .map((workspace) => [
+      `[\`${workspace.name}\`](${workspace.location})`,
+      `[npm](https://www.npmjs.com/package/${workspace.name})`,
+      workspace.description,
+    ]);
+  return formatMarkdownTable(['Package', 'npm', 'Description'], rows);
+}
+
+/**
+ * Formats a Markdown table with columns aligned to their widest cell, matching
+ * Prettier's output so the regenerated README passes `yarn lint:misc --check`
+ * without a separate formatting pass.
+ *
+ * @param headers - The column header cells.
+ * @param rows - The table rows, each an array of cells aligned to `headers`.
+ * @returns The aligned Markdown table as a string.
+ */
+function formatMarkdownTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, column) =>
+    Math.max(3, header.length, ...rows.map((row) => row[column].length)),
+  );
+  const formatRow = (cells: string[]): string =>
+    `| ${cells.map((cell, column) => cell.padEnd(widths[column])).join(' | ')} |`;
+  const separator = `| ${widths.map((width) => '-'.repeat(width)).join(' | ')} |`;
+  return [formatRow(headers), separator, ...rows.map(formatRow)].join('\n');
 }
 
 /**


### PR DESCRIPTION
## Explanation

As part of moving `connect-monorepo` into stable, maintenance-only mode, this PR closes gaps in the package documentation so the repo is self-serve for new maintainers. The goal: every published package has an accurate README, and the repo has a top-level architecture diagram showing package topology and how `@metamask/connect` composes its sub-packages and transports.

What was wrong and what this changes:

- **`@metamask/analytics` README was a one-word stub** → full rewrite, framed as internal telemetry: the `analytics` singleton, `enable`/`disable`/`setGlobalProperty`/`track`, `Sender` batching, endpoint + env override, the event taxonomy, and CSP note.
- **`@metamask/multichain-ui` README was thin and stale** (claimed the OTP flow was "not yet supported") → full rewrite documenting it as a Stencil web-component library (`<mm-install-modal>`, `<mm-otp-modal>`), the `.` (types) and `./loader` (`defineCustomElements`) exports, and how it's consumed by `connect-multichain`'s `ModalFactory`.
- **`@metamask/connect` README documented a broken import path** — `@metamask/connect/multichain`, which is not an exported subpath (only `.`, resolving to multichain, and `./evm` exist) → fixed all examples and clarified the entry points.
- **New `docs/architecture.md`** with two diagrams: package topology/composition (incl. playgrounds) and transport selection/composition (extension `DefaultTransport` vs `MWPTransport` relay → QR/deeplink → CAIP-25 session). The transport diagram is also embedded in a new "Architecture" section of the root README.
- **Root README cleanup + generator re-wiring:** fixed pervasive broken links that were written `` `[name](url)` `` (backticks outside the link, so they rendered as literal text); restored the `<!-- start/end -->` markers so `yarn update-readme-content` works again (it had become a silent no-op after the markers were removed); and upgraded `getPackageList()` in `scripts/update-readme-content.ts` to emit a Prettier-aligned table scoped to `packages/*`.

A couple of changes whose purpose may not be obvious:

- **`scripts/update-readme-content.ts` now reads the Description column from each package's `package.json` `description` field** (instead of a hardcoded map), so a package's blurb is single-sourced and shared between npm and the README table. The six `package.json` `description` fields were rewritten accordingly — these are publishable metadata changes (they appear on npm), not just README edits.
- The auto-generated dependency graph is scoped to published `packages/*`; the full picture including the private playgrounds lives in `docs/architecture.md`.

This is a documentation/metadata-only change — no runtime code or tests were touched. I did **not** add per-package changelog entries; the `package.json` `description` updates are publishable, so let me know if you'd like changelog entries for those.

## References

- WAPI-1530

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate — _N/A, documentation/metadata only_
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary — _no changelog entries added; see note above re: `package.json` description changes_
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes — _N/A, no breaking changes_
