### PR TITLE
chore: migrate NPM publishing to trusted publishing (OIDC) via action-npm-publish@v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
     if: needs.is-release.outputs.IS_RELEASE == 'true'
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,6 +12,9 @@ on:
       INFURA_API_KEY:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
       PUBLISH_DOCS_TOKEN:
@@ -52,7 +52,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry run publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -62,6 +62,9 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -73,7 +76,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "vitest": "^3.1.2",
     "yargs": "^17.7.2"
   },
-  "packageManager": "yarn@4.9.2",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": ">=20.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "vitest": "^3.1.2",
     "yargs": "^17.7.2"
   },
-  "packageManager": "yarn@4.16.0",
+  "packageManager": "yarn@4.9.2",
   "engines": {
     "node": ">=20.19.0"
   },

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -204,7 +204,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.9.2');
+        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.16.0');
       }
 
       // All packages must specify a minimum Node.js version of 20.19.0.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 10
+  version: 8
   cacheKey: 10
 
 "@0no-co/graphql.web@npm:^1.0.13, @0no-co/graphql.web@npm:^1.0.8":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10
 
 "@0no-co/graphql.web@npm:^1.0.13, @0no-co/graphql.web@npm:^1.0.8":


### PR DESCRIPTION
## Explanation

Core Platform is hardening MetaMask's NPM supply chain by replacing long-lived NPM tokens with trusted publishing (OIDC) plus staged publishing. All package owners must move to `MetaMask/action-npm-publish@v6`, which implements those changes. This covers all six non-private `@metamask/connect` packages published from this monorepo (`connect`, `connect-evm`, `connect-solana`, `connect-multichain`, `multichain-ui`, `analytics`).

Previously the release workflow published with `action-npm-publish@v5` using a required, long-lived `NPM_TOKEN` and no `id-token: write` permission. This PR migrates the release publishing path to OIDC trusted publishing:

- Bumped both the dry-run and publish steps in `publish-release.yml` from `action-npm-publish@v5` to `@v6`.
- Granted the `publish-npm` job `permissions: id-token: write` (with `contents: read`) so it can request the OIDC token used by trusted publishing.
- Made the `NPM_TOKEN` secret optional (`required: false`) rather than required. The token is still passed to the publish step as the fallback / first-publish path, per the MetaMask module template.
- Bumped `packageManager` to `yarn@4.16.0` (latest stable; the previous `4.9.2` was below the `>= 4.16.0` requirement). This also bumps the `yarn.lock` metadata format from `version: 8` to `10`.

### Scope notes

- **`action-checkout-and-setup` / `download-artifact` were intentionally left untouched.** Only the npm-publish action bump is required by the acceptance criteria; bumping the other helper actions is unrelated scope and is better handled separately.
- **`publish-preview.yml` is out of scope.** It publishes preview builds to GitHub Packages via a dedicated `PUBLISH_PREVIEW_NPM_TOKEN`, and NPM trusted publishing (OIDC) is an npmjs.com registry feature that does not apply to GitHub Packages.
- **No `SKIP_PREPACK`** was added (present in the module template) because none of the packages define a `prepack` script, so it would be a no-op here.

### Verification

- `yarn install --immutable` passes cleanly on Yarn 4.16.0.
- `yarn build` passes (11/11 tasks).

> [!IMPORTANT]
> Trusted publishing must be enabled on the npm side for all six packages by the **@metamask-npm-publishers** team before the first OIDC-based release. Until then, publishing continues to rely on the (now optional) `NPM_TOKEN`.

## References

- WAPI-1542: https://consensyssoftware.atlassian.net/browse/WAPI-1542
- Reference: [MetaMask module template](https://github.com/MetaMask/metamask-module-template)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary — _N/A: CI/workflow + tooling change only, no published package code changes._
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
