### PR TITLE
docs: link to the wallet-side Multichain API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Instead of the traditional EIP-1193 model (`eth_requestAccounts` on one chain at
 
 This means a dApp that supports both EVM and Solana doesn't need separate connection flows — one session covers both.
 
+> Looking for the **wallet-side** JSON-RPC contract (the `wallet_createSession` /
+> `wallet_invokeMethod` requests and responses underneath this SDK)? See the
+> [Multichain API reference](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/MULTICHAIN_API.md)
+> in `@metamask/multichain-api-middleware`, including how MetaMask currently
+> diverges from the latest CAIP-25.
+
 ## Integration Options
 
 There are two ways to integrate, depending on how much you want to adopt:


### PR DESCRIPTION
## Summary

Adds a one-paragraph pointer from the README's "The Multichain API" section to the new wallet-side [Multichain API reference](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/MULTICHAIN_API.md) in `@metamask/multichain-api-middleware`.

This SDK is the dapp-facing consumer of the Multichain API; the new doc covers the wallet-side JSON-RPC contract underneath it (`wallet_createSession` / `wallet_invokeMethod` inputs/outputs, supported methods, and divergences from the current CAIP-25). The pointer helps integrators who need to drop down a layer find it.

Depends on the companion `MetaMask/core` PR that adds `MULTICHAIN_API.md` (the link targets `main`, so it resolves once that merges).

## Test plan

- [x] Markdown renders; link points to the doc's eventual location on `core` `main`.