### PR TITLE
fix: remove stale packageManager from browser-playground

### DIFF
--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -105,7 +105,6 @@
     "viem": "2.*",
     "wagmi": "^3.5.0"
   },
-  "packageManager": "yarn@4.1.1",
   "engines": {
     "node": ">=20.19.0"
   },


### PR DESCRIPTION
`playground/browser-playground/package.json` carried a stale workspace-level `"packageManager": "yarn@4.1.1"`. Per `yarn.config.cjs`, child workspaces must **unset** `packageManager` — only the root pins it (now `yarn@4.16.0`) so corepack resolves a single yarn version across the workspace. This leftover slipped through because `yarn constraints` isn't run in CI.

It bites when publishing with `action-npm-publish@v6` (requires `yarn >= 4.16.0`): corepack reads the workspace field and aborts with `Yarn version 4.16.0 or higher is required. Detected version: 4.1.1`.

## Fix

Remove the field (equivalent to `yarn constraints --fix`). corepack then falls back to the root's `yarn@4.16.0`.

I confirmed `browser-playground` was the only workspace affected — no other workspace pins `packageManager` or `engines.yarn`, and there's no `yarnPath`/bundled release.

<sub>Surfaced while publishing the `38.0.0` release.</sub>