### PR TITLE
fix(connect-multichain): emit connection_rejected on QR modal close

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Closing the QR code / install modal mid-connection now emits `mmconnect_connection_rejected` instead of `mmconnect_connection_failed`. Modal close is a user-driven cancellation; it previously rejected with a plain `Error('User closed modal')` that `isRejectionError` did not recognise, so user cancellations polluted the `_failed` bucket. The close handler now rejects with the canonical EIP-1193 `4001` error (`providerErrors.userRejectedRequest()`). Genuine errors (transport timeouts/disconnects, wallet RPC errors) still emit `mmconnect_connection_failed`. ([#333](https://github.com/MetaMask/connect-monorepo/pull/333))
+
 ## [1.1.0]
 
 ### Fixed

--- a/packages/connect-multichain/src/multichain/utils/analytics.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable id-length -- vitest alias */
+import { providerErrors } from '@metamask/rpc-errors';
 import * as t from 'vitest';
 
 import {
@@ -485,6 +486,13 @@ t.describe('isRejectionError', () => {
       );
     },
   );
+
+  t.it('treats the modal-close error as a rejection', () => {
+    // BaseModalFactory.onCloseModal rejects with this when the user closes
+    // the QR/install modal mid-connection. It must classify as `_rejected`,
+    // not `_failed`.
+    t.expect(isRejectionError(providerErrors.userRejectedRequest())).toBe(true);
+  });
 
   t.it(
     'unwraps RPCInvokeMethodErr to detect wallet-side rejection codes',

--- a/packages/connect-multichain/src/multichain/utils/analytics.test.ts
+++ b/packages/connect-multichain/src/multichain/utils/analytics.test.ts
@@ -487,7 +487,7 @@ t.describe('isRejectionError', () => {
     },
   );
 
-  t.it('treats the modal-close error as a rejection', () => {
+  t.it('recognises userRejectedRequest (4001) as a rejection', () => {
     // BaseModalFactory.onCloseModal rejects with this when the user closes
     // the QR/install modal mid-connection. It must classify as `_rejected`,
     // not `_failed`.

--- a/packages/connect-multichain/src/ui/ModalFactory.ts
+++ b/packages/connect-multichain/src/ui/ModalFactory.ts
@@ -8,6 +8,7 @@
 
 /* eslint-disable @typescript-eslint/naming-convention */
 import MetaMaskOnboarding from '@metamask/onboarding';
+import { providerErrors } from '@metamask/rpc-errors';
 
 import { METAMASK_CONNECT_BASE_URL, METAMASK_DEEPLINK_BASE } from '../config';
 import {
@@ -17,9 +18,9 @@ import {
   type OTPCode,
   PlatformType,
 } from '../domain';
+import { compressString } from '../multichain/utils';
 import type { AbstractOTPCodeModal } from './modals/base/AbstractOTPModal';
 import type { FactoryModals, ModalTypes } from './modals/types';
-import { compressString } from '../multichain/utils';
 
 /**
  * Preload function type for loading UI dependencies
@@ -138,8 +139,11 @@ export abstract class BaseModalFactory<
   }
 
   private async onCloseModal(shouldTerminate = true) {
+    // Closing the modal is a user-driven cancellation, so reject with the
+    // canonical EIP-1193 4001 error. This lets `isRejectionError` classify it
+    // as `mmconnect_connection_rejected` instead of `mmconnect_connection_failed`.
     return this.unload(
-      shouldTerminate ? new Error('User closed modal') : undefined,
+      shouldTerminate ? providerErrors.userRejectedRequest() : undefined,
     );
   }
 

--- a/packages/connect-multichain/src/ui/index.test.ts
+++ b/packages/connect-multichain/src/ui/index.test.ts
@@ -388,9 +388,6 @@ t.describe('ModalFactory', () => {
         // Multichain SDK is what will close the modal instead
         t.expect(mockModal.unmount).toHaveBeenCalled();
 
-        // Closing the modal is a user-driven cancellation: the error handed to
-        // the success callback must classify as a rejection so the SDK emits
-        // `mmconnect_connection_rejected`, not `_failed` (WAPI-1552).
         t.expect(closeError).toBeDefined();
         t.expect(isRejectionError(closeError)).toBe(true);
       });

--- a/packages/connect-multichain/src/ui/index.test.ts
+++ b/packages/connect-multichain/src/ui/index.test.ts
@@ -24,6 +24,7 @@ import {
   type QRLink,
 } from '../domain';
 import type { FactoryModals } from './modals/types';
+import { isRejectionError } from '../multichain/utils/analytics';
 
 // Mock external dependencies
 t.vi.mock('@metamask/onboarding', () => ({
@@ -370,10 +371,13 @@ t.describe('ModalFactory', () => {
           },
         };
 
+        let closeError: Error | undefined;
         await uiModule.renderInstallModal(
           false,
           async () => Promise.resolve(connectionRequest),
-          async () => {},
+          async (error?: Error) => {
+            closeError = error;
+          },
         );
 
         const constructorArgs = (mockFactoryOptions.InstallModal as any).mock
@@ -383,6 +387,12 @@ t.describe('ModalFactory', () => {
 
         // Multichain SDK is what will close the modal instead
         t.expect(mockModal.unmount).toHaveBeenCalled();
+
+        // Closing the modal is a user-driven cancellation: the error handed to
+        // the success callback must classify as a rejection so the SDK emits
+        // `mmconnect_connection_rejected`, not `_failed` (WAPI-1552).
+        t.expect(closeError).toBeDefined();
+        t.expect(isRejectionError(closeError)).toBe(true);
       });
 
       t.it('should handle desktop onboarding correctly', async () => {


### PR DESCRIPTION
## Explanation

When a user closes the MWP install / QR code modal during a connection attempt, the SDK tracked an `mmconnect_connection_failed` analytics event. Closing the modal is a user-driven cancellation, so it should be classified as `mmconnect_connection_rejected` instead. The bug polluted the `_failed` event (meant for genuine errors like transport timeouts/disconnects) with user cancellations, skewing the connection funnel and failure-reason metrics.

**Root cause:** `BaseModalFactory.onCloseModal` rejected the connection with `new Error('User closed modal')`. That error bubbles up to `#handleConnection`, which calls `isRejectionError(error)` to branch between `_rejected` and `_failed`. `isRejectionError` only matches code `4001` or the substrings `reject` / `denied` / `cancel` / `user rejected` / etc. — the message `"User closed modal"` matches none, so it fell through to `mmconnect_connection_failed`.

**Fix:** `onCloseModal` now rejects with `providerErrors.userRejectedRequest()` (the canonical EIP-1193 `4001` "User rejected the request" error from `@metamask/rpc-errors`, already a dependency of this package). This makes the cancellation intent explicit at the source rather than relying on string heuristics. The error flows directly through the success callback — no transport-boundary wrapping — so the `4001` code reaches `isRejectionError` intact, where it matches on both `code === 4001` and the `reject` substring. Genuine connection errors (transport timeout, transport disconnect, wallet RPC errors) are untouched and still emit `mmconnect_connection_failed`.

This is "Option 1" from the ticket, which was preferred over broadening the `isRejectionError` heuristics.

## References

- Fixes [WAPI-1552](https://consensyssoftware.atlassian.net/browse/WAPI-1552)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
