### PR TITLE
Revert "Release/38.0.0 (#326)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-monorepo",
-  "version": "38.0.0",
+  "version": "37.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -272,8 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#58](https://github.com/MetaMask/connect-monorepo/pull/58))
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...@metamask/connect-evm@2.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...HEAD
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.4.0...@metamask/connect-evm@2.0.0
 [1.4.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.1...@metamask/connect-evm@1.4.0
 [1.3.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.0...@metamask/connect-evm@1.3.1

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-evm",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain client",
   "keywords": [
     "MetaMask",

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0]
-
 ### Fixed
 
 - Normalize `invokeMethod()` wallet errors across transports. Wallet-side JSON-RPC / EIP-1193 `code`, `message`, and `data` fields are now preserved in `RPCInvokeMethodErr` as `rpcCode`, `rpcMessage`, and `rpcData` whether the wallet error arrives as a resolved JSON-RPC error response or as a rejected transport error. Wrapped transport errors now walk a capped `cause` chain so wallet error details are not hidden by transport/API wrapper errors. ([#312](https://github.com/MetaMask/connect-monorepo/pull/312))
@@ -316,8 +314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.1.0...HEAD
-[1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...@metamask/connect-multichain@1.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.15.0...@metamask/connect-multichain@1.0.0
 [0.15.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.14.0...@metamask/connect-multichain@0.15.0
 [0.14.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.13.0...@metamask/connect-multichain@0.14.0

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-multichain",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -119,8 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...@metamask/connect-solana@2.1.0
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...HEAD
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.2.0...@metamask/connect-solana@2.0.0
 [1.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.1.0...@metamask/connect-solana@1.2.0
 [1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.0.0...@metamask/connect-solana@1.1.0

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-solana",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain client",
   "keywords": [
     "MetaMask",

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.1]
-
-### Changed
-
-- Bump workspace dependencies:
-  - @metamask/connect-evm@2.1.0
-  - @metamask/connect-multichain@1.1.0
-
 ## [0.8.0]
 
 ### Added
@@ -261,8 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.1...HEAD
-[0.8.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...@metamask/browser-playground@0.8.1
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...HEAD
 [0.8.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.5...@metamask/browser-playground@0.8.0
 [0.7.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.4...@metamask/browser-playground@0.7.5
 [0.7.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.3...@metamask/browser-playground@0.7.4

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browser-playground",
-  "version": "0.8.1",
+  "version": "0.8.0",
   "description": "A browser test dapp for multichain api",
   "keywords": [
     "MetaMask",

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.1]
-
-### Changed
-
-- Bump workspace dependencies:
-  - @metamask/connect-evm@2.1.0
-  - @metamask/connect-multichain@1.1.0
-
 ## [0.5.0]
 
 ### Changed
@@ -196,8 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.1...HEAD
-[0.5.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...@metamask/react-native-playground@0.5.1
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...HEAD
 [0.5.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.5...@metamask/react-native-playground@0.5.0
 [0.4.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.4...@metamask/react-native-playground@0.4.5
 [0.4.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.3...@metamask/react-native-playground@0.4.4

--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-playground",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "private": true,
   "description": "A React Native test dapp for multichain api",
   "keywords": [


### PR DESCRIPTION
Reverts the `38.0.0` release bumps from [Release/38.0.0 (#326)](https://github.com/MetaMask/connect-monorepo/pull/326).

## Why

The `38.0.0` publish failed at the npm step (`action-npm-publish@v6` rejected a stale `yarn@4.1.1` pin in `browser-playground`). Nothing was published to npm. Rather than re-trigger publish with a no-op "release" PR, we're resetting `main` back to the pre-`38.0.0` versions so we can cut a clean `38.0.0` release once the fix ([fix: remove stale packageManager from browser-playground](https://github.com/MetaMask/connect-monorepo/pull/328)) is merged.

## What

- Reverts the version bumps and CHANGELOG entries from `0e9f4fa`.
- Applies cleanly (it's the current tip of `main`).

No package source code is affected. The phantom `v38.0.0` GitHub release + package tags from the failed run were already deleted.