### PR TITLE
Release/38.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-monorepo",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "private": true,
   "description": "MetaMask Connect Monorepo",
   "repository": {

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -270,7 +272,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#58](https://github.com/MetaMask/connect-monorepo/pull/58))
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@2.0.0...@metamask/connect-evm@2.1.0
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.4.0...@metamask/connect-evm@2.0.0
 [1.4.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.1...@metamask/connect-evm@1.4.0
 [1.3.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-evm@1.3.0...@metamask/connect-evm@1.3.1

--- a/packages/connect-evm/package.json
+++ b/packages/connect-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-evm",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MetaMask Connect EVM adapter — EIP-1193 provider over the multichain client",
   "keywords": [
     "MetaMask",

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
 ### Fixed
 
 - Normalize `invokeMethod()` wallet errors across transports. Wallet-side JSON-RPC / EIP-1193 `code`, `message`, and `data` fields are now preserved in `RPCInvokeMethodErr` as `rpcCode`, `rpcMessage`, and `rpcData` whether the wallet error arrives as a resolved JSON-RPC error response or as a rejected transport error. Wrapped transport errors now walk a capped `cause` chain so wallet error details are not hidden by transport/API wrapper errors. ([#312](https://github.com/MetaMask/connect-monorepo/pull/312))
@@ -314,7 +316,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.1.0...HEAD
+[1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@1.0.0...@metamask/connect-multichain@1.1.0
 [1.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.15.0...@metamask/connect-multichain@1.0.0
 [0.15.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.14.0...@metamask/connect-multichain@0.15.0
 [0.14.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-multichain@0.13.0...@metamask/connect-multichain@0.14.0

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-multichain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",

--- a/packages/connect-solana/CHANGELOG.md
+++ b/packages/connect-solana/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
 ### Changed
 
 - `@metamask/connect-multichain` is no longer a peer dependency and will be installed transitively as a regular dependency ([#323](https://github.com/MetaMask/connect-monorepo/pull/323))
@@ -117,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@2.0.0...@metamask/connect-solana@2.1.0
 [2.0.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.2.0...@metamask/connect-solana@2.0.0
 [1.2.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.1.0...@metamask/connect-solana@1.2.0
 [1.1.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/connect-solana@1.0.0...@metamask/connect-solana@1.1.0

--- a/packages/connect-solana/package.json
+++ b/packages/connect-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-solana",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MetaMask Connect Solana adapter — Wallet Standard integration over the multichain client",
   "keywords": [
     "MetaMask",

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1]
+
+### Changed
+
+- Bump workspace dependencies:
+  - @metamask/connect-evm@2.1.0
+  - @metamask/connect-multichain@1.1.0
+
 ## [0.8.0]
 
 ### Added
@@ -253,7 +261,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.1...HEAD
+[0.8.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.8.0...@metamask/browser-playground@0.8.1
 [0.8.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.5...@metamask/browser-playground@0.8.0
 [0.7.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.4...@metamask/browser-playground@0.7.5
 [0.7.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/browser-playground@0.7.3...@metamask/browser-playground@0.7.4

--- a/playground/browser-playground/package.json
+++ b/playground/browser-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browser-playground",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A browser test dapp for multichain api",
   "keywords": [
     "MetaMask",

--- a/playground/react-native-playground/CHANGELOG.md
+++ b/playground/react-native-playground/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1]
+
+### Changed
+
+- Bump workspace dependencies:
+  - @metamask/connect-evm@2.1.0
+  - @metamask/connect-multichain@1.1.0
+
 ## [0.5.0]
 
 ### Changed
@@ -188,7 +196,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...HEAD
+[Unreleased]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.1...HEAD
+[0.5.1]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.5.0...@metamask/react-native-playground@0.5.1
 [0.5.0]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.5...@metamask/react-native-playground@0.5.0
 [0.4.5]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.4...@metamask/react-native-playground@0.4.5
 [0.4.4]: https://github.com/MetaMask/connect-monorepo/compare/@metamask/react-native-playground@0.4.3...@metamask/react-native-playground@0.4.4

--- a/playground/react-native-playground/package.json
+++ b/playground/react-native-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-playground",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "A React Native test dapp for multichain api",
   "keywords": [


### PR DESCRIPTION
Cuts the `38.0.0` release off current `main`, now that it includes the OIDC trusted-publishing migration ([#321](https://github.com/MetaMask/connect-monorepo/pull/321)) and the yarn fix ([#328](https://github.com/MetaMask/connect-monorepo/pull/328)).

## Background

The first two `38.0.0` attempts ([#324](https://github.com/MetaMask/connect-monorepo/pull/324), [#326](https://github.com/MetaMask/connect-monorepo/pull/326)) failed to publish — #324 predated the OIDC migration, and #326 hit a stale `yarn@4.1.1` pin in `browser-playground` that `action-npm-publish@v6` rejected. Both were reverted ([#325](https://github.com/MetaMask/connect-monorepo/pull/325), [#329](https://github.com/MetaMask/connect-monorepo/pull/329)); the yarn fix landed in #328. This re-cut is clean off the fixed `main`.

## Version bumps

- `@metamask/connect-monorepo` 37.0.0 → 38.0.0
- `@metamask/connect-evm` 2.0.0 → 2.1.0
- `@metamask/connect-multichain` 1.0.0 → 1.1.0
- `@metamask/connect-solana` 2.0.0 → 2.1.0
- `@metamask/browser-playground` 0.8.0 → 0.8.1
- `@metamask/react-native-playground` 0.5.0 → 0.5.1

Version bumps and CHANGELOG entries are identical to #324/#326. The phantom `v38.0.0` GitHub release + package tags from the failed runs were deleted, so publish recreates them cleanly on merge. Nothing was published to npm.