### PR TITLE
fix: recognize MetaMask Flask (io.metamask.flask) as native MetaMask

### DIFF
--- a/integrations/wagmi/metamask-connector.ts
+++ b/integrations/wagmi/metamask-connector.ts
@@ -76,7 +76,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'metaMaskSDK',
     name: 'MetaMask',
-    rdns: ['io.metamask', 'io.metamask.mobile'],
+    rdns: ['io.metamask', 'io.metamask.mobile', 'io.metamask.flask'],
     type: metaMask.type,
     async connect({ chainId = 1, isReconnecting, withCapabilities } = {}) {
       const instance = await this.getInstance();

--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Recognize MetaMask Flask (`io.metamask.flask`) as a native MetaMask EIP-6963 provider. The MMConnect-managed provider announcement is now suppressed when Flask has announced, avoiding a duplicate MetaMask entry in wallet pickers. ([#336](https://github.com/MetaMask/connect-monorepo/pull/336))
+
 ## [2.1.0]
 
 ### Changed

--- a/packages/connect-evm/README.md
+++ b/packages/connect-evm/README.md
@@ -311,7 +311,7 @@ await client.disconnect();
 
 ##### `announceProvider()`
 
-Announces the MMConnect-managed EIP-1193 provider through EIP-6963 unless a native MetaMask provider has already announced with `rdns` `io.metamask` or `io.metamask.mobile`. This is called automatically by `createEVMClient()` unless `skipAutoAnnounce: true` is set. The first call may take up to 300 ms while native providers are requested.
+Announces the MMConnect-managed EIP-1193 provider through EIP-6963 unless a native MetaMask provider has already announced with `rdns` `io.metamask`, `io.metamask.mobile`, or `io.metamask.flask`. This is called automatically by `createEVMClient()` unless `skipAutoAnnounce: true` is set. The first call may take up to 300 ms while native providers are requested.
 
 **Parameters**
 

--- a/packages/connect-evm/src/eip6963.test.ts
+++ b/packages/connect-evm/src/eip6963.test.ts
@@ -263,7 +263,7 @@ describe('EIP-6963 announcement', () => {
     expect(details).toHaveLength(0);
   });
 
-  it('does not suppress the SDK provider when MetaMask Flask has announced', async () => {
+  it('suppresses the SDK provider when MetaMask Flask has announced', async () => {
     const client = await MetamaskConnectEVM.create({ core: createMockCore() });
     const nativeHandler = (): void =>
       announceNativeMetaMaskProvider('io.metamask.flask');
@@ -278,8 +278,7 @@ describe('EIP-6963 announcement', () => {
       EIP6963_REQUEST_PROVIDER_EVENT,
       nativeHandler,
     );
-    expect(details).toHaveLength(1);
-    expect(details[0].info.rdns).toBe(CONNECT_EVM_EIP6963_RDNS);
+    expect(details).toHaveLength(0);
   });
 
   it('re-announces the same SDK provider detail on later EIP-6963 provider requests', async () => {

--- a/packages/connect-evm/src/eip6963.ts
+++ b/packages/connect-evm/src/eip6963.ts
@@ -34,6 +34,7 @@ export const CONNECT_EVM_EIP6963_RDNS = 'io.metamask.mmc';
 export const METAMASK_EIP6963_RDNS = [
   'io.metamask',
   'io.metamask.mobile',
+  'io.metamask.flask',
 ] as const;
 
 /**
@@ -232,8 +233,8 @@ const hasNativeMetaMaskProvider = async (): Promise<boolean> => {
  * Announces an MMConnect-managed EIP-1193 provider through EIP-6963.
  *
  * Announcement is best-effort and browser-only. Native MetaMask providers with
- * `io.metamask` or `io.metamask.mobile` suppress this SDK provider to avoid
- * duplicate MetaMask entries in wallet pickers.
+ * `io.metamask`, `io.metamask.mobile`, or `io.metamask.flask` suppress this SDK
+ * provider to avoid duplicate MetaMask entries in wallet pickers.
  */
 export class EIP6963ProviderAnnouncer {
   /** EIP-1193 provider exposed in EIP-6963 announcements. */

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Recognize MetaMask Flask (`io.metamask.flask`) as a native MetaMask extension in EIP-6963 detection. `hasExtension()` now returns `true` when only Flask is installed, so `connect()` uses the browser extension transport instead of falling back to the MWP/QR flow. ([#336](https://github.com/MetaMask/connect-monorepo/pull/336))
 - Closing the QR code / install modal mid-connection now emits `mmconnect_connection_rejected` instead of `mmconnect_connection_failed`. Modal close is a user-driven cancellation; it previously rejected with a plain `Error('User closed modal')` that `isRejectionError` did not recognise, so user cancellations polluted the `_failed` bucket. The close handler now rejects with the canonical EIP-1193 `4001` error (`providerErrors.userRejectedRequest()`). Genuine errors (transport timeouts/disconnects, wallet RPC errors) still emit `mmconnect_connection_failed`. ([#333](https://github.com/MetaMask/connect-monorepo/pull/333))
 
 ## [1.1.0]

--- a/packages/connect-multichain/src/domain/platform/index.test.ts
+++ b/packages/connect-multichain/src/domain/platform/index.test.ts
@@ -93,7 +93,7 @@ describe('hasExtension', () => {
     await expect(detection).resolves.toBe(true);
   });
 
-  it.each(['io.metamask', 'io.metamask.mobile'])(
+  it.each(['io.metamask', 'io.metamask.mobile', 'io.metamask.flask'])(
     'treats native MetaMask rdns %s as the extension',
     async (rdns) => {
       setupEip6963Window(rdns);

--- a/packages/connect-multichain/src/domain/platform/index.ts
+++ b/packages/connect-multichain/src/domain/platform/index.ts
@@ -21,6 +21,7 @@ export enum PlatformType {
 const NATIVE_METAMASK_EIP6963_RDNS = new Set([
   'io.metamask',
   'io.metamask.mobile',
+  'io.metamask.flask',
 ]);
 
 function isNotBrowser(): boolean {

--- a/playground/browser-playground/src/wagmi/metamask-connector.ts
+++ b/playground/browser-playground/src/wagmi/metamask-connector.ts
@@ -95,7 +95,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'metaMaskSDK',
     name: 'MetaMask',
-    rdns: ['io.metamask', 'io.metamask.mobile'],
+    rdns: ['io.metamask', 'io.metamask.mobile', 'io.metamask.flask'],
     type: metaMask.type,
     async connect({ chainId = 1, isReconnecting, withCapabilities } = {}) {
       const instance = await this.getInstance();

--- a/playground/react-native-playground/src/wagmi/metamask-connector.ts
+++ b/playground/react-native-playground/src/wagmi/metamask-connector.ts
@@ -95,7 +95,7 @@ export function metaMask(parameters: MetaMaskParameters = {}) {
   return createConnector<Provider, Properties>((config) => ({
     id: 'metaMaskSDK',
     name: 'MetaMask',
-    rdns: ['io.metamask', 'io.metamask.mobile'],
+    rdns: ['io.metamask', 'io.metamask.mobile', 'io.metamask.flask'],
     type: metaMask.type,
     async connect({ chainId = 1, isReconnecting, withCapabilities } = {}) {
       const instance = await this.getInstance();

--- a/skills/metamask-connect/references/troubleshooting.md
+++ b/skills/metamask-connect/references/troubleshooting.md
@@ -487,6 +487,16 @@ Add `connect-src` entries for any custom RPC endpoints you pass to `supportedNet
 
 ---
 
+### 23. MetaMask Flask not detected as the extension (falls back to QR / mobile)
+
+**Cause:** Before this fix, MetaMask Connect only recognized the native MetaMask RDNS values `io.metamask` (production extension) and `io.metamask.mobile`. MetaMask **Flask** announces itself over EIP-6963 with `rdns: 'io.metamask.flask'`, which was not in the allowlist — so `hasExtension()` returned `false` when only Flask was installed, and `connect()` fell through to the MWP transport (QR code / mobile deeplink) instead of using the local Flask extension. (The legacy `@metamask/sdk` did recognize Flask, which is why this looked like a regression.)
+
+**Fix:** `io.metamask.flask` is now included in the recognized native MetaMask RDNS values (extension detection, the connect-evm EIP-6963 announcement suppression, and the wagmi `metaMask()` connector's `rdns`). With a current version, Flask connects through the browser extension transport just like the production extension — no extra configuration needed.
+
+If you are pinned to an older version and cannot upgrade, the workaround is to connect through wagmi's built-in EIP-6963 auto-discovery: Flask shows up as a separate connector whose `id` is its rdns, `io.metamask.flask`. Selecting that connector talks directly to the Flask injected provider, but note it bypasses the MetaMask Connect SDK (no MWP fallback, no Connect session handling).
+
+---
+
 ## Diagnostic Checklist
 
 Run through this checklist when any MetaMask Connect integration is misbehaving:

--- a/skills/metamask-connect/workflows/migrate-wagmi-connector.md
+++ b/skills/metamask-connect/workflows/migrate-wagmi-connector.md
@@ -270,7 +270,7 @@ metaMask({
 
 - `@metamask/connect-evm` is an **optional peer dependency** of `@wagmi/connectors` — you only need it if you use the `metaMask()` connector
 - The connector ID remains `'metaMaskSDK'` and the name remains `'MetaMask'` — no changes to connector identity
-- The connector's `rdns` is `['io.metamask', 'io.metamask.mobile']` — unchanged
+- The connector's `rdns` is `['io.metamask', 'io.metamask.mobile', 'io.metamask.flask']` — MetaMask Flask is recognized as a native install, so it connects through the extension transport like the production extension (the legacy `@metamask/sdk` also recognized Flask)
 - The `supportedNetworks` map is now auto-built from wagmi's configured chains and their default RPC URLs — you no longer need to pass `readonlyRPCMap`
 - The `dappMetadata` parameter still works (it's mapped to `dapp` internally) but is deprecated — migrate to `dapp` for forward compatibility
 - The `logging` parameter still works (mapped to `debug: true`) but is deprecated

--- a/skills/metamask-connect/workflows/setup-wagmi-connector.md
+++ b/skills/metamask-connect/workflows/setup-wagmi-connector.md
@@ -293,7 +293,7 @@ Ensure React Native polyfills are set up per [../references/react-native.md](../
 ## Important Notes
 
 - The connector ID is `'metaMaskSDK'` and the display name is `'MetaMask'`
-- The connector RDNS is `['io.metamask', 'io.metamask.mobile']`
+- The connector RDNS is `['io.metamask', 'io.metamask.mobile', 'io.metamask.flask']` — MetaMask Flask (`io.metamask.flask`) is recognized as a native MetaMask install, so the connector uses the extension transport for Flask just like the production extension
 - `@metamask/connect-evm` is an optional peer dependency of `@wagmi/connectors` — only needed when you use the `metaMask()` connector, and the installed version must satisfy wagmi's declared peer range (currently `^2.1.0`), not "latest"
 - The `supportedNetworks` map is auto-built from wagmi chain config — no manual RPC URL configuration needed
 - If no `dapp` config is provided, defaults to `{ name: window.location.hostname, url: window.location.href }` in browsers


### PR DESCRIPTION
## Explanation

MetaMask Connect only treated `io.metamask` (production extension) and `io.metamask.mobile` as native MetaMask EIP-6963 providers. **MetaMask Flask** announces itself with `rdns: 'io.metamask.flask'`, which was missing from every allowlist. As a result `hasExtension()` returned `false` when only Flask was installed, so `MetaMaskConnectMultichain.connect()` fell through to the MWP transport (QR code / mobile deeplink) instead of using the locally-installed Flask extension — even though the browser `postMessage` transport (`metamask-contentscript`) works with Flask just fine. The legacy `@metamask/sdk` recognized Flask (`METAMASK_EIP_6369_PROVIDER_INFO.RDNS = ['io.metamask', 'io.metamask.flask']`), so to consumers this looked like a regression.

This surfaced during a live-stream dApp build that migrated to MetaMask Connect + wagmi while using Flask: the connection only worked after manually selecting wagmi's auto-discovered `io.metamask.flask` connector, which bypasses the Connect SDK entirely.

### What changed

**Primary fix** — add `io.metamask.flask` to the recognized native MetaMask RDNS values in the three places that gate Flask:

- `packages/connect-multichain/src/domain/platform/index.ts` — `NATIVE_METAMASK_EIP6963_RDNS` (drives `hasExtension()`, which selects the extension vs MWP transport).
- `packages/connect-evm/src/eip6963.ts` — `METAMASK_EIP6963_RDNS` (announce-suppression so the SDK doesn't announce a duplicate MetaMask entry alongside Flask).
- `integrations/wagmi/metamask-connector.ts` — the `metaMask()` connector's `rdns` (plus the two playground copies for parity).

**Docs (nice-to-have)** — the `metamask-connect` skill never mentioned Flask. Added a troubleshooting entry, updated the wagmi setup/migration notes, and fixed related doc comments + the connect-evm README.

### Result

With only Flask installed on desktop web, the Connect connector now uses the browser extension transport (no QR/MWP fallback) and connects like the production extension.

## References

- WAPI-1559
- Legacy behavior: `@metamask/sdk` `packages/sdk/src/constants.ts` (`METAMASK_EIP_6369_PROVIDER_INFO.RDNS`)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes