### PR TITLE
feat(connect-multichain): resolve wallet_getCapabilities locally on MWP (WAPI-1560)

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the cached `wallet_getSession` response (case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, or an older wallet that doesn't publish capabilities. ([#XXX](https://github.com/MetaMask/connect-monorepo/pull/XXX))
+
 ### Fixed
 
 - Recognize MetaMask Flask (`io.metamask.flask`) as a native MetaMask extension in EIP-6963 detection. `hasExtension()` now returns `true` when only Flask is installed, so `connect()` uses the browser extension transport instead of falling back to the MWP/QR flow. ([#336](https://github.com/MetaMask/connect-monorepo/pull/336))

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the cached `wallet_getSession` response (case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, or an older wallet that doesn't publish capabilities. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
+- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the transport's cached session (read cache-only via the new `MWPTransport.getCachedSession`, so a cache miss falls back to the deeplink immediately; case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, malformed params, or an older wallet that doesn't publish capabilities. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
 
 ### Fixed
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the cached `wallet_getSession` response (case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, or an older wallet that doesn't publish capabilities. ([#XXX](https://github.com/MetaMask/connect-monorepo/pull/XXX))
+- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the cached `wallet_getSession` response (case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, or an older wallet that doesn't publish capabilities. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
 
 ### Fixed
 

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the transport's cached session (read cache-only via the new `MWPTransport.getCachedSession`, so a cache miss falls back to the deeplink immediately; case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, malformed params, or an older wallet that doesn't publish capabilities. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
+- Resolve `wallet_getCapabilities` locally from the cached session on the MWP (mobile deeplink) transport, avoiding a deeplink round-trip. When the wallet publishes EIP-5792 capabilities in `sessionProperties.eip155Capabilities`, `RequestRouter` answers `wallet_getCapabilities` from the transport's cached session (read cache-only via the new `getCachedSession` accessor, so a cache miss falls back to the deeplink immediately; case-insensitive address/chain lookup) and falls back to the wallet on any miss, partial chain coverage, malformed params, or an older wallet that doesn't publish capabilities. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
+- Add optional `getCachedSession` to the exported `ExtendedTransport` type: a cache-only read of the stored `wallet_getSession` result that resolves `undefined` on a miss instead of issuing a live request (and never replays transport notifications). Implemented by the MWP transport; transports without a session cache simply omit it. ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
 
 ### Fixed
 

--- a/packages/connect-multichain/src/domain/multichain/api/constants.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/constants.ts
@@ -167,7 +167,11 @@ export const RPC_HANDLED_METHODS = new Set([
 ]);
 
 // Methods that are handled by the SDK directly
-export const SDK_HANDLED_METHODS = new Set(['eth_accounts', 'eth_chainId']);
+export const SDK_HANDLED_METHODS = new Set([
+  'eth_accounts',
+  'eth_chainId',
+  'wallet_getCapabilities',
+]);
 
 // EIP-1193 / legacy provider methods that bypass the multichain `wallet_invokeMethod`
 // envelope and are forwarded directly to the underlying transport's

--- a/packages/connect-multichain/src/domain/multichain/api/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { CaipChainId } from '@metamask/utils';
+import type { CaipChainId, Json } from '@metamask/utils';
 
 import type EIP155 from './eip155';
 
@@ -100,3 +100,26 @@ export type RPCResponse = {
   jsonrpc: string;
   result: unknown;
 };
+
+/**
+ * The `sessionProperties` key under which the wallet publishes EIP-5792
+ * capabilities for permitted EVM accounts (see MetaMask/core#9294).
+ */
+export const EIP155_CAPABILITIES_SESSION_PROPERTY = 'eip155Capabilities';
+
+/**
+ * EIP-5792 capabilities for a single account on a single chain, e.g.
+ * `{ atomic: { status: 'supported' } }`.
+ */
+export type Eip155ChainCapabilities = Record<string, Json>;
+
+/**
+ * EIP-5792 capabilities published in a session's `sessionProperties` under
+ * {@link EIP155_CAPABILITIES_SESSION_PROPERTY}. Keyed by EVM address (in the
+ * casing the wallet returned, typically checksummed), then by chain ID (hex),
+ * mirroring what `wallet_getCapabilities` resolves to per chain.
+ */
+export type Eip155Capabilities = Record<
+  string,
+  Record<string, Eip155ChainCapabilities>
+>;

--- a/packages/connect-multichain/src/domain/multichain/api/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/api/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { CaipChainId, Json } from '@metamask/utils';
+import type { CaipChainId, Hex, Json } from '@metamask/utils';
 
 import type EIP155 from './eip155';
 
@@ -111,7 +111,7 @@ export const EIP155_CAPABILITIES_SESSION_PROPERTY = 'eip155Capabilities';
  * EIP-5792 capabilities for a single account on a single chain, e.g.
  * `{ atomic: { status: 'supported' } }`.
  */
-export type Eip155ChainCapabilities = Record<string, Json>;
+export type Eip155ChainCapabilities = Record<Hex, Json>;
 
 /**
  * EIP-5792 capabilities published in a session's `sessionProperties` under
@@ -120,6 +120,6 @@ export type Eip155ChainCapabilities = Record<string, Json>;
  * mirroring what `wallet_getCapabilities` resolves to per chain.
  */
 export type Eip155Capabilities = Record<
-  string,
-  Record<string, Eip155ChainCapabilities>
+  Hex,
+  Record<Hex, Eip155ChainCapabilities>
 >;

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -146,6 +146,5 @@ export function getTransportType(type: string): TransportType {
 
 export * from './api/constants';
 export * from './api/infura';
-export { EIP155_CAPABILITIES_SESSION_PROPERTY } from './api/types';
-export type * from './api/types';
+export * from './api/types';
 export type * from './types';

--- a/packages/connect-multichain/src/domain/multichain/index.ts
+++ b/packages/connect-multichain/src/domain/multichain/index.ts
@@ -146,5 +146,6 @@ export function getTransportType(type: string): TransportType {
 
 export * from './api/constants';
 export * from './api/infura';
+export { EIP155_CAPABILITIES_SESSION_PROPERTY } from './api/types';
 export type * from './api/types';
 export type * from './types';

--- a/packages/connect-multichain/src/domain/multichain/types.ts
+++ b/packages/connect-multichain/src/domain/multichain/types.ts
@@ -3,6 +3,7 @@ import type {
   SessionRequest,
 } from '@metamask/mobile-wallet-protocol-core';
 import type {
+  SessionData,
   SessionProperties,
   Transport,
   TransportRequest,
@@ -16,7 +17,7 @@ import type { PlatformType } from '../platform';
 import type { StoreClient } from '../store';
 import type { RpcUrlsMap, Scope } from './api/types';
 
-export type { SessionData } from '@metamask/multichain-api-client';
+export type { SessionData };
 
 /**
  * Configuration settings for the dapp using the SDK.
@@ -169,6 +170,13 @@ export type ExtendedTransport = Omit<Transport, 'connect'> & {
   getActiveSession: () => Promise<Session | undefined>;
 
   getStoredPendingSessionRequest: () => Promise<SessionRequest | null>;
+
+  /**
+   * Reads the cached `wallet_getSession` result without issuing a live
+   * request to the wallet. Resolves `undefined` when nothing is cached.
+   * Optional: only transports that maintain a session cache implement it.
+   */
+  getCachedSession?: () => Promise<SessionData | undefined>;
 
   disconnect: (scopes: Scope[]) => Promise<void>;
 };

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -618,7 +618,14 @@ t.describe('RequestRouter', () => {
     const CAPS_MAINNET = { atomic: { status: 'supported' } };
     const CAPS_BASE = { atomic: { status: 'ready' } };
 
-    const buildSessionResponse = (eip155Capabilities: unknown) => ({
+    const buildSessionResponse = (
+      eip155Capabilities: unknown,
+    ): {
+      result: {
+        sessionScopes: Record<string, never>;
+        sessionProperties: { eip155Capabilities: unknown };
+      };
+    } => ({
       result: {
         sessionScopes: {},
         sessionProperties: { eip155Capabilities },
@@ -726,25 +733,28 @@ t.describe('RequestRouter', () => {
       },
     );
 
-    t.it('falls back to the wallet when the address is not cached', async () => {
-      const router = await createMwpRouter();
-      const options = getCapabilitiesOptions([
-        '0x0000000000000000000000000000000000000001',
-      ]);
-      mockTransport.request
-        .mockResolvedValueOnce(
-          buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
-        )
-        .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
+    t.it(
+      'falls back to the wallet when the address is not cached',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([
+          '0x0000000000000000000000000000000000000001',
+        ]);
+        mockTransport.request
+          .mockResolvedValueOnce(
+            buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+          )
+          .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
 
-      const result = await router.invokeMethod(options);
+        const result = await router.invokeMethod(options);
 
-      t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
-      t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
-        method: 'wallet_invokeMethod',
-        params: options,
-      });
-    });
+        t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
 
     t.it(
       'falls back to the wallet when the session has no eip155Capabilities (older wallet)',
@@ -770,7 +780,9 @@ t.describe('RequestRouter', () => {
     t.it('does not resolve locally for non-MWP transports', async () => {
       // `requestRouter` (from beforeEach) uses TransportType.Browser.
       const options = getCapabilitiesOptions([ADDRESS]);
-      mockTransport.request.mockResolvedValue({ result: { '0x1': CAPS_MAINNET } });
+      mockTransport.request.mockResolvedValue({
+        result: { '0x1': CAPS_MAINNET },
+      });
 
       const result = await requestRouter.invokeMethod(options);
 

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -612,4 +612,172 @@ t.describe('RequestRouter', () => {
       },
     );
   });
+
+  t.describe('wallet_getCapabilities local resolution (MWP)', () => {
+    const ADDRESS = '0x742C3cF9Af45f91B109a81EfEaf11535ECDe9571';
+    const CAPS_MAINNET = { atomic: { status: 'supported' } };
+    const CAPS_BASE = { atomic: { status: 'ready' } };
+
+    const buildSessionResponse = (eip155Capabilities: unknown) => ({
+      result: {
+        sessionScopes: {},
+        sessionProperties: { eip155Capabilities },
+      },
+    });
+
+    const createMwpRouter = async (): Promise<RequestRouter> => {
+      const requestRouterModule = await import('./requestRouter');
+      return new requestRouterModule.RequestRouter(
+        mockTransport,
+        mockRpcClient,
+        mockConfig,
+        TransportType.MWP,
+      );
+    };
+
+    const getCapabilitiesOptions = (params: unknown): InvokeMethodOptions => ({
+      scope: 'eip155:1' as Scope,
+      request: { method: 'wallet_getCapabilities', params },
+    });
+
+    t.it(
+      'resolves all chains from the cached session without hitting the wallet',
+      async () => {
+        const router = await createMwpRouter();
+        mockTransport.request.mockResolvedValue(
+          buildSessionResponse({
+            [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
+          }),
+        );
+
+        const result = await router.invokeMethod(
+          getCapabilitiesOptions([ADDRESS]),
+        );
+
+        t.expect(result).toStrictEqual({
+          '0x1': CAPS_MAINNET,
+          '0x2105': CAPS_BASE,
+        });
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
+          method: 'wallet_getSession',
+        });
+        t.expect(mockTransport.request).not.toHaveBeenCalledWith(
+          t.expect.objectContaining({ method: 'wallet_invokeMethod' }),
+        );
+      },
+    );
+
+    t.it('matches the address case-insensitively', async () => {
+      const router = await createMwpRouter();
+      mockTransport.request.mockResolvedValue(
+        buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+      );
+
+      const result = await router.invokeMethod(
+        getCapabilitiesOptions([ADDRESS.toLowerCase()]),
+      );
+
+      t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+    });
+
+    t.it('filters to the requested chain ids (case-insensitive)', async () => {
+      const router = await createMwpRouter();
+      mockTransport.request.mockResolvedValue(
+        buildSessionResponse({
+          [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
+        }),
+      );
+
+      const result = await router.invokeMethod(
+        getCapabilitiesOptions([ADDRESS, ['0x2105']]),
+      );
+
+      t.expect(result).toStrictEqual({ '0x2105': CAPS_BASE });
+      t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+    });
+
+    t.it(
+      'falls back to the wallet when a requested chain is not cached',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([ADDRESS, ['0xa']]);
+        mockTransport.request
+          .mockResolvedValueOnce(
+            buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+          )
+          .mockResolvedValueOnce({ result: { '0xa': CAPS_BASE } });
+
+        const result = await router.invokeMethod(options);
+
+        t.expect(result).toStrictEqual({ '0xa': CAPS_BASE });
+        t.expect(mockTransport.request).toHaveBeenNthCalledWith(1, {
+          method: 'wallet_getSession',
+        });
+        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
+
+    t.it('falls back to the wallet when the address is not cached', async () => {
+      const router = await createMwpRouter();
+      const options = getCapabilitiesOptions([
+        '0x0000000000000000000000000000000000000001',
+      ]);
+      mockTransport.request
+        .mockResolvedValueOnce(
+          buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+        )
+        .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
+
+      const result = await router.invokeMethod(options);
+
+      t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+      t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+        method: 'wallet_invokeMethod',
+        params: options,
+      });
+    });
+
+    t.it(
+      'falls back to the wallet when the session has no eip155Capabilities (older wallet)',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([ADDRESS]);
+        mockTransport.request
+          .mockResolvedValueOnce({
+            result: { sessionScopes: {}, sessionProperties: {} },
+          })
+          .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
+
+        const result = await router.invokeMethod(options);
+
+        t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
+
+    t.it('does not resolve locally for non-MWP transports', async () => {
+      // `requestRouter` (from beforeEach) uses TransportType.Browser.
+      const options = getCapabilitiesOptions([ADDRESS]);
+      mockTransport.request.mockResolvedValue({ result: { '0x1': CAPS_MAINNET } });
+
+      const result = await requestRouter.invokeMethod(options);
+
+      t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+      t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+      t.expect(mockTransport.request).toHaveBeenCalledWith({
+        method: 'wallet_invokeMethod',
+        params: options,
+      });
+      t.expect(mockTransport.request).not.toHaveBeenCalledWith({
+        method: 'wallet_getSession',
+      });
+    });
+  });
 });

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -35,6 +35,7 @@ t.describe('RequestRouter', () => {
     mockTransport = {
       request: t.vi.fn(),
       sendEip1193Message: t.vi.fn(),
+      getCachedSession: t.vi.fn(),
     };
     mockRpcClient = {
       request: t.vi.fn(),
@@ -618,18 +619,14 @@ t.describe('RequestRouter', () => {
     const CAPS_MAINNET = { atomic: { status: 'supported' } };
     const CAPS_BASE = { atomic: { status: 'ready' } };
 
-    const buildSessionResponse = (
+    const buildSession = (
       eip155Capabilities: unknown,
     ): {
-      result: {
-        sessionScopes: Record<string, never>;
-        sessionProperties: { eip155Capabilities: unknown };
-      };
+      sessionScopes: Record<string, never>;
+      sessionProperties: { eip155Capabilities: unknown };
     } => ({
-      result: {
-        sessionScopes: {},
-        sessionProperties: { eip155Capabilities },
-      },
+      sessionScopes: {},
+      sessionProperties: { eip155Capabilities },
     });
 
     const createMwpRouter = async (): Promise<RequestRouter> => {
@@ -651,8 +648,8 @@ t.describe('RequestRouter', () => {
       'resolves all chains from the cached session without hitting the wallet',
       async () => {
         const router = await createMwpRouter();
-        mockTransport.request.mockResolvedValue(
-          buildSessionResponse({
+        mockTransport.getCachedSession.mockResolvedValue(
+          buildSession({
             [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
           }),
         );
@@ -665,20 +662,15 @@ t.describe('RequestRouter', () => {
           '0x1': CAPS_MAINNET,
           '0x2105': CAPS_BASE,
         });
-        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
-        t.expect(mockTransport.request).toHaveBeenCalledWith({
-          method: 'wallet_getSession',
-        });
-        t.expect(mockTransport.request).not.toHaveBeenCalledWith(
-          t.expect.objectContaining({ method: 'wallet_invokeMethod' }),
-        );
+        // A local hit produces no relay traffic at all.
+        t.expect(mockTransport.request).not.toHaveBeenCalled();
       },
     );
 
     t.it('matches the address case-insensitively', async () => {
       const router = await createMwpRouter();
-      mockTransport.request.mockResolvedValue(
-        buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+      mockTransport.getCachedSession.mockResolvedValue(
+        buildSession({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
       );
 
       const result = await router.invokeMethod(
@@ -686,14 +678,15 @@ t.describe('RequestRouter', () => {
       );
 
       t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+      t.expect(mockTransport.request).not.toHaveBeenCalled();
     });
 
     t.it(
       'filters to the requested chain ids (case-insensitive) and returns the cached (normalized) chain key',
       async () => {
         const router = await createMwpRouter();
-        mockTransport.request.mockResolvedValue(
-          buildSessionResponse({
+        mockTransport.getCachedSession.mockResolvedValue(
+          buildSession({
             [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
           }),
         );
@@ -705,7 +698,7 @@ t.describe('RequestRouter', () => {
         );
 
         t.expect(result).toStrictEqual({ '0x2105': CAPS_BASE });
-        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).not.toHaveBeenCalled();
       },
     );
 
@@ -714,19 +707,18 @@ t.describe('RequestRouter', () => {
       async () => {
         const router = await createMwpRouter();
         const options = getCapabilitiesOptions([ADDRESS, ['0xa']]);
-        mockTransport.request
-          .mockResolvedValueOnce(
-            buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
-          )
-          .mockResolvedValueOnce({ result: { '0xa': CAPS_BASE } });
+        mockTransport.getCachedSession.mockResolvedValue(
+          buildSession({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+        );
+        mockTransport.request.mockResolvedValueOnce({
+          result: { '0xa': CAPS_BASE },
+        });
 
         const result = await router.invokeMethod(options);
 
         t.expect(result).toStrictEqual({ '0xa': CAPS_BASE });
-        t.expect(mockTransport.request).toHaveBeenNthCalledWith(1, {
-          method: 'wallet_getSession',
-        });
-        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
           method: 'wallet_invokeMethod',
           params: options,
         });
@@ -740,16 +732,18 @@ t.describe('RequestRouter', () => {
         const options = getCapabilitiesOptions([
           '0x0000000000000000000000000000000000000001',
         ]);
-        mockTransport.request
-          .mockResolvedValueOnce(
-            buildSessionResponse({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
-          )
-          .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
+        mockTransport.getCachedSession.mockResolvedValue(
+          buildSession({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+        );
+        mockTransport.request.mockResolvedValueOnce({
+          result: { '0x1': CAPS_MAINNET },
+        });
 
         const result = await router.invokeMethod(options);
 
         t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
-        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
           method: 'wallet_invokeMethod',
           params: options,
         });
@@ -761,21 +755,118 @@ t.describe('RequestRouter', () => {
       async () => {
         const router = await createMwpRouter();
         const options = getCapabilitiesOptions([ADDRESS]);
-        mockTransport.request
-          .mockResolvedValueOnce({
-            result: { sessionScopes: {}, sessionProperties: {} },
-          })
-          .mockResolvedValueOnce({ result: { '0x1': CAPS_MAINNET } });
+        mockTransport.getCachedSession.mockResolvedValue({
+          sessionScopes: {},
+          sessionProperties: {},
+        });
+        mockTransport.request.mockResolvedValueOnce({
+          result: { '0x1': CAPS_MAINNET },
+        });
 
         const result = await router.invokeMethod(options);
 
         t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
-        t.expect(mockTransport.request).toHaveBeenNthCalledWith(2, {
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
           method: 'wallet_invokeMethod',
           params: options,
         });
       },
     );
+
+    t.it(
+      'falls back immediately when nothing is cached (no live wallet_getSession)',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([ADDRESS]);
+        mockTransport.getCachedSession.mockResolvedValue(undefined);
+        mockTransport.request.mockResolvedValueOnce({
+          result: { '0x1': CAPS_MAINNET },
+        });
+
+        const result = await router.invokeMethod(options);
+
+        t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
+
+    t.it(
+      'falls back when the transport has no getCachedSession accessor',
+      async () => {
+        delete mockTransport.getCachedSession;
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([ADDRESS]);
+        mockTransport.request.mockResolvedValueOnce({
+          result: { '0x1': CAPS_MAINNET },
+        });
+
+        const result = await router.invokeMethod(options);
+
+        t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    t.it(
+      'falls back (does not throw) when the address param is not a string',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([12345]);
+        mockTransport.request.mockResolvedValueOnce({ result: {} });
+
+        await t.expect(router.invokeMethod(options)).resolves.toStrictEqual({});
+
+        t.expect(mockTransport.getCachedSession).not.toHaveBeenCalled();
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
+
+    t.it(
+      'falls back when chainIds is not an array instead of returning all cached capabilities',
+      async () => {
+        const router = await createMwpRouter();
+        const options = getCapabilitiesOptions([ADDRESS, {}]);
+        mockTransport.getCachedSession.mockResolvedValue(
+          buildSession({
+            [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
+          }),
+        );
+        mockTransport.request.mockResolvedValueOnce({ result: {} });
+
+        const result = await router.invokeMethod(options);
+
+        // Must NOT be the full cached map — the wallet decides how to answer
+        // malformed params.
+        t.expect(result).toStrictEqual({});
+        t.expect(mockTransport.request).toHaveBeenCalledWith({
+          method: 'wallet_invokeMethod',
+          params: options,
+        });
+      },
+    );
+
+    t.it('falls back when chainIds contains a non-string entry', async () => {
+      const router = await createMwpRouter();
+      const options = getCapabilitiesOptions([ADDRESS, [42]]);
+      mockTransport.getCachedSession.mockResolvedValue(
+        buildSession({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
+      );
+      mockTransport.request.mockResolvedValueOnce({ result: {} });
+
+      await t.expect(router.invokeMethod(options)).resolves.toStrictEqual({});
+      t.expect(mockTransport.request).toHaveBeenCalledWith({
+        method: 'wallet_invokeMethod',
+        params: options,
+      });
+    });
 
     t.it('does not resolve locally for non-MWP transports', async () => {
       // `requestRouter` (from beforeEach) uses TransportType.Browser.
@@ -787,13 +878,11 @@ t.describe('RequestRouter', () => {
       const result = await requestRouter.invokeMethod(options);
 
       t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
+      t.expect(mockTransport.getCachedSession).not.toHaveBeenCalled();
       t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
       t.expect(mockTransport.request).toHaveBeenCalledWith({
         method: 'wallet_invokeMethod',
         params: options,
-      });
-      t.expect(mockTransport.request).not.toHaveBeenCalledWith({
-        method: 'wallet_getSession',
       });
     });
   });

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -681,21 +681,26 @@ t.describe('RequestRouter', () => {
       t.expect(result).toStrictEqual({ '0x1': CAPS_MAINNET });
     });
 
-    t.it('filters to the requested chain ids (case-insensitive)', async () => {
-      const router = await createMwpRouter();
-      mockTransport.request.mockResolvedValue(
-        buildSessionResponse({
-          [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
-        }),
-      );
+    t.it(
+      'filters to the requested chain ids (case-insensitive) and returns the cached (normalized) chain key',
+      async () => {
+        const router = await createMwpRouter();
+        mockTransport.request.mockResolvedValue(
+          buildSessionResponse({
+            [ADDRESS]: { '0x1': CAPS_MAINNET, '0x2105': CAPS_BASE },
+          }),
+        );
 
-      const result = await router.invokeMethod(
-        getCapabilitiesOptions([ADDRESS, ['0x2105']]),
-      );
+        // Caller passes an upper-cased chain id; the result must be keyed with
+        // the wallet's cached lowercase key, matching the wallet-fallback path.
+        const result = await router.invokeMethod(
+          getCapabilitiesOptions([ADDRESS, ['0x2105'.toUpperCase()]]),
+        );
 
-      t.expect(result).toStrictEqual({ '0x2105': CAPS_BASE });
-      t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
-    });
+        t.expect(result).toStrictEqual({ '0x2105': CAPS_BASE });
+        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
+      },
+    );
 
     t.it(
       'falls back to the wallet when a requested chain is not cached',

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.test.ts
@@ -703,25 +703,18 @@ t.describe('RequestRouter', () => {
     );
 
     t.it(
-      'falls back to the wallet when a requested chain is not cached',
+      'does not fall back to the wallet when a requested chain is not cached and returns an empty object',
       async () => {
         const router = await createMwpRouter();
         const options = getCapabilitiesOptions([ADDRESS, ['0xa']]);
         mockTransport.getCachedSession.mockResolvedValue(
           buildSession({ [ADDRESS]: { '0x1': CAPS_MAINNET } }),
         );
-        mockTransport.request.mockResolvedValueOnce({
-          result: { '0xa': CAPS_BASE },
-        });
 
         const result = await router.invokeMethod(options);
 
-        t.expect(result).toStrictEqual({ '0xa': CAPS_BASE });
-        t.expect(mockTransport.request).toHaveBeenCalledTimes(1);
-        t.expect(mockTransport.request).toHaveBeenCalledWith({
-          method: 'wallet_invokeMethod',
-          params: options,
-        });
+        t.expect(result).toStrictEqual({});
+        t.expect(mockTransport.request).not.toHaveBeenCalled();
       },
     );
 

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -92,11 +92,12 @@ export class RequestRouter {
    * Attempts to resolve `wallet_getCapabilities` from the cached session's
    * `eip155Capabilities` (published by the wallet in `sessionProperties`).
    *
-   * The read goes through `transport.request({ method: 'wallet_getSession' })`,
-   * which the MWP transport serves from its local cache without a deeplink.
-   * Returns `undefined` (so the caller falls back to the wallet) when the data
-   * isn't available for the requested address/chains, e.g. against a wallet
-   * that predates capability publishing.
+   * The read uses the transport's cache-only `getCachedSession` accessor, so
+   * a cache miss falls back to the wallet immediately instead of waiting on a
+   * relay request that a backgrounded wallet may never answer. Returns
+   * `undefined` (so the caller falls back to the wallet) when the data isn't
+   * available for the requested address/chains, e.g. against a wallet that
+   * predates capability publishing.
    *
    * @param options - The invoke method options for `wallet_getCapabilities`.
    * The `request.params` are `[address]` or `[address, chainIds]`.
@@ -105,22 +106,33 @@ export class RequestRouter {
   async #tryLocalCapabilities(
     options: InvokeMethodOptions,
   ): Promise<Json | undefined> {
-    const params = options.request.params as [string, string[]?] | undefined;
-    const address = params?.[0];
-    if (!address) {
+    const { params } = options.request;
+    if (!Array.isArray(params)) {
       return undefined;
     }
-    const requestedChainIds = params?.[1];
+    const [address, rawChainIds] = params as [unknown, unknown?];
+    if (typeof address !== 'string' || address.length === 0) {
+      return undefined;
+    }
+    // Malformed chain ids (non-array, or non-string entries): fall back so
+    // the wallet answers with a proper invalid-params error instead of the
+    // cache guessing (a non-array second param must NOT resolve to the full
+    // cached capability map).
+    if (
+      rawChainIds !== undefined &&
+      (!Array.isArray(rawChainIds) ||
+        rawChainIds.some((chainId) => typeof chainId !== 'string'))
+    ) {
+      return undefined;
+    }
+    const requestedChainIds = rawChainIds as string[] | undefined;
 
+    if (!this.transport.getCachedSession) {
+      return undefined;
+    }
     let sessionResult: SessionData | undefined;
     try {
-      const sessionResponse = await this.transport.request({
-        method: 'wallet_getSession',
-      });
-      if (sessionResponse.error) {
-        return undefined;
-      }
-      sessionResult = sessionResponse.result as SessionData | undefined;
+      sessionResult = await this.transport.getCachedSession();
     } catch {
       return undefined;
     }

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -4,6 +4,7 @@
 /* eslint-disable jsdoc/require-returns -- Auto-generated JSDoc */
 /* eslint-disable @typescript-eslint/no-misused-promises -- setTimeout callback is async intentionally */
 import { analytics } from '@metamask/analytics';
+import type { SessionData } from '@metamask/multichain-api-client';
 import type { Json } from '@metamask/utils';
 
 import {
@@ -11,6 +12,9 @@ import {
   METAMASK_DEEPLINK_BASE,
 } from '../../config';
 import {
+  EIP155_CAPABILITIES_SESSION_PROPERTY,
+  type Eip155Capabilities,
+  type Eip155ChainCapabilities,
   EIP1193_PASSTHROUGH_METHODS,
   type ExtendedTransport,
   type InvokeMethodOptions,
@@ -18,7 +22,7 @@ import {
   type MultichainOptions,
   RPC_HANDLED_METHODS,
   SDK_HANDLED_METHODS,
-  type TransportType,
+  TransportType,
 } from '../../domain';
 import { openDeeplink } from '../utils';
 import {
@@ -59,6 +63,19 @@ export class RequestRouter {
    */
   async invokeMethod(options: InvokeMethodOptions): Promise<Json> {
     const { method } = options.request;
+    // On the MWP (mobile deeplink) transport, try to resolve
+    // `wallet_getCapabilities` from the cached session's `eip155Capabilities`
+    // so we avoid an extra deeplink round-trip to the wallet. Falls back to the
+    // wallet on any miss (older wallet, unknown address/chain, cache error).
+    if (
+      method === 'wallet_getCapabilities' &&
+      this.transportType === TransportType.MWP
+    ) {
+      const localCapabilities = await this.#tryLocalCapabilities(options);
+      if (localCapabilities !== undefined) {
+        return localCapabilities;
+      }
+    }
     if (EIP1193_PASSTHROUGH_METHODS.has(method)) {
       return this.handleWithEip1193Passthrough(options);
     }
@@ -69,6 +86,83 @@ export class RequestRouter {
       return this.handleWithSdkState(options);
     }
     return this.handleWithWallet(options);
+  }
+
+  /**
+   * Attempts to resolve `wallet_getCapabilities` from the cached session's
+   * `eip155Capabilities` (published by the wallet in `sessionProperties`).
+   *
+   * The read goes through `transport.request({ method: 'wallet_getSession' })`,
+   * which the MWP transport serves from its local cache without a deeplink.
+   * Returns `undefined` (so the caller falls back to the wallet) when the data
+   * isn't available for the requested address/chains, e.g. against a wallet
+   * that predates capability publishing.
+   *
+   * @param options - The invoke method options for `wallet_getCapabilities`.
+   * The `request.params` are `[address]` or `[address, chainIds]`.
+   * @returns The resolved capabilities, or `undefined` on a cache miss.
+   */
+  async #tryLocalCapabilities(
+    options: InvokeMethodOptions,
+  ): Promise<Json | undefined> {
+    const params = options.request.params as
+      | [string, string[]?]
+      | undefined;
+    const address = params?.[0];
+    if (!address) {
+      return undefined;
+    }
+    const requestedChainIds = params?.[1];
+
+    let sessionResult: SessionData | undefined;
+    try {
+      const sessionResponse = await this.transport.request({
+        method: 'wallet_getSession',
+      });
+      if (sessionResponse.error) {
+        return undefined;
+      }
+      sessionResult = sessionResponse.result as SessionData | undefined;
+    } catch {
+      return undefined;
+    }
+
+    const capabilitiesByAddress = sessionResult?.sessionProperties?.[
+      EIP155_CAPABILITIES_SESSION_PROPERTY
+    ] as Eip155Capabilities | undefined;
+    if (!capabilitiesByAddress) {
+      return undefined;
+    }
+
+    // The wallet keys `eip155Capabilities` by the caveat's address casing
+    // (typically checksummed) while callers may pass any casing, so match
+    // case-insensitively.
+    const addressCapabilities = Object.entries(capabilitiesByAddress).find(
+      ([cachedAddress]) =>
+        cachedAddress.toLowerCase() === address.toLowerCase(),
+    )?.[1];
+    if (!addressCapabilities) {
+      return undefined;
+    }
+
+    if (!requestedChainIds || requestedChainIds.length === 0) {
+      return addressCapabilities as Json;
+    }
+
+    // If any requested chain isn't cached, fall back to the wallet rather than
+    // returning a partial result.
+    const filtered: Record<string, Eip155ChainCapabilities> = {};
+    for (const chainId of requestedChainIds) {
+      const chainEntry = Object.entries(addressCapabilities).find(
+        ([cachedChainId]) =>
+          cachedChainId.toLowerCase() === chainId.toLowerCase(),
+      );
+      if (!chainEntry) {
+        return undefined;
+      }
+      filtered[chainId] = chainEntry[1];
+    }
+    return filtered as Json;
   }
 
   /**

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -105,9 +105,7 @@ export class RequestRouter {
   async #tryLocalCapabilities(
     options: InvokeMethodOptions,
   ): Promise<Json | undefined> {
-    const params = options.request.params as
-      | [string, string[]?]
-      | undefined;
+    const params = options.request.params as [string, string[]?] | undefined;
     const address = params?.[0];
     if (!address) {
       return undefined;

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -150,7 +150,10 @@ export class RequestRouter {
     }
 
     // If any requested chain isn't cached, fall back to the wallet rather than
-    // returning a partial result.
+    // returning a partial result. Key the result with the wallet's cached chain
+    // ID casing (lowercase hex, as `wallet_getCapabilities` normalizes) rather
+    // than the caller-supplied casing, so a local hit and the wallet-fallback
+    // path return the same key shape.
     const filtered: Record<string, Eip155ChainCapabilities> = {};
     for (const chainId of requestedChainIds) {
       const chainEntry = Object.entries(addressCapabilities).find(
@@ -160,7 +163,7 @@ export class RequestRouter {
       if (!chainEntry) {
         return undefined;
       }
-      filtered[chainId] = chainEntry[1];
+      filtered[chainEntry[0]] = chainEntry[1];
     }
     return filtered as Json;
   }

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -170,9 +170,10 @@ export class RequestRouter {
         ([cachedChainId]) =>
           cachedChainId.toLowerCase() === chainId.toLowerCase(),
       );
-      if (chainEntry) {
-        filtered[chainEntry[0]] = chainEntry[1];
+      if (!chainEntry) {
+        return undefined;
       }
+      filtered[chainEntry[0]] = chainEntry[1];
     }
     return filtered as Json;
   }

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -63,19 +63,6 @@ export class RequestRouter {
    */
   async invokeMethod(options: InvokeMethodOptions): Promise<Json> {
     const { method } = options.request;
-    // On the MWP (mobile deeplink) transport, try to resolve
-    // `wallet_getCapabilities` from the cached session's `eip155Capabilities`
-    // so we avoid an extra deeplink round-trip to the wallet. Falls back to the
-    // wallet on any miss (older wallet, unknown address/chain, cache error).
-    if (
-      method === 'wallet_getCapabilities' &&
-      this.transportType === TransportType.MWP
-    ) {
-      const localCapabilities = await this.#tryLocalCapabilities(options);
-      if (localCapabilities !== undefined) {
-        return localCapabilities;
-      }
-    }
     if (EIP1193_PASSTHROUGH_METHODS.has(method)) {
       return this.handleWithEip1193Passthrough(options);
     }
@@ -385,6 +372,21 @@ export class RequestRouter {
   private async handleWithSdkState(
     options: InvokeMethodOptions,
   ): Promise<Json> {
+    // On the MWP (mobile deeplink) transport, try to resolve
+    // `wallet_getCapabilities` from the cached session's `eip155Capabilities`
+    // so we avoid an extra deeplink round-trip to the wallet. Falls back to the
+    // wallet on any miss (older wallet, unknown address/chain, cache error).
+    if (options.request.method === 'wallet_getCapabilities') {
+      if (this.transportType === TransportType.MWP) {
+        const localCapabilities = await this.#tryLocalCapabilities(options);
+        if (localCapabilities !== undefined) {
+          return localCapabilities;
+        }
+      }
+      // Fallback to wallet
+      return this.handleWithWallet(options);
+    }
+
     // TODO: to be implemented
     console.warn(
       `Method "${options.request.method}" is configured for SDK state handling, but this is not yet implemented. Falling back to wallet passthrough.`,

--- a/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
+++ b/packages/connect-multichain/src/multichain/rpc/requestRouter.ts
@@ -170,10 +170,9 @@ export class RequestRouter {
         ([cachedChainId]) =>
           cachedChainId.toLowerCase() === chainId.toLowerCase(),
       );
-      if (!chainEntry) {
-        return undefined;
+      if (chainEntry) {
+        filtered[chainEntry[0]] = chainEntry[1];
       }
-      filtered[chainEntry[0]] = chainEntry[1];
     }
     return filtered as Json;
   }

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -780,4 +780,35 @@ t.describe('MWPTransport', () => {
       },
     );
   });
+
+  t.describe('getCachedResponse for wallet_getSession', () => {
+    t.it(
+      'serves the cached session (including sessionProperties.eip155Capabilities) without hitting the wallet',
+      async () => {
+        const eip155Capabilities = {
+          '0x742C3cF9Af45f91B109a81EfEaf11535ECDe9571': {
+            '0x1': { atomic: { status: 'supported' } },
+          },
+        };
+        const cached = {
+          result: {
+            sessionScopes: {},
+            sessionProperties: { eip155Capabilities },
+          },
+        };
+        (mockKvstore.get as any).mockResolvedValue(JSON.stringify(cached));
+
+        const response: any = await transport.request({
+          method: 'wallet_getSession',
+        });
+
+        t.expect(mockKvstore.get).toHaveBeenCalledWith('cache_wallet_getSession');
+        t.expect(response.result.sessionProperties.eip155Capabilities).toStrictEqual(
+          eip155Capabilities,
+        );
+        // Served from cache, so nothing is sent to the wallet.
+        t.expect(mockDappClient.sendRequest).not.toHaveBeenCalled();
+      },
+    );
+  });
 });

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -802,10 +802,13 @@ t.describe('MWPTransport', () => {
           method: 'wallet_getSession',
         });
 
-        t.expect(mockKvstore.get).toHaveBeenCalledWith('cache_wallet_getSession');
-        t.expect(response.result.sessionProperties.eip155Capabilities).toStrictEqual(
-          eip155Capabilities,
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        t.expect(mockKvstore.get).toHaveBeenCalledWith(
+          'cache_wallet_getSession',
         );
+        t.expect(
+          response.result.sessionProperties.eip155Capabilities,
+        ).toStrictEqual(eip155Capabilities);
         // Served from cache, so nothing is sent to the wallet.
         t.expect(mockDappClient.sendRequest).not.toHaveBeenCalled();
       },

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -813,5 +813,40 @@ t.describe('MWPTransport', () => {
         t.expect(mockDappClient.sendRequest).not.toHaveBeenCalled();
       },
     );
+
+    t.it(
+      'getCachedSession returns the cached session without hitting the wallet or replaying notifications',
+      async () => {
+        const eip155Capabilities = {
+          '0x742C3cF9Af45f91B109a81EfEaf11535ECDe9571': {
+            '0x1': { atomic: { status: 'supported' } },
+          },
+        };
+        const cached = {
+          result: {
+            sessionScopes: {},
+            sessionProperties: { eip155Capabilities },
+          },
+        };
+        (mockKvstore.get as any).mockResolvedValue(JSON.stringify(cached));
+
+        const session = await transport.getCachedSession();
+
+        t.expect(session?.sessionProperties?.eip155Capabilities).toStrictEqual(
+          eip155Capabilities,
+        );
+        t.expect(mockDappClient.sendRequest).not.toHaveBeenCalled();
+      },
+    );
+
+    t.it(
+      'getCachedSession resolves undefined when nothing is cached',
+      async () => {
+        (mockKvstore.get as any).mockResolvedValue(null);
+
+        await t.expect(transport.getCachedSession()).resolves.toBeUndefined();
+        t.expect(mockDappClient.sendRequest).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -688,13 +688,8 @@ export class MWPTransport implements ExtendedTransport {
    * @returns Nothing
    */
   async disconnect(scopes: Scope[] = []): Promise<void> {
-    const cachedSession = await this.getCachedResponse({
-      jsonrpc: '2.0',
-      id: '0',
-      method: 'wallet_getSession',
-    });
-    const cachedSessionScopes =
-      (cachedSession?.result as SessionData | undefined)?.sessionScopes ?? {};
+    const cachedSession = await this.getCachedSession();
+    const cachedSessionScopes = cachedSession?.sessionScopes ?? {};
 
     const remainingScopes =
       scopes.length === 0

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -862,6 +862,24 @@ export class MWPTransport implements ExtendedTransport {
     }
   }
 
+  /**
+   * Reads the cached `wallet_getSession` result from the kvstore without
+   * issuing a live request to the wallet and without replaying transport
+   * notifications. Lets callers (e.g. local `wallet_getCapabilities`
+   * resolution) treat a cache miss as an immediate fallback instead of
+   * waiting on a relay request that a backgrounded wallet may never answer.
+   *
+   * @returns The cached session data, or `undefined` when nothing is cached.
+   */
+  async getCachedSession(): Promise<SessionData | undefined> {
+    const cached = await this.getCachedResponse({
+      jsonrpc: '2.0',
+      id: '0',
+      method: 'wallet_getSession',
+    });
+    return cached?.result as SessionData | undefined;
+  }
+
   async request<
     TRequest extends TransportRequest,
     TResponse extends TransportResponse,

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -723,10 +723,14 @@ export class MWPTransport implements ExtendedTransport {
     }
 
     if (remainingScopes.length > 0) {
+      // Preserve `sessionProperties` (e.g. the wallet-published EIP-5792
+      // `eip155Capabilities`) across a partial disconnect; rebuilding the
+      // cached session from only `sessionScopes` would otherwise drop them.
       this.kvstore.set(
         SESSION_STORE_KEY,
         JSON.stringify({
           result: {
+            ...cachedSession,
             sessionScopes: newSessionScopes,
           },
         }),

--- a/playground/browser-playground/CHANGELOG.md
+++ b/playground/browser-playground/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a `wallet_getCapabilities` button to the Legacy EVM card's read-only RPC calls, requesting EIP-5792 capabilities for the active account (scoped to the connected chain when available). ([#339](https://github.com/MetaMask/connect-monorepo/pull/339))
+
 ## [0.8.1]
 
 ### Changed

--- a/playground/browser-playground/src/components/LegacyEVMCard.tsx
+++ b/playground/browser-playground/src/components/LegacyEVMCard.tsx
@@ -72,6 +72,26 @@ export function LegacyEVMCard({
     }
   };
 
+  const wallet_getCapabilities = async () => {
+    if (!provider || !accounts[0]) {
+      setResponse('Provider or accounts not available');
+      return;
+    }
+    try {
+      const params = chainId
+        ? [accounts[0], [chainId]]
+        : [accounts[0]];
+      const result = await provider.request({
+        method: 'wallet_getCapabilities',
+        params,
+      });
+      setResponse(`Capabilities: ${JSON.stringify(result, null, 2)}`);
+    } catch (e) {
+      console.error('Error getting capabilities', e);
+      setResponse(`Error: ${e instanceof Error ? e.message : 'Unknown error'}`);
+    }
+  };
+
   const eth_gasPrice = async () => {
     if (!provider) {
       setResponse('Provider not available');
@@ -334,6 +354,14 @@ export function LegacyEVMCard({
               className="w-full bg-purple-500 text-white px-4 py-2 rounded text-sm hover:bg-purple-600 transition-colors"
             >
               eth_gasPrice
+            </button>
+            <button
+              type="button"
+              data-testid="legacy-evm-get-capabilities-button"
+              onClick={wallet_getCapabilities}
+              className="w-full bg-emerald-600 text-white px-4 py-2 rounded text-sm hover:bg-emerald-700 transition-colors"
+            >
+              wallet_getCapabilities
             </button>
           </div>
         </div>

--- a/playground/browser-playground/src/components/LegacyEVMCard.tsx
+++ b/playground/browser-playground/src/components/LegacyEVMCard.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import type { EIP1193Provider } from '@metamask/connect-evm';
 import { TEST_IDS } from '@metamask/playground-ui';
-import { send_eth_signTypedData_v4, send_personal_sign } from '../helpers/SignHelpers';
+import {
+  send_eth_signTypedData_v4,
+  send_personal_sign,
+} from '../helpers/SignHelpers';
 
 interface LegacyEVMCardProps {
   provider: EIP1193Provider;
@@ -78,9 +81,7 @@ export function LegacyEVMCard({
       return;
     }
     try {
-      const params = chainId
-        ? [accounts[0], [chainId]]
-        : [accounts[0]];
+      const params = chainId ? [accounts[0], [chainId]] : [accounts[0]];
       const result = await provider.request({
         method: 'wallet_getCapabilities',
         params,
@@ -191,9 +192,15 @@ export function LegacyEVMCard({
   };
 
   return (
-    <div data-testid={TEST_IDS.legacyEvm.card} className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow duration-200">
+    <div
+      data-testid={TEST_IDS.legacyEvm.card}
+      className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow duration-200"
+    >
       <div className="flex items-center justify-between mb-4">
-        <h3 data-testid={TEST_IDS.legacyEvm.title} className="text-lg font-semibold text-gray-800 truncate">
+        <h3
+          data-testid={TEST_IDS.legacyEvm.title}
+          className="text-lg font-semibold text-gray-800 truncate"
+        >
           Legacy EVM Connection
         </h3>
         <button
@@ -208,24 +215,43 @@ export function LegacyEVMCard({
 
       <div className="mb-4">
         <div className="flex items-center gap-2 mb-2">
-          <span data-testid={TEST_IDS.legacyEvm.chainIdLabel} className="text-sm font-medium text-gray-600">
+          <span
+            data-testid={TEST_IDS.legacyEvm.chainIdLabel}
+            className="text-sm font-medium text-gray-600"
+          >
             Connected Chain:
           </span>
-          <span data-testid={TEST_IDS.legacyEvm.chainIdValue} className="text-sm text-gray-500 bg-blue-50 text-blue-700 px-2 py-1 rounded-full">
+          <span
+            data-testid={TEST_IDS.legacyEvm.chainIdValue}
+            className="text-sm text-gray-500 bg-blue-50 text-blue-700 px-2 py-1 rounded-full"
+          >
             {chainId || 'Not available'}
           </span>
         </div>
 
         <div className="flex items-center gap-2 mb-2">
-          <span data-testid={TEST_IDS.legacyEvm.accountsLabel} className="text-sm font-medium text-gray-600">Accounts:</span>
-          <span data-testid={TEST_IDS.legacyEvm.accountsValue} className="text-sm text-gray-500 bg-blue-50 text-blue-700 px-2 py-1 rounded-full">
+          <span
+            data-testid={TEST_IDS.legacyEvm.accountsLabel}
+            className="text-sm font-medium text-gray-600"
+          >
+            Accounts:
+          </span>
+          <span
+            data-testid={TEST_IDS.legacyEvm.accountsValue}
+            className="text-sm text-gray-500 bg-blue-50 text-blue-700 px-2 py-1 rounded-full"
+          >
             {accounts.length} available
           </span>
         </div>
 
         {accounts.length > 0 && (
-          <div data-testid={TEST_IDS.legacyEvm.activeAccount} className="mt-2 p-3 bg-green-50 border border-green-200 rounded-md">
-            <p className="text-sm text-green-800 font-medium">Active Account:</p>
+          <div
+            data-testid={TEST_IDS.legacyEvm.activeAccount}
+            className="mt-2 p-3 bg-green-50 border border-green-200 rounded-md"
+          >
+            <p className="text-sm text-green-800 font-medium">
+              Active Account:
+            </p>
             <p className="text-sm text-green-700 font-mono break-all">
               {accounts[0]}
             </p>
@@ -234,11 +260,20 @@ export function LegacyEVMCard({
       </div>
 
       {response && (
-        <div data-testid={TEST_IDS.legacyEvm.responseContainer} className="mb-4 p-3 bg-gray-50 border border-gray-200 rounded-md">
-          <p data-testid={TEST_IDS.legacyEvm.responseLabel} className="text-sm font-medium text-gray-600 mb-1">
+        <div
+          data-testid={TEST_IDS.legacyEvm.responseContainer}
+          className="mb-4 p-3 bg-gray-50 border border-gray-200 rounded-md"
+        >
+          <p
+            data-testid={TEST_IDS.legacyEvm.responseLabel}
+            className="text-sm font-medium text-gray-600 mb-1"
+          >
             Last Response:
           </p>
-          <p data-testid={TEST_IDS.legacyEvm.responseText} className="text-sm text-gray-700 font-mono break-all">
+          <p
+            data-testid={TEST_IDS.legacyEvm.responseText}
+            className="text-sm text-gray-700 font-mono break-all"
+          >
             {String(response)}
           </p>
         </div>
@@ -326,7 +361,10 @@ export function LegacyEVMCard({
           Add Polygon Chain
         </button>
 
-        <div data-testid={TEST_IDS.legacyEvm.readOnlySection} className="mt-4 pt-4 border-t border-gray-200">
+        <div
+          data-testid={TEST_IDS.legacyEvm.readOnlySection}
+          className="mt-4 pt-4 border-t border-gray-200"
+        >
           <h4 className="text-sm font-medium text-gray-700 mb-2">
             Read-Only RPC Calls
           </h4>


### PR DESCRIPTION
## Explanation

On the MWP (mobile deeplink) transport, `wallet_getCapabilities` currently always routes to the wallet via `wallet_invokeMethod`, which schedules a deeplink round-trip (`RequestRouter.handleWithWallet`). For mobile dapps this is unnecessary friction whenever the wallet has already told us the account's EIP-5792 capabilities.

Core [#9294](https://github.com/MetaMask/core/pull/9294) makes the wallet publish those capabilities inside CAIP-25 session properties (`sessionProperties.eip155Capabilities`, keyed by EVM address → chain ID → capabilities) on `wallet_createSession` / `wallet_getSession` and on `wallet_sessionChanged`. This PR makes the SDK read that cached data and answer `wallet_getCapabilities` locally.

What changed:

- **`RequestRouter.invokeMethod`** gains a `wallet_getCapabilities` branch gated to `TransportType.MWP` that short-circuits **before** `handleWithWallet` (so the deeplink never fires). Extension/browser transport behavior is unchanged.
- **`#tryLocalCapabilities`** reads the cached session via `transport.request({ method: 'wallet_getSession' })` (served from the MWP cache, no deeplink), then does a **case-insensitive** address lookup (the wallet keys by caveat casing, typically checksummed) and per-chain filtering. It returns `undefined` — falling back to the wallet — on any miss: unknown address, a requested chain that isn't cached (no partial results), or an older wallet that doesn't publish `eip155Capabilities`.
- **Types**: added `EIP155_CAPABILITIES_SESSION_PROPERTY`, `Eip155Capabilities`, `Eip155ChainCapabilities` in the domain and exported them from the barrel. `SessionProperties` from `@metamask/multichain-api-client` is an open map, so no client dep bump is needed to read the field.

Cache freshness is already handled: `MWPTransport.handleMessage` persists incoming `wallet_sessionChanged` params under `SESSION_STORE_KEY`, so once the wallet includes `sessionProperties` there (see the mobile-side PR) the cached capabilities stay current automatically.

This is backward compatible: with no cached `eip155Capabilities`, it falls back to the existing deeplink path, so it's safe to land before any wallet ships the data.

Companion Mobile PR: https://github.com/MetaMask/metamask-mobile/pull/32660

### Video Demonstrating Cached Capabilities

A new `wallet_getCapabilities` button is added to the browser playground:

https://github.com/user-attachments/assets/950fe3e3-9420-45d2-848c-843fb2cfdb0e


## References

- Jira: WAPI-1560
- Wallet side (metamask-mobile): publishes `sessionProperties.eip155Capabilities` on session responses and `wallet_sessionChanged` (companion PR)
- Core: Related to MetaMask/core#9294

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<sub>Note: `connect-multichain` CHANGELOG updated under Unreleased; the PR link placeholder is filled in after creation.</sub>