### PR TITLE
Release/38.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-monorepo",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -270,7 +272,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#58](https://github.com/MetaMask/connect-monorepo/pull/58))
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...@metamask/connect-evm@2.1.0
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.4.0...@metamask/connect-evm@2.0.0
 [1.4.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.1...@metamask/connect-evm@1.4.0
 [1.3.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.0...@metamask/connect-evm@1.3.1

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-evm",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain client",
   "keywords": [
     "MetaMask",

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
 ### Fixed
 
 - Normalize `invokeMethod()` wallet errors across transports. Wallet-side JSON-RPC / EIP-1193 `code`, `message`, and `data` fields are now preserved in `RPCInvokeMethodErr` as `rpcCode`, `rpcMessage`, and `rpcData` whether the wallet error arrives as a resolved JSON-RPC error response or as a rejected transport error. Wrapped transport errors now walk a capped `cause` chain so wallet error details are not hidden by transport/API wrapper errors. ([#312](https://github.com/MetaMask/connect-monorepo/pull/312))
@@ -314,7 +316,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.1.0...HEAD
+[1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...@metamask/connect-multichain@1.1.0
 [1.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.15.0...@metamask/connect-multichain@1.0.0
 [0.15.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.14.0...@metamask/connect-multichain@0.15.0
 [0.14.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.13.0...@metamask/connect-multichain@0.14.0

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-multichain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -117,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...@metamask/connect-solana@2.1.0
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.2.0...@metamask/connect-solana@2.0.0
 [1.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.1.0...@metamask/connect-solana@1.2.0
 [1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.0.0...@metamask/connect-solana@1.1.0

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-solana",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain client",
   "keywords": [
     "MetaMask",

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1]
+
+### Changed
+
+- Bump workspace dependencies:
+  - @metamask/connect-evm@2.1.0
+  - @metamask/connect-multichain@1.1.0
+
 ## [0.8.0]
 
 ### Added
@@ -253,7 +261,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.1...HEAD
+[0.8.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...@metamask/browser-playground@0.8.1
 [0.8.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.5...@metamask/browser-playground@0.8.0
 [0.7.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.4...@metamask/browser-playground@0.7.5
 [0.7.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.3...@metamask/browser-playground@0.7.4

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browser-playground",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A browser test dapp for multichain api",
   "keywords": [
     "MetaMask",

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1]
+
+### Changed
+
+- Bump workspace dependencies:
+  - @metamask/connect-evm@2.1.0
+  - @metamask/connect-multichain@1.1.0
+
 ## [0.5.0]
 
 ### Changed
@@ -188,7 +196,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.1...HEAD
+[0.5.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...@metamask/react-native-playground@0.5.1
 [0.5.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.5...@metamask/react-native-playground@0.5.0
 [0.4.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.4...@metamask/react-native-playground@0.4.5
 [0.4.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.3...@metamask/react-native-playground@0.4.4

--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-playground",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "A React Native test dapp for multichain api",
   "keywords": [


### PR DESCRIPTION
Recreates the `38.0.0` release after [Revert "Release/38.0.0 (#324)" (#325)](https://github.com/MetaMask/connect-monorepo/pull/325), this time cut off `main` so it includes the OIDC trusted-publishing changes from [chore: migrate NPM publishing to trusted publishing (OIDC) via action-npm-publish@v6 (#321)](https://github.com/MetaMask/connect-monorepo/pull/321).

## Why

The original `38.0.0` release ([#324](https://github.com/MetaMask/connect-monorepo/pull/324)) was cut *before* #321 landed, so its publish path still used `action-npm-publish@v5` + the (now-disabled) long-lived `NPM_TOKEN`. The npm publish stalled at the manual approval gate. We reverted that release (#325) and merged #321; this PR re-cuts the same release on top of `main`.

## What

- Identical version bumps and CHANGELOG entries to #324:
  - `@metamask/connect-monorepo` 37.0.0 → 38.0.0
  - `@metamask/connect-evm` 2.0.0 → 2.1.0
  - `@metamask/connect-multichain` 1.0.0 → 1.1.0
  - `@metamask/connect-solana` 2.0.0 → 2.1.0
  - `@metamask/browser-playground` 0.8.0 → 0.8.1
  - `@metamask/react-native-playground` 0.5.0 → 0.5.1
- Because it's branched off current `main`, the release now carries #321's OIDC publishing workflow (`action-npm-publish@v6`, `id-token: write`, optional `NPM_TOKEN`).

## Note on the previous attempt

The earlier `38.0.0` attempt created a GitHub release `v38.0.0` and package tags (`@metamask/connect-evm@2.1.0`, `@metamask/connect-multichain@1.1.0`, `@metamask/connect-solana@2.1.0`, `@metamask/browser-playground@0.8.1`) before stalling at the npm gate. Nothing was published to npm. Those phantom release/tags have been deleted so this re-release can create them cleanly on merge.