### PR TITLE
docs(skills): add README for the metamask-connect skill

### DIFF
--- a/skills/metamask-connect/README.md
+++ b/skills/metamask-connect/README.md
@@ -44,10 +44,6 @@ metamask-connect/
 
 The agent reads `SKILL.md` first, then loads the relevant reference(s) and workflow for the task at hand.
 
-## Provenance
-
-Generated from the [`metamask-connect-cursor-plugin`](https://github.com/MetaMask/metamask-connect-cursor-plugin)'s `skills/` and always-on `rules/`, and source-verified against the published `@metamask/connect-*` packages in this monorepo. It lives here so it stays in sync with the SDK it documents.
-
 ## License
 
 This skill is part of the connect-monorepo and is covered by the repository's [`LICENCE`](../../LICENCE).

--- a/skills/metamask-connect/README.md
+++ b/skills/metamask-connect/README.md
@@ -2,7 +2,7 @@
 
 An [agent skill](https://skills.sh) for building dApps that integrate MetaMask via the **MetaMask Connect SDK** — EVM (`@metamask/connect-evm`), Solana (`@metamask/connect-solana`), and multichain (`@metamask/connect-multichain`), plus the wagmi `metaMask()` connector.
 
-It teaches coding agents (Cursor, Claude Code, Copilot, Codex, etc.) how to set up clients across browser / React / React Native, connect and manage sessions, sign messages, send transactions, run multichain `invokeMethod` across CAIP-2 scopes, migrate from `@metamask/sdk`, and troubleshoot connection/polyfill issues — with guidance source-verified against the published packages.
+It teaches coding agents (Cursor, Claude Code, Copilot, Codex, etc.) how to set up clients across browser / React / React Native / nodejs, connect and manage sessions, sign messages, send transactions, run multichain `invokeMethod` across CAIP-2 scopes, migrate from `@metamask/sdk`, and troubleshoot connection/polyfill issues — with guidance source-verified against the published packages.
 
 ## Install
 

--- a/skills/metamask-connect/README.md
+++ b/skills/metamask-connect/README.md
@@ -1,0 +1,53 @@
+# metamask-connect — Agent Skill
+
+An [agent skill](https://skills.sh) for building dApps that integrate MetaMask via the **MetaMask Connect SDK** — EVM (`@metamask/connect-evm`), Solana (`@metamask/connect-solana`), and multichain (`@metamask/connect-multichain`), plus the wagmi `metaMask()` connector.
+
+It teaches coding agents (Cursor, Claude Code, Copilot, Codex, etc.) how to set up clients across browser / React / React Native, connect and manage sessions, sign messages, send transactions, run multichain `invokeMethod` across CAIP-2 scopes, migrate from `@metamask/sdk`, and troubleshoot connection/polyfill issues — with guidance source-verified against the published packages.
+
+## Install
+
+The skill is distributed straight from this repo with the [`skills` CLI](https://github.com/vercel-labs/skills):
+
+```bash
+# Install just this skill (no prompts), into the agent the CLI detects
+npx skills add MetaMask/connect-monorepo --skill metamask-connect -y
+
+# Or run it interactively to choose agent + scope
+npx skills add MetaMask/connect-monorepo --skill metamask-connect
+
+# Install globally (available across all your projects)
+npx skills add MetaMask/connect-monorepo --skill metamask-connect -g -y
+
+# Preview what's in the repo without installing
+npx skills add MetaMask/connect-monorepo --list
+```
+
+By default the CLI symlinks the skill into your agent's directory (e.g. `.cursor/skills/`); pass `--copy` to copy the files instead. Search the bare term `metamask` with `npx skills find metamask` to locate it in the directory.
+
+## What's inside
+
+```
+metamask-connect/
+├── SKILL.md          # entry point — routing table the agent reads first
+├── references/       # focused, always-on guidance per topic
+│   ├── conventions.md      # core guardrails (import paths, config, supportedNetworks, errors)
+│   ├── evm.md              # chain IDs / switchChain
+│   ├── solana.md           # CAIP-2 genesis hashes, wallet-adapter, platform limits
+│   ├── multichain.md       # singleton, sessions, invokeMethod, lazy transport
+│   ├── events.md           # EIP-1193 events, eventHandlers, Solana state changes
+│   ├── react-native.md     # polyfills / Metro config
+│   ├── csp.md              # Content Security Policy
+│   ├── testing.md          # mocking the client
+│   └── troubleshooting.md  # symptom → cause → fix index
+└── workflows/        # step-by-step setup, sign/send, multichain, and migration guides
+```
+
+The agent reads `SKILL.md` first, then loads the relevant reference(s) and workflow for the task at hand.
+
+## Provenance
+
+Generated from the [`metamask-connect-cursor-plugin`](https://github.com/MetaMask/metamask-connect-cursor-plugin)'s `skills/` and always-on `rules/`, and source-verified against the published `@metamask/connect-*` packages in this monorepo. It lives here so it stays in sync with the SDK it documents.
+
+## License
+
+This skill is part of the connect-monorepo and is covered by the repository's [`LICENCE`](../../LICENCE).


### PR DESCRIPTION
## Summary

- Adds a `README.md` to `skills/metamask-connect/` documenting the `npx skills add` install command, the skill's layout, provenance, and license.
- This README renders on the skill's [skills.sh](https://skills.sh) profile page and gives integrators a copy-paste one-liner to install the skill into their agent.

Follow-up to the merged skill PR (#334).

## Test plan

- [x] Verified reference/workflow filenames in the README match the on-disk files.
- [x] Verified the skill installs from this repo via `npx skills add MetaMask/connect-monorepo --skill metamask-connect` (28 files land under `.agents/skills/metamask-connect/`).