### PR TITLE
fix: escape regex metacharacters when building changelog link pattern

### DIFF
--- a/scripts/bump-dependent-playgrounds.ts
+++ b/scripts/bump-dependent-playgrounds.ts
@@ -203,6 +203,17 @@ async function bumpPlaygroundIfNeeded(
 }
 
 /**
+ * Escapes regular-expression metacharacters so a string can be safely embedded
+ * in a dynamically-constructed `RegExp`.
+ *
+ * @param value - The raw string to escape.
+ * @returns The string with all regex metacharacters escaped.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+/**
  * Updates the CHANGELOG.md file for a playground package.
  *
  * @param playgroundPath - The path to the playground package.
@@ -238,7 +249,7 @@ ${depsList}
 
   // Update the links at the bottom
   const unreleasedLinkPattern = new RegExp(
-    `\\[Unreleased\\]: (https://github\\.com/MetaMask/connect-monorepo/compare/${packageName.replace(/\//gu, '\\/')}@)[\\d.]+\\.\\.\\.HEAD`,
+    `\\[Unreleased\\]: (https://github\\.com/MetaMask/connect-monorepo/compare/${escapeRegExp(packageName)}@)[\\d.]+\\.\\.\\.HEAD`,
     'u',
   );
 


### PR DESCRIPTION
## Description

Resolves CodeQL [`js/incomplete-sanitization`](https://github.com/MetaMask/connect-monorepo/security/code-scanning/35) (high) in `scripts/bump-dependent-playgrounds.ts`.

`packageName` is interpolated into a dynamically-constructed `RegExp`, but it was only run through `.replace(/\//gu, '\\/')` — which escapes forward slashes and leaves backslashes and other regex metacharacters unescaped. This replaces the ad-hoc escape with a proper `escapeRegExp` helper.

This is a pre-existing issue on `main` (independent of the repo rename in #267). Splitting it out into its own PR so the rename PR stays scoped to the rename.

## Changes

- Add an `escapeRegExp(value)` helper that escapes all regex metacharacters.
- Use it for `packageName` when building the `[Unreleased]` link pattern.

Behavior is unchanged for real package names (e.g. `@metamask/analytics`), which contain no regex metacharacters.

## Notes

- No functional change to the changelog-bumping output.
- `eslint` passes (verified via the pre-commit hook).