### PR TITLE
revert: Revert moving connect-multichain into peerDep for ecosystem packages

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
+
 ### Fixed
 
 - `EIP1193Provider.request()` now preserves JSON-RPC error `data` on provider-facing errors when `connect-multichain` surfaces a wallet error through `RPCInvokeMethodErr`. Dapps can read revert reasons, custom-error bytes, and other wallet-provided error metadata from `error.data` alongside the original wallet `error.code` and `error.message`. ([#312](https://github.com/MetaMask/connect-monorepo/pull/312))

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -55,12 +55,12 @@
   },
   "dependencies": {
     "@metamask/analytics": "workspace:^",
+    "@metamask/connect-multichain": "workspace:^",
     "@metamask/utils": "^11.8.1",
     "semver": "^7.7.4"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/connect-multichain": "workspace:^",
     "@types/jsdom": "^21.1.7",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^3.2.4",
@@ -71,9 +71,6 @@
     "typedoc-plugin-missing-exports": "^4.1.2",
     "typescript": "^5.9.3",
     "vitest": "^3.1.2"
-  },
-  "peerDependencies": {
-    "@metamask/connect-multichain": "workspace:^"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/packages/connect-evm/tsup.config.ts
+++ b/packages/connect-evm/tsup.config.ts
@@ -16,7 +16,7 @@ const external = [...deps, ...peerDeps];
 const entryName = pkg.name.replace('@metamask/', '');
 
 const multichainPeerRange = resolveWorkspaceRange(
-  pkg.peerDependencies?.['@metamask/connect-multichain'],
+  pkg.dependencies?.['@metamask/connect-multichain'],
   multichainPkg.version,
 );
 

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
+
 ## [2.0.0]
 
 ### Added

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -58,6 +58,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@metamask/connect-multichain": "workspace:^",
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@wallet-standard/app": "~1.1.0",
     "@wallet-standard/base": "^1.1.0",
@@ -65,7 +66,6 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/connect-multichain": "workspace:^",
     "@types/jsdom": "^21.1.7",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^3.2.4",
@@ -76,9 +76,6 @@
     "typedoc-plugin-missing-exports": "^4.1.2",
     "typescript": "^5.9.3",
     "vitest": "^3.1.2"
-  },
-  "peerDependencies": {
-    "@metamask/connect-multichain": "workspace:^"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/packages/connect-solana/tsup.config.ts
+++ b/packages/connect-solana/tsup.config.ts
@@ -16,7 +16,7 @@ const external = [...deps, ...peerDeps];
 const entryName = pkg.name.replace('@metamask/', '');
 
 const multichainPeerRange = resolveWorkspaceRange(
-  pkg.peerDependencies?.['@metamask/connect-multichain'],
+  pkg.dependencies?.['@metamask/connect-multichain'],
   multichainPkg.version,
 );
 

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -641,15 +641,6 @@ function expectUpToDateWorkspacePeerDependencies(Yarn, workspace) {
       dependencyWorkspace !== null &&
       dependency.type === 'peerDependencies'
     ) {
-      // Yarn rewrites `workspace:` protocol ranges to a satisfying semver
-      // range at publish time (e.g. `workspace:^` -> `^<workspace-version>`),
-      // so by construction they always satisfy the workspace version. Skip
-      // the satisfies() check, which would otherwise treat `workspace:^` as
-      // an invalid range and "fix" it to `^<major>.0.0`.
-      if (dependency.range.startsWith('workspace:')) {
-        continue;
-      }
-
       const dependencyWorkspaceVersion = new semver.SemVer(
         dependencyWorkspace.manifest.version,
       );
@@ -732,16 +723,6 @@ function expectPeerDependenciesAlsoListedAsDevDependencies(
     const dependencyWorkspace = Yarn.workspace({ ident: dependencyIdent });
 
     if (dependencyWorkspace) {
-      const existingDevDependency =
-        dependencyInstancesByType.get('devDependencies');
-      const ignoredRanges = ALLOWED_INCONSISTENT_DEPENDENCIES[dependencyIdent];
-      if (
-        existingDevDependency &&
-        ignoredRanges?.includes(existingDevDependency.range)
-      ) {
-        continue;
-      }
-
       expectWorkspaceField(
         workspace,
         `devDependencies["${dependencyIdent}"]`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,8 +4011,6 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^4.1.2"
     typescript: "npm:^5.9.3"
     vitest: "npm:^3.1.2"
-  peerDependencies:
-    "@metamask/connect-multichain": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -4136,8 +4134,6 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^4.1.2"
     typescript: "npm:^5.9.3"
     vitest: "npm:^3.1.2"
-  peerDependencies:
-    "@metamask/connect-multichain": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

Reverts just the peerDep changes from 7786de8aeb349648033abbd3986652de01974710 . The devex degradation for library consumers having to install two peerDeps (ecosystem client, and multichain client) isn't worth the gains from build time warnings. 

## References

Fixes: https://consensys.slack.com/archives/C058P09HT17/p1781040721508819?thread_ts=1781037006.244619&cid=C058P09HT17

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/{{REPO_NAME}}/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
