### PR TITLE
feat: add @metamask/mwp-connect-bench private benchmark harness

### DIFF
--- a/playground/mwp-connect-bench/AGENTS.md
+++ b/playground/mwp-connect-bench/AGENTS.md
@@ -1,0 +1,134 @@
+# Agent guide: mwp-connect-bench
+
+Operational playbook for AI agents (and humans) running MWP connect-latency
+experiments with this harness. The [README](./README.md) explains what the
+harness is; this file is the "how to actually run it without stepping on the
+known landmines" guide. Everything below was learned running the first real
+A/B test (metamask-mobile#32475, July 2026).
+
+## What this measures (and what it doesn't)
+
+- **Measures**: wallet-side MWP connect-handshake latency
+  (`connect_start → connect_end`), session-resume latency and success, resume
+  contention inside connect windows, and (with `--with-request`) the approval
+  gate (`create_session_received − connect_start`).
+- **Does not measure**: dapp-side deeplink-open latency, time-to-modal-visible
+  (UI render), Android, physical devices, untrusted-mode handshakes.
+
+## Environment assumptions
+
+- macOS with Xcode; deeplinks are delivered with `xcrun simctl` — there is no
+  dependency on any private CLI.
+- Env overrides: `BENCH_SIM_DEVICE` (simulator UDID, default `booted`),
+  `BENCH_BUNDLE_ID` (default `io.metamask.MetaMask`; QA builds use
+  `io.metamask.MetaMask-QA`).
+- A booted simulator with MetaMask installed and **onboarded** (wallet
+  created). Transport-level metrics (connect/resume) are collected even while
+  the wallet is locked; approval-path metrics need it unlocked.
+- Run `yarn install` at the monorepo root first (this package needs
+  `eciesjs`).
+
+## Playbook A — quick check on a dev build (Metro attached)
+
+Use when a rough signal is enough and the branch difference is JS-only.
+
+1. In the metamask-mobile checkout, on the branch under test:
+   `git apply <this-dir>/patches/mwp-perf-instrumentation.patch`
+2. `yarn setup:expo`, then `yarn watch | tee arm-<name>.log` and
+   `yarn start:ios`.
+3. Seed the resume load once: `yarn seed` (18 sessions, persists in the sim).
+4. `yarn trial 8 30000` per arm; swap arms (see README); re-tee to a new log.
+5. `yarn analyze arm-control.log arm-pr.log`.
+
+**Caveat**: dev builds boot into the Expo dev-launcher on cold start, which
+swallows the deeplink — so dev-build trials are _not_ true cold starts. For
+cold-start-sensitive changes use Playbook B.
+
+## Playbook B — faithful cold-start A/B (Release build)
+
+This is the protocol that produced the #32475 numbers.
+
+1. Apply the instrumentation patch (as above) on the **control** arm's code
+   (usually `main` + the patch).
+2. Build a Release simulator app (embedded JS bundle, no Metro, no
+   dev-launcher):
+
+   ```bash
+   cd <metamask-mobile>/ios
+   xcodebuild -workspace MetaMask.xcworkspace -scheme MetaMask \
+     -configuration Release -sdk iphonesimulator -derivedDataPath build \
+     -destination 'platform=iOS Simulator,id=<UDID>' build
+   xcrun simctl install <UDID> build/Build/Products/Release-iphonesimulator/MetaMask.app
+   ```
+
+3. Onboard the wallet in the freshly installed app, then `yarn seed`.
+4. Rotate the on-device log, run the arm, collect:
+
+   ```bash
+   DATA=$(xcrun simctl get_app_container <UDID> <bundle-id> data)
+   rm -f "$DATA/Documents/mwp-perf.log"
+   yarn trial 8 40000        # allow extra settle time under throttle
+   sleep 45                  # let the last trial's resumes finish
+   cp "$DATA/Documents/mwp-perf.log" arm-<name>.log
+   ```
+
+5. Swap the arm (JS-only file swap per README), **re-run the xcodebuild from
+   step 2** (incremental, but required — there is no Metro to hot-reload, and
+   the bundle must be re-embedded), reinstall, repeat step 4.
+6. `yarn analyze arm-control.log arm-pr.log`.
+
+## Known pitfalls (each of these cost real time)
+
+- **Expo dev-launcher swallows cold-start deeplinks.** Dev-client builds are
+  unusable for cold-start trials. Use a Release build.
+- **`transform-remove-console` strips `console.*` in Release builds.** The
+  instrumentation survives via a bound `console.warn` alias and by appending
+  to `Documents/mwp-perf.log`. If you edit `mwp-perf.ts`, do not introduce a
+  direct `console.warn(...)` member call and expect it to survive Release.
+- **After swapping a JS file between arms you must rebuild.** An installed
+  Release app has the bundle baked in; verify the swap took effect by
+  checking `main.jsbundle`'s mtime inside the built `.app` before installing.
+- **Release builds are resource-hungry.** Tens of GB of intermediates in
+  `ios/build`, heavily parallel compile. Check free disk _and_ free memory
+  first; never run two xcodebuilds against the same `-derivedDataPath` (the
+  build DB locks, and interrupted builds can leave a hung build-service
+  process holding the lock — kill it by PID before retrying).
+- **Every trial persists a session.** The wallet caps at
+  `MAX_CONNECTIONS = 20` (oldest evicted). Keep the seeded count + trial
+  count consistent across arms so both resume the same load.
+- **One resume per trial can still land inside the connect window** on a
+  deferral arm: a resume already in flight when the deeplink arrives cannot
+  be preempted. `resume_start events inside a connect window` dropping to
+  ~1 per trial (not 0) is expected there.
+- **Give trials generous spacing** (`yarn trial <n> <ms>`): the connect
+  handshake plus ~20 sequential session resumes must finish before the next
+  terminate, or you bias the next trial. 30 s unthrottled, 40 s+ throttled.
+- **Network throttling amplifies the signal** (relay round-trips are what
+  contend). macOS Network Link Conditioner affects simulator traffic.
+  Verify the throttle is actually active before trusting a throttled run
+  (e.g. `curl -w '%{time_connect}'` against the relay host) — and turn it
+  off afterwards.
+
+## Interpreting analyze.mjs output
+
+- Compare **median / p75**, never means (relay latency is long-tailed).
+- `connects: N ok, 0 failed` and `resumes: M total, 0 failed` on **both**
+  arms are the safety/regression gates; a delta with failed resumes is
+  invalid.
+- On a warm unthrottled network with few sessions, a null result is normal —
+  contention fixes cut the tail, not the base case. Throttle and/or raise
+  the seeded-session count before concluding "no effect".
+
+## Extending the harness
+
+- **New timing hypothesis**: add `mwpPerf('<event>', id, {...})` call sites
+  to the instrumentation patch, then teach `analyze.mjs` the new event pair.
+  Events are JSON lines `{ event, id, t, ...extra }`; `t` is ms since JS
+  module load (per-session ordering only — never compare `t` across app
+  launches).
+- **Patch rot**: the patches target `connection.ts` as of July 2026. If
+  `git apply` fails, regenerate: add `mwp-perf.ts` (copy from the patch) and
+  wrap `Connection.create` / `connect` / `resume` with start/end events.
+  Keep `mwp-perf.ts` identical across all patch variants.
+- **Branches that refactor `connection.ts`** need their own patch variant
+  (see `mwp-perf-instrumentation.h1-32470.patch` as the template).

--- a/playground/mwp-connect-bench/CHANGELOG.md
+++ b/playground/mwp-connect-bench/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial benchmark harness for MetaMask Connect (MWP) deeplink connection latency against MetaMask Mobile: instrumentation patch, session seeder, cold-start trial runner, and log analyzer

--- a/playground/mwp-connect-bench/CHANGELOG.md
+++ b/playground/mwp-connect-bench/CHANGELOG.md
@@ -10,3 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial benchmark harness for MetaMask Connect (MWP) deeplink connection latency against MetaMask Mobile: instrumentation patch, session seeder, cold-start trial runner, and log analyzer
+- Approval-path measurement: `create_session_received` marker in the instrumentation, `--with-request` trial mode (inline `wallet_createSession`), and an "approval gate" metric in the analyzer — enables A/B of metamask-mobile#32470 (eager approval)
+- Dedicated instrumentation patch variant for metamask-mobile#32470's refactored `Connection` service, plus a per-PR measurement guide in the README

--- a/playground/mwp-connect-bench/README.md
+++ b/playground/mwp-connect-bench/README.md
@@ -11,20 +11,20 @@ any MWP connect-latency experiment (see WAPI-1564 for the broader latency
 investigation).
 
 The rig uses real Safari/WebKit and real relay traffic. Simulator caveat: your
-Mac's CPU is faster than device-class hardware, which *underestimates*
+Mac's CPU is faster than device-class hardware, which _underestimates_
 contention effects — if a measured delta is small, confirm on a physical
 device before concluding a change isn't worth it.
 
 ## Contents
 
-| File | Purpose |
-| --- | --- |
-| `patches/mwp-perf-instrumentation.patch` | Adds `[MWPPerf]` timing logs to metamask-mobile's `connection.ts` (+ helper module). Applies to `main`, #32475, and #32473 branches. **Not for merge** — apply locally to the build under test. |
-| `patches/mwp-perf-instrumentation.h1-32470.patch` | Same instrumentation adapted to #32470's refactored `connection.ts` (eager-approval branch). |
-| `seed-sessions.mjs` | Persists N synthetic MWP sessions (the cold-start resume load). |
-| `run-trial.mjs` | One measurement trial: force-kill app → cold-start via a fresh connect deeplink. |
-| `analyze.mjs` | Parses `[MWPPerf]` lines from tee'd Metro logs **or** raw JSON lines from the on-device `mwp-perf.log` (Release builds); prints medians + safety/contention indicators. |
-| `lib.mjs` | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `mmdl`. |
+| File                                              | Purpose                                                                                                                                                                                         |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `patches/mwp-perf-instrumentation.patch`          | Adds `[MWPPerf]` timing logs to metamask-mobile's `connection.ts` (+ helper module). Applies to `main`, #32475, and #32473 branches. **Not for merge** — apply locally to the build under test. |
+| `patches/mwp-perf-instrumentation.h1-32470.patch` | Same instrumentation adapted to #32470's refactored `connection.ts` (eager-approval branch).                                                                                                    |
+| `seed-sessions.mjs`                               | Persists N synthetic MWP sessions (the cold-start resume load).                                                                                                                                 |
+| `run-trial.mjs`                                   | One measurement trial: force-kill app → cold-start via a fresh connect deeplink.                                                                                                                |
+| `analyze.mjs`                                     | Parses `[MWPPerf]` lines from tee'd Metro logs **or** raw JSON lines from the on-device `mwp-perf.log` (Release builds); prints medians + safety/contention indicators.                         |
+| `lib.mjs`                                         | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `mmdl`.                                                                                         |
 
 ## How the synthetic connects work
 
@@ -107,11 +107,11 @@ cp "$DATA/Documents/mwp-perf.log" arm-pr.log        # then delete it before the 
 
 ## Measuring each latency PR
 
-| PR | What it changes | Patch to apply | Trial mode | Metric to compare (analyze.mjs) | Expected result |
-| --- | --- | --- | --- | --- | --- |
-| [#32475](https://github.com/MetaMask/metamask-mobile/pull/32475) defer resume/reconnect | New connect no longer contends with cold-start resume | `mwp-perf-instrumentation.patch` | default (no request) | `connect handshake durMs` median/p75, with ~18 seeded sessions | Lower on PR arm; `resume_start inside a connect window` drops to 0 |
-| [#32470](https://github.com/MetaMask/metamask-mobile/pull/32470) eager approval (draft) | Approval surfaces before the handshake instead of after | `mwp-perf-instrumentation.h1-32470.patch` on the PR arm; base patch on control | `--with-request` | `approval gate ms` (create_session_received − connect_start) | ≈ handshake duration on control; ≈ 0 ms on PR arm. `connect handshake durMs` itself is unchanged — that's expected |
-| [#32473](https://github.com/MetaMask/metamask-mobile/pull/32473) loading sheet | Perceived latency only (feedback while waiting) | `mwp-perf-instrumentation.patch` (applies cleanly) | either | None — no timing change expected; use the rig as a regression check (identical `connect`/`approval gate` numbers, sheet appears/dismisses correctly, none stranded after trials) | No numeric delta |
+| PR                                                                                      | What it changes                                         | Patch to apply                                                                 | Trial mode           | Metric to compare (analyze.mjs)                                                                                                                                                  | Expected result                                                                                                    |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| [#32475](https://github.com/MetaMask/metamask-mobile/pull/32475) defer resume/reconnect | New connect no longer contends with cold-start resume   | `mwp-perf-instrumentation.patch`                                               | default (no request) | `connect handshake durMs` median/p75, with ~18 seeded sessions                                                                                                                   | Lower on PR arm; `resume_start inside a connect window` drops to 0                                                 |
+| [#32470](https://github.com/MetaMask/metamask-mobile/pull/32470) eager approval (draft) | Approval surfaces before the handshake instead of after | `mwp-perf-instrumentation.h1-32470.patch` on the PR arm; base patch on control | `--with-request`     | `approval gate ms` (create_session_received − connect_start)                                                                                                                     | ≈ handshake duration on control; ≈ 0 ms on PR arm. `connect handshake durMs` itself is unchanged — that's expected |
+| [#32473](https://github.com/MetaMask/metamask-mobile/pull/32473) loading sheet          | Perceived latency only (feedback while waiting)         | `mwp-perf-instrumentation.patch` (applies cleanly)                             | either               | None — no timing change expected; use the rig as a regression check (identical `connect`/`approval gate` numbers, sheet appears/dismisses correctly, none stranded after trials) | No numeric delta                                                                                                   |
 
 Arm-switching notes per PR:
 

--- a/playground/mwp-connect-bench/README.md
+++ b/playground/mwp-connect-bench/README.md
@@ -23,7 +23,7 @@ device before concluding a change isn't worth it.
 | `patches/mwp-perf-instrumentation.h1-32470.patch` | Same instrumentation adapted to #32470's refactored `connection.ts` (eager-approval branch). |
 | `seed-sessions.mjs` | Persists N synthetic MWP sessions (the cold-start resume load). |
 | `run-trial.mjs` | One measurement trial: force-kill app → cold-start via a fresh connect deeplink. |
-| `analyze.mjs` | Parses `[MWPPerf]` lines from tee'd Metro logs; prints medians + safety/contention indicators. |
+| `analyze.mjs` | Parses `[MWPPerf]` lines from tee'd Metro logs **or** raw JSON lines from the on-device `mwp-perf.log` (Release builds); prints medians + safety/contention indicators. |
 | `lib.mjs` | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `mmdl`. |
 
 ## How the synthetic connects work
@@ -71,6 +71,39 @@ yarn trial 5             # 5 cold-start trials, 20s apart
 # 6. Compare
 yarn analyze arm-control.log arm-pr.log
 ```
+
+## Cold-start fidelity: use a Release build
+
+An Expo **dev-client** build boots into the dev launcher on cold start, which
+intercepts the connect deeplink — so `run-trial.mjs` (terminate → deeplink)
+never exercises the real cold-start path. For faithful cold-start trials,
+build a **Release** simulator app (embedded bundle, no Metro):
+
+```bash
+cd ~/path/to/metamask-mobile/ios
+xcodebuild -workspace MetaMask.xcworkspace -scheme MetaMask \
+  -configuration Release -sdk iphonesimulator -derivedDataPath build \
+  -destination 'platform=iOS Simulator,id=<UDID>' build
+xcrun simctl install <UDID> build/Build/Products/Release-iphonesimulator/MetaMask.app
+```
+
+The instrumentation is built for this: Release builds run Babel's
+`transform-remove-console`, so `mwp-perf.ts` calls `console.warn` through a
+bound alias (survives the plugin) **and** appends every event as a JSON line
+to `<Documents>/mwp-perf.log` inside the app container. Collect per arm with:
+
+```bash
+DATA=$(xcrun simctl get_app_container <UDID> io.metamask.MetaMask data)
+cp "$DATA/Documents/mwp-perf.log" arm-pr.log        # then delete it before the next arm
+```
+
+`analyze.mjs` accepts these raw-JSON logs directly. Two Release-build caveats:
+
+- No Metro, so the JS-only arm swap below still needs an (incremental)
+  `xcodebuild` re-run to re-embed the bundle after swapping the file.
+- The build is resource-hungry (tens of GB of intermediates in `ios/build`,
+  heavily parallel compile). Ensure ample free disk before starting, and
+  don't run trials while a build is in flight.
 
 ## Measuring each latency PR
 

--- a/playground/mwp-connect-bench/README.md
+++ b/playground/mwp-connect-bench/README.md
@@ -15,6 +15,9 @@ Mac's CPU is faster than device-class hardware, which _underestimates_
 contention effects — if a measured delta is small, confirm on a physical
 device before concluding a change isn't worth it.
 
+> **Agents / operators**: see [AGENTS.md](./AGENTS.md) for the step-by-step
+> run playbooks (dev vs Release builds) and the list of known pitfalls.
+
 ## Contents
 
 | File                                              | Purpose                                                                                                                                                                                         |
@@ -24,7 +27,7 @@ device before concluding a change isn't worth it.
 | `seed-sessions.mjs`                               | Persists N synthetic MWP sessions (the cold-start resume load).                                                                                                                                 |
 | `run-trial.mjs`                                   | One measurement trial: force-kill app → cold-start via a fresh connect deeplink.                                                                                                                |
 | `analyze.mjs`                                     | Parses `[MWPPerf]` lines from tee'd Metro logs **or** raw JSON lines from the on-device `mwp-perf.log` (Release builds); prints medians + safety/contention indicators.                         |
-| `lib.mjs`                                         | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `mmdl`.                                                                                         |
+| `lib.mjs`                                         | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `xcrun simctl`.                                                                                 |
 
 ## How the synthetic connects work
 
@@ -39,9 +42,11 @@ peer-key check.
 ## Prerequisites
 
 - A `metamask-mobile` checkout (any path — you apply the patch inside it).
-- `mmdl` CLI on PATH — opens deeplinks in the simulator MetaMask
-  (env overrides: `MMDL_BUNDLE_ID`, `MMDL_DEVICE`). Any equivalent of
-  `xcrun simctl openurl booted <url>` with optional pre-terminate also works.
+- macOS with Xcode installed — deeplinks are delivered with `xcrun simctl`
+  (terminate + openurl), no other tooling required. Env overrides:
+  - `BENCH_SIM_DEVICE` — simulator UDID (default `booted`);
+  - `BENCH_BUNDLE_ID` — app bundle id (default `io.metamask.MetaMask`; use
+    `io.metamask.MetaMask-QA` for QA builds).
 - Booted iOS simulator with a dev build of MetaMask, onboarded (wallet created).
 - `yarn install` at the monorepo root (installs this package's `eciesjs`).
 

--- a/playground/mwp-connect-bench/README.md
+++ b/playground/mwp-connect-bench/README.md
@@ -1,0 +1,132 @@
+# @metamask/mwp-connect-bench
+
+Private (unpublished) benchmark harness for **MetaMask Connect (Mobile Wallet
+Protocol) deeplink connection latency** against a MetaMask Mobile dev build in
+the iOS simulator.
+
+Built to quantify the win from
+[metamask-mobile#32475 — defer session resume/reconnect while a new connect is in flight](https://github.com/MetaMask/metamask-mobile/pull/32475)
+(WAPI-1566) and to verify it causes no resume regressions — but reusable for
+any MWP connect-latency experiment (see WAPI-1564 for the broader latency
+investigation).
+
+The rig uses real Safari/WebKit and real relay traffic. Simulator caveat: your
+Mac's CPU is faster than device-class hardware, which *underestimates*
+contention effects — if a measured delta is small, confirm on a physical
+device before concluding a change isn't worth it.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `patches/mwp-perf-instrumentation.patch` | Adds `[MWPPerf]` timing logs to metamask-mobile's `connection.ts` (+ helper module). **Not for merge** — apply locally to the build under test. |
+| `seed-sessions.mjs` | Persists N synthetic MWP sessions (the cold-start resume load). |
+| `run-trial.mjs` | One measurement trial: force-kill app → cold-start via a fresh connect deeplink. |
+| `analyze.mjs` | Parses `[MWPPerf]` lines from tee'd Metro logs; prints medians + safety/contention indicators. |
+| `lib.mjs` | Builds valid trusted-mode connect deeplinks (real secp256k1 keys via `eciesjs`), opens them via `mmdl`. |
+
+## How the synthetic connects work
+
+Trusted-mode MWP handshakes need **no dapp on the other end**: the wallet
+connects to the relay, subscribes, publishes its handshake-offer, and persists
+the session. A valid connect deeplink with **no `initialMessage`** (QR-style)
+therefore creates a real persisted session with no approval UI — perfect for
+seeding and for repeatable trials. Payloads pass every check in the wallet's
+`isConnectionRequest()` validator, including the compressed-secp256k1
+peer-key check.
+
+## Prerequisites
+
+- A `metamask-mobile` checkout (any path — you apply the patch inside it).
+- `mmdl` CLI on PATH — opens deeplinks in the simulator MetaMask
+  (env overrides: `MMDL_BUNDLE_ID`, `MMDL_DEVICE`). Any equivalent of
+  `xcrun simctl openurl booted <url>` with optional pre-terminate also works.
+- Booted iOS simulator with a dev build of MetaMask, onboarded (wallet created).
+- `yarn install` at the monorepo root (installs this package's `eciesjs`).
+
+## Quick start
+
+```bash
+BENCH_DIR=$(pwd)  # this package's directory
+
+# 1. In your metamask-mobile checkout, on the branch under test:
+cd ~/path/to/metamask-mobile
+git apply "$BENCH_DIR/patches/mwp-perf-instrumentation.patch"
+
+# 2. Build once, keep Metro output tee'd (the [MWPPerf] lines land there)
+yarn setup:expo
+yarn watch | tee "$BENCH_DIR/arm-pr.log"     # terminal 1
+yarn start:ios                               # terminal 2
+
+# 3. Onboard the sim wallet, then seed the resume load (persists in the sim)
+cd "$BENCH_DIR"
+yarn seed                # 18 sessions, 4s apart   (yarn seed 10 6000 …)
+
+# 4. Run trials
+yarn trial 5             # 5 cold-start trials, 20s apart
+
+# 5. Switch arms (see below), re-tee Metro to arm-control.log, rerun step 4
+
+# 6. Compare
+yarn analyze arm-control.log arm-pr.log
+```
+
+## A/B arm switching for metamask-mobile#32475
+
+The PR's behavior lives entirely in
+`app/core/SDKConnectV2/services/connection-registry.ts`, and `main` has not
+touched that file since the PR's merge-base — so both arms run on **one native
+build** with a JS-only file swap (Metro hot-reloads it):
+
+```bash
+# control arm (pre-PR behavior):
+git checkout origin/main -- app/core/SDKConnectV2/services/connection-registry.ts
+# treatment arm (the PR):
+git checkout perf/mwp-defer-resume-during-connect -- app/core/SDKConnectV2/services/connection-registry.ts
+```
+
+The instrumentation patch touches only `connection.ts` (identical on both
+branches), so it stays constant across arms.
+
+## Measurement protocol
+
+- **≥10 trials per arm**, alternated in blocks (ABBA) so network drift doesn't
+  bias one arm.
+- **Throttle the network** (Network Link Conditioner on the Mac affects
+  simulator traffic) — relay round-trips are what contend, so throttling
+  amplifies the effect under test.
+- Compare **medians / p75**, not means (relay latency is long-tailed). On a
+  warm network with few sessions, expect a no-op — contention fixes cut the
+  tail, not the average case.
+- Watch the two safety signals in `analyze.mjs` output:
+  - `resumes: N total, 0 failed` with N matching your seed count on **both**
+    arms (no resumes lost — the regression check);
+  - `resume_start events inside a connect window` — >0 on the contending arm,
+    0 when deferral is working.
+
+## Trial hygiene
+
+- Every trial's connect **persists as a session** (wallet cap:
+  `MAX_CONNECTIONS = 20`, oldest evicted). Disconnect trial sessions between
+  blocks or let the cap hold — just be consistent across arms so both resume
+  the same load.
+- Seeded state lives in the simulator app container: survives cold starts
+  (intended), wiped by `simctl erase`/reinstall. Sessions expire after the
+  standard 30-day TTL.
+- Each seed/trial shows the "Connecting to dApp" toast (auto-dismisses ~10s) —
+  harmless.
+
+## Cleanup (de-instrument metamask-mobile)
+
+```bash
+cd ~/path/to/metamask-mobile
+git checkout -- app/core/SDKConnectV2/services/connection.ts
+rm app/core/SDKConnectV2/services/mwp-perf.ts
+```
+
+## Maintenance note
+
+`patches/mwp-perf-instrumentation.patch` targets metamask-mobile's
+`app/core/SDKConnectV2/services/connection.ts` as of July 2026. If it stops
+applying cleanly, regenerate it: add `mwp-perf.ts` (see the patch content) and
+wrap `Connection.create` / `connect` / `resume` with start/end timing logs.

--- a/playground/mwp-connect-bench/README.md
+++ b/playground/mwp-connect-bench/README.md
@@ -19,7 +19,8 @@ device before concluding a change isn't worth it.
 
 | File | Purpose |
 | --- | --- |
-| `patches/mwp-perf-instrumentation.patch` | Adds `[MWPPerf]` timing logs to metamask-mobile's `connection.ts` (+ helper module). **Not for merge** — apply locally to the build under test. |
+| `patches/mwp-perf-instrumentation.patch` | Adds `[MWPPerf]` timing logs to metamask-mobile's `connection.ts` (+ helper module). Applies to `main`, #32475, and #32473 branches. **Not for merge** — apply locally to the build under test. |
+| `patches/mwp-perf-instrumentation.h1-32470.patch` | Same instrumentation adapted to #32470's refactored `connection.ts` (eager-approval branch). |
 | `seed-sessions.mjs` | Persists N synthetic MWP sessions (the cold-start resume load). |
 | `run-trial.mjs` | One measurement trial: force-kill app → cold-start via a fresh connect deeplink. |
 | `analyze.mjs` | Parses `[MWPPerf]` lines from tee'd Metro logs; prints medians + safety/contention indicators. |
@@ -70,6 +71,27 @@ yarn trial 5             # 5 cold-start trials, 20s apart
 # 6. Compare
 yarn analyze arm-control.log arm-pr.log
 ```
+
+## Measuring each latency PR
+
+| PR | What it changes | Patch to apply | Trial mode | Metric to compare (analyze.mjs) | Expected result |
+| --- | --- | --- | --- | --- | --- |
+| [#32475](https://github.com/MetaMask/metamask-mobile/pull/32475) defer resume/reconnect | New connect no longer contends with cold-start resume | `mwp-perf-instrumentation.patch` | default (no request) | `connect handshake durMs` median/p75, with ~18 seeded sessions | Lower on PR arm; `resume_start inside a connect window` drops to 0 |
+| [#32470](https://github.com/MetaMask/metamask-mobile/pull/32470) eager approval (draft) | Approval surfaces before the handshake instead of after | `mwp-perf-instrumentation.h1-32470.patch` on the PR arm; base patch on control | `--with-request` | `approval gate ms` (create_session_received − connect_start) | ≈ handshake duration on control; ≈ 0 ms on PR arm. `connect handshake durMs` itself is unchanged — that's expected |
+| [#32473](https://github.com/MetaMask/metamask-mobile/pull/32473) loading sheet | Perceived latency only (feedback while waiting) | `mwp-perf-instrumentation.patch` (applies cleanly) | either | None — no timing change expected; use the rig as a regression check (identical `connect`/`approval gate` numbers, sheet appears/dismisses correctly, none stranded after trials) | No numeric delta |
+
+Arm-switching notes per PR:
+
+- **#32475**: one native build, JS-only registry swap (see below).
+- **#32470**: `connection.ts` is refactored on that branch, so the base patch
+  does not apply — use the dedicated `h1-32470` patch variant there. Compare
+  against `main` + base patch. Both are JS-only, so one native build still
+  works: check out the branch's `connection.ts` (plus its test file if Metro
+  complains) rather than rebuilding.
+- **#32470 with `--with-request`**: each trial pops a real connection approval —
+  reject it between trials (don't approve; granting permissions changes state
+  across trials). The `create_session_received` marker fires before any UI, so
+  the metric itself needs no user action.
 
 ## A/B arm switching for metamask-mobile#32475
 

--- a/playground/mwp-connect-bench/analyze.mjs
+++ b/playground/mwp-connect-bench/analyze.mjs
@@ -53,6 +53,21 @@ for (const file of files) {
 
   const durations = connectEnds.map((e) => e.durMs).sort((a, b) => a - b);
 
+  // Approval gate: how long after connect_start the wallet_createSession
+  // request became available to the approval flow. ≈ handshake duration when
+  // the approval is gated behind the relay (main); ≈ 0 with eager approval
+  // (metamask-mobile#32470). Requires trials run with --with-request.
+  const approvalGates = [];
+  for (const received of events.filter(
+    (e) => e.event === 'create_session_received',
+  )) {
+    const start = events.find(
+      (e) => e.event === 'connect_start' && e.id === received.id,
+    );
+    if (start) approvalGates.push(received.t - start.t);
+  }
+  approvalGates.sort((a, b) => a - b);
+
   console.log(`\n=== ${file} ===`);
   console.log(`connects: ${connectEnds.length} ok, ${connectFails.length} failed`);
   if (durations.length > 0) {
@@ -60,6 +75,14 @@ for (const file of files) {
       `connect handshake durMs — median: ${percentile(durations, 50)}  ` +
         `p75: ${percentile(durations, 75)}  min: ${durations[0]}  ` +
         `max: ${durations[durations.length - 1]}  (n=${durations.length})`,
+    );
+  }
+  if (approvalGates.length > 0) {
+    console.log(
+      `approval gate ms (create_session_received − connect_start) — ` +
+        `median: ${percentile(approvalGates, 50)}  ` +
+        `max: ${approvalGates[approvalGates.length - 1]}  ` +
+        `(n=${approvalGates.length}; ≈handshake when gated, ≈0 when eager)`,
     );
   }
   console.log(

--- a/playground/mwp-connect-bench/analyze.mjs
+++ b/playground/mwp-connect-bench/analyze.mjs
@@ -22,10 +22,16 @@ const percentile = (sorted, p) =>
 for (const file of files) {
   const events = [];
   for (const line of readFileSync(file, 'utf8').split('\n')) {
+    // Two supported formats:
+    //  - Metro/console capture: "... [MWPPerf] {json}" (dev builds)
+    //  - Raw file capture: "{json}" per line from the app's Documents/
+    //    mwp-perf.log (release builds)
     const idx = line.indexOf('[MWPPerf] ');
-    if (idx === -1) continue;
+    const jsonText =
+      idx !== -1 ? line.slice(idx + '[MWPPerf] '.length) : line.trim();
+    if (!jsonText.startsWith('{')) continue;
     try {
-      events.push(JSON.parse(line.slice(idx + '[MWPPerf] '.length)));
+      events.push(JSON.parse(jsonText));
     } catch {
       // tolerate wrapped/truncated lines
     }

--- a/playground/mwp-connect-bench/analyze.mjs
+++ b/playground/mwp-connect-bench/analyze.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Parses [MWPPerf] lines from one or more log files (e.g. tee'd Metro output)
  * and prints per-file connect/resume stats plus a contention indicator.
@@ -10,14 +9,15 @@ import { readFileSync } from 'node:fs';
 
 const files = process.argv.slice(2);
 if (files.length === 0) {
-  console.error('Usage: node analyze.mjs <log file> [more log files…]');
-  process.exit(1);
+  throw new Error('Usage: node analyze.mjs <log file> [more log files…]');
 }
 
-const percentile = (sorted, p) =>
+const percentile = (sorted, pct) =>
   sorted.length === 0
     ? NaN
-    : sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+    : sorted[
+        Math.min(sorted.length - 1, Math.floor((pct / 100) * sorted.length))
+      ];
 
 for (const file of files) {
   const events = [];
@@ -28,8 +28,10 @@ for (const file of files) {
     //    mwp-perf.log (release builds)
     const idx = line.indexOf('[MWPPerf] ');
     const jsonText =
-      idx !== -1 ? line.slice(idx + '[MWPPerf] '.length) : line.trim();
-    if (!jsonText.startsWith('{')) continue;
+      idx === -1 ? line.trim() : line.slice(idx + '[MWPPerf] '.length);
+    if (!jsonText.startsWith('{')) {
+      continue;
+    }
     try {
       events.push(JSON.parse(jsonText));
     } catch {
@@ -37,27 +39,33 @@ for (const file of files) {
     }
   }
 
-  const connectEnds = events.filter((e) => e.event === 'connect_end' && e.ok);
-  const connectFails = events.filter((e) => e.event === 'connect_end' && !e.ok);
-  const resumeEnds = events.filter((e) => e.event === 'resume_end');
-  const resumeFails = resumeEnds.filter((e) => !e.ok);
+  const connectEnds = events.filter(
+    (evt) => evt.event === 'connect_end' && evt.ok,
+  );
+  const connectFails = events.filter(
+    (evt) => evt.event === 'connect_end' && !evt.ok,
+  );
+  const resumeEnds = events.filter((evt) => evt.event === 'resume_end');
+  const resumeFails = resumeEnds.filter((evt) => !evt.ok);
 
   // Contention indicator: resume activity starting inside a connect window.
   // Expect > 0 on the control arm (contends) and 0 on the PR arm (defers).
   const connectWindows = [];
   for (const end of connectEnds) {
     const start = events.find(
-      (e) => e.event === 'connect_start' && e.id === end.id,
+      (evt) => evt.event === 'connect_start' && evt.id === end.id,
     );
-    if (start) connectWindows.push([start.t, end.t]);
+    if (start) {
+      connectWindows.push([start.t, end.t]);
+    }
   }
   const resumesDuringConnect = events.filter(
-    (e) =>
-      e.event === 'resume_start' &&
-      connectWindows.some(([s, t]) => e.t > s && e.t < t),
+    (evt) =>
+      evt.event === 'resume_start' &&
+      connectWindows.some(([startT, endT]) => evt.t > startT && evt.t < endT),
   ).length;
 
-  const durations = connectEnds.map((e) => e.durMs).sort((a, b) => a - b);
+  const durations = connectEnds.map((evt) => evt.durMs).sort((a, b) => a - b);
 
   // Approval gate: how long after connect_start the wallet_createSession
   // request became available to the approval flow. ≈ handshake duration when
@@ -65,17 +73,21 @@ for (const file of files) {
   // (metamask-mobile#32470). Requires trials run with --with-request.
   const approvalGates = [];
   for (const received of events.filter(
-    (e) => e.event === 'create_session_received',
+    (evt) => evt.event === 'create_session_received',
   )) {
     const start = events.find(
-      (e) => e.event === 'connect_start' && e.id === received.id,
+      (evt) => evt.event === 'connect_start' && evt.id === received.id,
     );
-    if (start) approvalGates.push(received.t - start.t);
+    if (start) {
+      approvalGates.push(received.t - start.t);
+    }
   }
   approvalGates.sort((a, b) => a - b);
 
   console.log(`\n=== ${file} ===`);
-  console.log(`connects: ${connectEnds.length} ok, ${connectFails.length} failed`);
+  console.log(
+    `connects: ${connectEnds.length} ok, ${connectFails.length} failed`,
+  );
   if (durations.length > 0) {
     console.log(
       `connect handshake durMs — median: ${percentile(durations, 50)}  ` +

--- a/playground/mwp-connect-bench/analyze.mjs
+++ b/playground/mwp-connect-bench/analyze.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Parses [MWPPerf] lines from one or more log files (e.g. tee'd Metro output)
+ * and prints per-file connect/resume stats plus a contention indicator.
+ *
+ * Usage:
+ *   node analyze.mjs arm-control.log arm-pr.log
+ */
+import { readFileSync } from 'node:fs';
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('Usage: node analyze.mjs <log file> [more log files…]');
+  process.exit(1);
+}
+
+const percentile = (sorted, p) =>
+  sorted.length === 0
+    ? NaN
+    : sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+
+for (const file of files) {
+  const events = [];
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    const idx = line.indexOf('[MWPPerf] ');
+    if (idx === -1) continue;
+    try {
+      events.push(JSON.parse(line.slice(idx + '[MWPPerf] '.length)));
+    } catch {
+      // tolerate wrapped/truncated lines
+    }
+  }
+
+  const connectEnds = events.filter((e) => e.event === 'connect_end' && e.ok);
+  const connectFails = events.filter((e) => e.event === 'connect_end' && !e.ok);
+  const resumeEnds = events.filter((e) => e.event === 'resume_end');
+  const resumeFails = resumeEnds.filter((e) => !e.ok);
+
+  // Contention indicator: resume activity starting inside a connect window.
+  // Expect > 0 on the control arm (contends) and 0 on the PR arm (defers).
+  const connectWindows = [];
+  for (const end of connectEnds) {
+    const start = events.find(
+      (e) => e.event === 'connect_start' && e.id === end.id,
+    );
+    if (start) connectWindows.push([start.t, end.t]);
+  }
+  const resumesDuringConnect = events.filter(
+    (e) =>
+      e.event === 'resume_start' &&
+      connectWindows.some(([s, t]) => e.t > s && e.t < t),
+  ).length;
+
+  const durations = connectEnds.map((e) => e.durMs).sort((a, b) => a - b);
+
+  console.log(`\n=== ${file} ===`);
+  console.log(`connects: ${connectEnds.length} ok, ${connectFails.length} failed`);
+  if (durations.length > 0) {
+    console.log(
+      `connect handshake durMs — median: ${percentile(durations, 50)}  ` +
+        `p75: ${percentile(durations, 75)}  min: ${durations[0]}  ` +
+        `max: ${durations[durations.length - 1]}  (n=${durations.length})`,
+    );
+  }
+  console.log(
+    `resumes: ${resumeEnds.length} total, ${resumeFails.length} failed`,
+  );
+  console.log(
+    `resume_start events inside a connect window: ${resumesDuringConnect} ` +
+      `(expect >0 on control, 0 on PR arm)`,
+  );
+}

--- a/playground/mwp-connect-bench/lib.mjs
+++ b/playground/mwp-connect-bench/lib.mjs
@@ -77,23 +77,45 @@ export const buildConnectUrl = (label, { withRequest = false } = {}) => {
 };
 
 /**
- * Opens a URL in the simulator MetaMask via the `mmdl` CLI
- * (https://github.com/MetaMask — internal tool; any equivalent of
- * `xcrun simctl openurl booted <url>` with optional pre-terminate works).
- *
- * @param {string} url - The deeplink to open.
- * @param {{ terminateFirst?: boolean }} [options] - Terminate the app first
- * so the launch is a true cold start.
- */
-export const openDeeplink = (url, { terminateFirst = false } = {}) => {
-  const args = terminateFirst ? ['-t', url] : [url];
-  execFileSync('mmdl', args, { stdio: 'inherit' });
-};
-
-/**
  * Waits for the given number of milliseconds.
  *
  * @param {number} ms - Milliseconds to sleep.
  * @returns {Promise<void>} Resolves after the delay.
  */
 export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Simulator target and app under test. Overridable so the harness works with
+ * any simulator (UDID or "booted") and any MetaMask build flavor (e.g. the
+ * QA bundle id `io.metamask.MetaMask-QA`).
+ */
+// eslint-disable-next-line n/no-process-env -- deliberate env-var override for a local benchmark script
+const SIM_DEVICE = process.env.BENCH_SIM_DEVICE ?? 'booted';
+// eslint-disable-next-line n/no-process-env -- deliberate env-var override for a local benchmark script
+const BUNDLE_ID = process.env.BENCH_BUNDLE_ID ?? 'io.metamask.MetaMask';
+
+/**
+ * Opens a deeplink in the simulator MetaMask via `xcrun simctl` (ships with
+ * Xcode — no extra tooling required).
+ *
+ * @param {string} url - The deeplink to open.
+ * @param {{ terminateFirst?: boolean }} [options] - Terminate the app first
+ * so the launch is a true cold start.
+ * @returns {Promise<void>} Resolves once the deeplink has been dispatched.
+ */
+export const openDeeplink = async (url, { terminateFirst = false } = {}) => {
+  if (terminateFirst) {
+    try {
+      execFileSync('xcrun', ['simctl', 'terminate', SIM_DEVICE, BUNDLE_ID], {
+        stdio: 'ignore',
+      });
+    } catch {
+      // App wasn't running — fine, we only need it not-running.
+    }
+    // Let the OS finish tearing the process down before relaunching.
+    await sleep(750);
+  }
+  execFileSync('xcrun', ['simctl', 'openurl', SIM_DEVICE, url], {
+    stdio: 'inherit',
+  });
+};

--- a/playground/mwp-connect-bench/lib.mjs
+++ b/playground/mwp-connect-bench/lib.mjs
@@ -19,13 +19,40 @@ import { PrivateKey } from 'eciesjs';
  * (app/core/SDKConnectV2/types/connection-request.ts).
  *
  * @param {string} label - Human-readable dapp name for the session.
+ * @param {{ withRequest?: boolean }} [options] - When `withRequest` is true,
+ * embeds an inline `wallet_createSession` request (`initialMessage`) like the
+ * SDK's direct deeplink flow. This makes the wallet surface a connection
+ * APPROVAL (reject it manually between trials) and emits the
+ * `create_session_received` marker needed to measure the approval path
+ * (e.g. metamask-mobile#32470). Without it (QR-style), the session persists
+ * silently with no approval UI.
  * @returns {{ id: string, url: string }} Session id and deeplink URL.
  */
-export const buildConnectUrl = (label) => {
+export const buildConnectUrl = (label, { withRequest = false } = {}) => {
   const id = randomUUID();
   const publicKeyB64 = Buffer.from(
     new PrivateKey().publicKey.toBytes(true), // 33-byte compressed point
   ).toString('base64');
+
+  // Shape mirrors the SDK's initialPayload: multiplexed stream name + JSON-RPC.
+  const initialMessage = withRequest
+    ? {
+        type: 'message',
+        payload: {
+          name: 'metamask-multichain-provider',
+          data: {
+            id: 1,
+            jsonrpc: '2.0',
+            method: 'wallet_createSession',
+            params: {
+              optionalScopes: {
+                'eip155:1': { methods: ['eth_chainId'], notifications: [] },
+              },
+            },
+          },
+        },
+      }
+    : undefined;
 
   const connectionRequest = {
     sessionRequest: {
@@ -34,6 +61,7 @@ export const buildConnectUrl = (label) => {
       channel: `handshake:${id}`,
       publicKeyB64,
       expiresAt: Date.now() + 10 * 60 * 1000,
+      ...(initialMessage ? { initialMessage } : {}),
     },
     metadata: {
       dapp: {

--- a/playground/mwp-connect-bench/lib.mjs
+++ b/playground/mwp-connect-bench/lib.mjs
@@ -1,9 +1,9 @@
 /**
  * Shared helpers for the MWP connect benchmark harness.
  */
+import { PrivateKey } from 'eciesjs';
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { PrivateKey } from 'eciesjs';
 
 /**
  * Builds a synthetic, valid trusted-mode MWP connect deeplink.
@@ -72,8 +72,8 @@ export const buildConnectUrl = (label, { withRequest = false } = {}) => {
     },
   };
 
-  const p = encodeURIComponent(JSON.stringify(connectionRequest));
-  return { id, url: `metamask://connect/mwp?p=${p}` };
+  const payload = encodeURIComponent(JSON.stringify(connectionRequest));
+  return { id, url: `metamask://connect/mwp?p=${payload}` };
 };
 
 /**
@@ -91,6 +91,8 @@ export const openDeeplink = (url, { terminateFirst = false } = {}) => {
 };
 
 /**
+ * Waits for the given number of milliseconds.
+ *
  * @param {number} ms - Milliseconds to sleep.
  * @returns {Promise<void>} Resolves after the delay.
  */

--- a/playground/mwp-connect-bench/lib.mjs
+++ b/playground/mwp-connect-bench/lib.mjs
@@ -1,0 +1,69 @@
+/**
+ * Shared helpers for the MWP connect benchmark harness.
+ */
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { PrivateKey } from 'eciesjs';
+
+/**
+ * Builds a synthetic, valid trusted-mode MWP connect deeplink.
+ *
+ * The peer key must be a REAL secp256k1 point — the wallet client validates
+ * it (validatePeerKey) and rejects random bytes.
+ *
+ * No `initialMessage` is included (QR-style flow), so the wallet performs the
+ * full relay handshake and persists the session WITHOUT showing an approval —
+ * ideal for both seeding background sessions and firing measurement trials.
+ *
+ * Passes every check in MetaMask Mobile's isConnectionRequest() validator
+ * (app/core/SDKConnectV2/types/connection-request.ts).
+ *
+ * @param {string} label - Human-readable dapp name for the session.
+ * @returns {{ id: string, url: string }} Session id and deeplink URL.
+ */
+export const buildConnectUrl = (label) => {
+  const id = randomUUID();
+  const publicKeyB64 = Buffer.from(
+    new PrivateKey().publicKey.toBytes(true), // 33-byte compressed point
+  ).toString('base64');
+
+  const connectionRequest = {
+    sessionRequest: {
+      id,
+      mode: 'trusted',
+      channel: `handshake:${id}`,
+      publicKeyB64,
+      expiresAt: Date.now() + 10 * 60 * 1000,
+    },
+    metadata: {
+      dapp: {
+        name: label,
+        url: `https://${label.toLowerCase().replace(/[^a-z0-9]+/gu, '-')}.example.com`,
+      },
+      sdk: { version: '0.0.0-bench', platform: 'JavaScript' },
+    },
+  };
+
+  const p = encodeURIComponent(JSON.stringify(connectionRequest));
+  return { id, url: `metamask://connect/mwp?p=${p}` };
+};
+
+/**
+ * Opens a URL in the simulator MetaMask via the `mmdl` CLI
+ * (https://github.com/MetaMask — internal tool; any equivalent of
+ * `xcrun simctl openurl booted <url>` with optional pre-terminate works).
+ *
+ * @param {string} url - The deeplink to open.
+ * @param {{ terminateFirst?: boolean }} [options] - Terminate the app first
+ * so the launch is a true cold start.
+ */
+export const openDeeplink = (url, { terminateFirst = false } = {}) => {
+  const args = terminateFirst ? ['-t', url] : [url];
+  execFileSync('mmdl', args, { stdio: 'inherit' });
+};
+
+/**
+ * @param {number} ms - Milliseconds to sleep.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/playground/mwp-connect-bench/package.json
+++ b/playground/mwp-connect-bench/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@metamask/mwp-connect-bench",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Benchmark harness for MetaMask Connect (MWP) deeplink connection latency against MetaMask Mobile",
+  "keywords": [
+    "MetaMask",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/connect-monorepo/tree/main/playground/mwp-connect-bench#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/connect-monorepo/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/connect-monorepo.git"
+  },
+  "license": "UNLICENSED",
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "analyze": "node analyze.mjs",
+    "seed": "node seed-sessions.mjs",
+    "test": "echo \"No test specified\"",
+    "trial": "node run-trial.mjs"
+  },
+  "dependencies": {
+    "eciesjs": "0.4.17"
+  }
+}

--- a/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.h1-32470.patch
+++ b/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.h1-32470.patch
@@ -94,32 +94,51 @@ index 97167540c2..c616804a14 100644
    /**
 diff --git a/app/core/SDKConnectV2/services/mwp-perf.ts b/app/core/SDKConnectV2/services/mwp-perf.ts
 new file mode 100644
-index 0000000000..c2ffd076e5
+index 0000000000..452253a953
 --- /dev/null
 +++ b/app/core/SDKConnectV2/services/mwp-perf.ts
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,44 @@
 +/**
 + * TEMPORARY perf instrumentation for MWP connection benchmarking.
-+ * NOT FOR MERGE — applied locally via mwp-perf-instrumentation.patch to
-+ * compare connect-handshake latency across branches (WAPI-1566 / PR #32475).
++ * NOT FOR MERGE — applied locally via patches/*.patch to compare
++ * connect-handshake latency across branches (WAPI-1566 / PR #32475).
 + *
-+ * Emits single-line JSON via console.warn so it is visible in Metro, Xcode
-+ * console, and `adb logcat` regardless of debug-log gating:
++ * Capture works in BOTH build types:
++ *   - Dev build (Metro attached): the aliased console.warn prints
++ *     `[MWPPerf] {…}` to the Metro terminal. The alias (a bound reference,
++ *     not a direct `console.warn(...)` call) is intentional: it survives the
++ *     `transform-remove-console` babel plugin that runs in the production
++ *     env, which would otherwise delete the log at compile time.
++ *   - Release/standalone build (no Metro): each event is appended as a JSON
++ *     line to `<Documents>/mwp-perf.log`, readable from the simulator data
++ *     container via:
++ *       xcrun simctl get_app_container booted io.metamask.MetaMask data
 + *
-+ *   [MWPPerf] {"event":"connect_end","id":"…","t":1234,"durMs":842,"ok":true}
-+ *
-+ * `t` is ms since JS module load (aligns events within one app session).
-+ * Collect with e.g.:  adb logcat | grep MWPPerf
++ * `t` is ms since JS module load (orders events within one app session).
 + */
++import RNFS from 'react-native-fs';
++
 +const t0 = Date.now();
++const LOG_PATH = `${RNFS.DocumentDirectoryPath}/mwp-perf.log`;
++
++// Bound reference — NOT a direct `console.warn(...)` member call, so the
++// production-env `transform-remove-console` plugin cannot strip it.
++const warn: ((msg: string) => void) | undefined =
++  typeof console !== 'undefined' && console.warn
++    ? console.warn.bind(console)
++    : undefined;
++
++// Serialize appends so rapid events can't interleave / corrupt a line.
++let writeChain: Promise<void> = Promise.resolve();
 +
 +export const mwpPerf = (
 +  event: string,
 +  id: string,
 +  extra?: Record<string, unknown>,
 +): void => {
-+  // eslint-disable-next-line no-console
-+  console.warn(
-+    `[MWPPerf] ${JSON.stringify({ event, id, t: Date.now() - t0, ...extra })}`,
-+  );
++  const line = JSON.stringify({ event, id, t: Date.now() - t0, ...extra });
++  warn?.(`[MWPPerf] ${line}`);
++  writeChain = writeChain
++    .then(() => RNFS.appendFile(LOG_PATH, `${line}\n`, 'utf8'))
++    .catch(() => undefined);
 +};

--- a/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.h1-32470.patch
+++ b/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.h1-32470.patch
@@ -1,5 +1,5 @@
 diff --git a/app/core/SDKConnectV2/services/connection.ts b/app/core/SDKConnectV2/services/connection.ts
-index 2e0a0a1de9..9b4301a7f6 100644
+index 97167540c2..c616804a14 100644
 --- a/app/core/SDKConnectV2/services/connection.ts
 +++ b/app/core/SDKConnectV2/services/connection.ts
 @@ -16,6 +16,7 @@ import { IHostApplicationAdapter } from '../types/host-application-adapter';
@@ -10,22 +10,22 @@ index 2e0a0a1de9..9b4301a7f6 100644
  
  /**
   * Known user-rejection error codes across ecosystems.
-@@ -105,6 +106,14 @@ export class Connection {
-         id: data?.id,
-       });
+@@ -227,6 +228,14 @@ export class Connection {
+       id: data?.id,
+     });
  
-+      // KEY METRIC (approval path): when the wallet_createSession request
-+      // reaches the wallet — i.e. when the connection approval can begin.
-+      // Compare against connect_start to see how long the approval was
-+      // gated behind the relay handshake.
-+      if (data?.method === 'wallet_createSession') {
-+        mwpPerf('create_session_received', this.id);
-+      }
++    // KEY METRIC (approval path): when the wallet_createSession request
++    // reaches the wallet — i.e. when the connection approval can begin.
++    // On this branch (eager approval) it fires ~immediately at connect_start
++    // instead of after the relay handshake.
++    if (data?.method === 'wallet_createSession') {
++      mwpPerf('create_session_received', this.id);
++    }
 +
-       const isWalletCreateSessionRequest =
-         payload &&
-         typeof payload === 'object' &&
-@@ -250,6 +259,7 @@ export class Connection {
+     const isWalletCreateSessionRequest =
+       payload &&
+       typeof payload === 'object' &&
+@@ -293,6 +302,7 @@ export class Connection {
      relayURL: string,
      hostApp: IHostApplicationAdapter,
    ): Promise<Connection> {
@@ -33,7 +33,7 @@ index 2e0a0a1de9..9b4301a7f6 100644
      const transport = await WebSocketTransport.create({
        url: relayURL,
        kvstore: new KVStore(`mwp/transport/${connInfo.id}`),
-@@ -259,6 +269,7 @@ export class Connection {
+@@ -302,6 +312,7 @@ export class Connection {
        new KVStore(`mwp/session-store/${connInfo.id}`),
      );
      const client = new WalletClient({ transport, sessionstore, keymanager });
@@ -41,41 +41,43 @@ index 2e0a0a1de9..9b4301a7f6 100644
  
      return new Connection(connInfo, client, hostApp);
    }
-@@ -268,14 +279,46 @@ export class Connection {
-    * @param sessionRequest - The session request.
+@@ -327,6 +338,9 @@ export class Connection {
     */
    public async connect(sessionRequest: SessionRequest): Promise<void> {
--    await this.client.connect({ sessionRequest });
+     const { initialMessage } = sessionRequest;
 +    // KEY METRIC: duration of the MWP relay handshake for a NEW connect.
 +    const perfStart = Date.now();
 +    mwpPerf('connect_start', this.id);
-+    try {
-+      await this.client.connect({ sessionRequest });
+ 
+     if (initialMessage) {
+       // Fire-and-forget: drives the approval modal from the inline payload
+@@ -341,7 +355,15 @@ export class Connection {
+           : sessionRequest,
+       });
+       await this.clientReady;
 +      mwpPerf('connect_end', this.id, {
 +        durMs: Date.now() - perfStart,
 +        ok: true,
 +      });
-+    } catch (error) {
+     } catch (error) {
 +      mwpPerf('connect_end', this.id, {
 +        durMs: Date.now() - perfStart,
 +        ok: false,
 +      });
-+      throw error;
-+    }
-   }
- 
-   /**
+       // The handshake failed after we eagerly surfaced the approval. Reject the
+       // pending approval so the user isn't left looking at a connection request
+       // whose response can never be delivered.
+@@ -356,8 +378,22 @@ export class Connection {
     * Resumes a previously established session.
     */
    public async resume(): Promise<void> {
--    await this.client.resume(this.id);
-+    // Resume of a persisted session (cold-start loop). Interleaving of these
-+    // lines vs connect_start/connect_end shows whether resume work contends
-+    // with (main) or defers to (PR branch) an in-flight new connect.
+-    this.clientReady = this.client.resume(this.id);
+-    await this.clientReady;
 +    const perfStart = Date.now();
 +    mwpPerf('resume_start', this.id);
 +    try {
-+      await this.client.resume(this.id);
++      this.clientReady = this.client.resume(this.id);
++      await this.clientReady;
 +      mwpPerf('resume_end', this.id, {
 +        durMs: Date.now() - perfStart,
 +        ok: true,

--- a/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.patch
+++ b/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.patch
@@ -1,0 +1,108 @@
+diff --git a/app/core/SDKConnectV2/services/connection.ts b/app/core/SDKConnectV2/services/connection.ts
+index 2e0a0a1de9..a6b9904f1f 100644
+--- a/app/core/SDKConnectV2/services/connection.ts
++++ b/app/core/SDKConnectV2/services/connection.ts
+@@ -16,6 +16,7 @@ import { IHostApplicationAdapter } from '../types/host-application-adapter';
+ import { errorCodes, providerErrors } from '@metamask/rpc-errors';
+ import Engine from '../../Engine';
+ import NavigationService from '../../NavigationService';
++import { mwpPerf } from './mwp-perf';
+ 
+ /**
+  * Known user-rejection error codes across ecosystems.
+@@ -250,6 +251,7 @@ export class Connection {
+     relayURL: string,
+     hostApp: IHostApplicationAdapter,
+   ): Promise<Connection> {
++    const perfStart = Date.now();
+     const transport = await WebSocketTransport.create({
+       url: relayURL,
+       kvstore: new KVStore(`mwp/transport/${connInfo.id}`),
+@@ -259,6 +261,7 @@ export class Connection {
+       new KVStore(`mwp/session-store/${connInfo.id}`),
+     );
+     const client = new WalletClient({ transport, sessionstore, keymanager });
++    mwpPerf('create', connInfo.id, { durMs: Date.now() - perfStart });
+ 
+     return new Connection(connInfo, client, hostApp);
+   }
+@@ -268,14 +271,46 @@ export class Connection {
+    * @param sessionRequest - The session request.
+    */
+   public async connect(sessionRequest: SessionRequest): Promise<void> {
+-    await this.client.connect({ sessionRequest });
++    // KEY METRIC: duration of the MWP relay handshake for a NEW connect.
++    const perfStart = Date.now();
++    mwpPerf('connect_start', this.id);
++    try {
++      await this.client.connect({ sessionRequest });
++      mwpPerf('connect_end', this.id, {
++        durMs: Date.now() - perfStart,
++        ok: true,
++      });
++    } catch (error) {
++      mwpPerf('connect_end', this.id, {
++        durMs: Date.now() - perfStart,
++        ok: false,
++      });
++      throw error;
++    }
+   }
+ 
+   /**
+    * Resumes a previously established session.
+    */
+   public async resume(): Promise<void> {
+-    await this.client.resume(this.id);
++    // Resume of a persisted session (cold-start loop). Interleaving of these
++    // lines vs connect_start/connect_end shows whether resume work contends
++    // with (main) or defers to (PR branch) an in-flight new connect.
++    const perfStart = Date.now();
++    mwpPerf('resume_start', this.id);
++    try {
++      await this.client.resume(this.id);
++      mwpPerf('resume_end', this.id, {
++        durMs: Date.now() - perfStart,
++        ok: true,
++      });
++    } catch (error) {
++      mwpPerf('resume_end', this.id, {
++        durMs: Date.now() - perfStart,
++        ok: false,
++      });
++      throw error;
++    }
+   }
+ 
+   /**
+diff --git a/app/core/SDKConnectV2/services/mwp-perf.ts b/app/core/SDKConnectV2/services/mwp-perf.ts
+new file mode 100644
+index 0000000000..c2ffd076e5
+--- /dev/null
++++ b/app/core/SDKConnectV2/services/mwp-perf.ts
+@@ -0,0 +1,25 @@
++/**
++ * TEMPORARY perf instrumentation for MWP connection benchmarking.
++ * NOT FOR MERGE — applied locally via mwp-perf-instrumentation.patch to
++ * compare connect-handshake latency across branches (WAPI-1566 / PR #32475).
++ *
++ * Emits single-line JSON via console.warn so it is visible in Metro, Xcode
++ * console, and `adb logcat` regardless of debug-log gating:
++ *
++ *   [MWPPerf] {"event":"connect_end","id":"…","t":1234,"durMs":842,"ok":true}
++ *
++ * `t` is ms since JS module load (aligns events within one app session).
++ * Collect with e.g.:  adb logcat | grep MWPPerf
++ */
++const t0 = Date.now();
++
++export const mwpPerf = (
++  event: string,
++  id: string,
++  extra?: Record<string, unknown>,
++): void => {
++  // eslint-disable-next-line no-console
++  console.warn(
++    `[MWPPerf] ${JSON.stringify({ event, id, t: Date.now() - t0, ...extra })}`,
++  );
++};

--- a/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.patch
+++ b/playground/mwp-connect-bench/patches/mwp-perf-instrumentation.patch
@@ -92,32 +92,51 @@ index 2e0a0a1de9..9b4301a7f6 100644
    /**
 diff --git a/app/core/SDKConnectV2/services/mwp-perf.ts b/app/core/SDKConnectV2/services/mwp-perf.ts
 new file mode 100644
-index 0000000000..c2ffd076e5
+index 0000000000..452253a953
 --- /dev/null
 +++ b/app/core/SDKConnectV2/services/mwp-perf.ts
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,44 @@
 +/**
 + * TEMPORARY perf instrumentation for MWP connection benchmarking.
-+ * NOT FOR MERGE — applied locally via mwp-perf-instrumentation.patch to
-+ * compare connect-handshake latency across branches (WAPI-1566 / PR #32475).
++ * NOT FOR MERGE — applied locally via patches/*.patch to compare
++ * connect-handshake latency across branches (WAPI-1566 / PR #32475).
 + *
-+ * Emits single-line JSON via console.warn so it is visible in Metro, Xcode
-+ * console, and `adb logcat` regardless of debug-log gating:
++ * Capture works in BOTH build types:
++ *   - Dev build (Metro attached): the aliased console.warn prints
++ *     `[MWPPerf] {…}` to the Metro terminal. The alias (a bound reference,
++ *     not a direct `console.warn(...)` call) is intentional: it survives the
++ *     `transform-remove-console` babel plugin that runs in the production
++ *     env, which would otherwise delete the log at compile time.
++ *   - Release/standalone build (no Metro): each event is appended as a JSON
++ *     line to `<Documents>/mwp-perf.log`, readable from the simulator data
++ *     container via:
++ *       xcrun simctl get_app_container booted io.metamask.MetaMask data
 + *
-+ *   [MWPPerf] {"event":"connect_end","id":"…","t":1234,"durMs":842,"ok":true}
-+ *
-+ * `t` is ms since JS module load (aligns events within one app session).
-+ * Collect with e.g.:  adb logcat | grep MWPPerf
++ * `t` is ms since JS module load (orders events within one app session).
 + */
++import RNFS from 'react-native-fs';
++
 +const t0 = Date.now();
++const LOG_PATH = `${RNFS.DocumentDirectoryPath}/mwp-perf.log`;
++
++// Bound reference — NOT a direct `console.warn(...)` member call, so the
++// production-env `transform-remove-console` plugin cannot strip it.
++const warn: ((msg: string) => void) | undefined =
++  typeof console !== 'undefined' && console.warn
++    ? console.warn.bind(console)
++    : undefined;
++
++// Serialize appends so rapid events can't interleave / corrupt a line.
++let writeChain: Promise<void> = Promise.resolve();
 +
 +export const mwpPerf = (
 +  event: string,
 +  id: string,
 +  extra?: Record<string, unknown>,
 +): void => {
-+  // eslint-disable-next-line no-console
-+  console.warn(
-+    `[MWPPerf] ${JSON.stringify({ event, id, t: Date.now() - t0, ...extra })}`,
-+  );
++  const line = JSON.stringify({ event, id, t: Date.now() - t0, ...extra });
++  warn?.(`[MWPPerf] ${line}`);
++  writeChain = writeChain
++    .then(() => RNFS.appendFile(LOG_PATH, `${line}\n`, 'utf8'))
++    .catch(() => undefined);
 +};

--- a/playground/mwp-connect-bench/run-trial.mjs
+++ b/playground/mwp-connect-bench/run-trial.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Runs one cold-start connect trial: force-terminates the simulator MetaMask,
+ * then fires a fresh synthetic connect deeplink so the app cold-launches
+ * straight into a new MWP connect while its persisted sessions resume.
+ *
+ * The [MWPPerf] `connect_end.durMs` for this trial's session id (printed
+ * below) is the measurement. Collect it from the Metro terminal (run
+ * `yarn watch | tee <arm>.log` so analyze.mjs can consume it).
+ *
+ * Usage:
+ *   node run-trial.mjs             # one trial
+ *   node run-trial.mjs 5           # five trials, 20s apart
+ *   node run-trial.mjs 5 30000     # five trials, 30s apart
+ */
+import { buildConnectUrl, openDeeplink, sleep } from './lib.mjs';
+
+const count = Number(process.argv[2] ?? 1);
+const delayMs = Number(process.argv[3] ?? 20000);
+
+for (let n = 1; n <= count; n++) {
+  const { id, url } = buildConnectUrl(`Trial ${Date.now()}`);
+  console.log(`[trial ${n}/${count}] session id=${id}`);
+  // -t: terminate the app first so every trial is a true cold start.
+  openDeeplink(url, { terminateFirst: true });
+  if (n < count) {
+    console.log(`  waiting ${delayMs}ms for resume/handshake to settle…`);
+    await sleep(delayMs);
+  }
+}
+
+console.log(
+  'Done. Trials also persist as sessions — stay under the 20-connection cap ' +
+    'or disconnect them between blocks (keep arms consistent).',
+);

--- a/playground/mwp-connect-bench/run-trial.mjs
+++ b/playground/mwp-connect-bench/run-trial.mjs
@@ -27,8 +27,8 @@ const withRequest = process.argv.includes('--with-request');
 for (let trialIndex = 1; trialIndex <= count; trialIndex++) {
   const { id, url } = buildConnectUrl(`Trial ${Date.now()}`, { withRequest });
   console.log(`[trial ${trialIndex}/${count}] session id=${id}`);
-  // -t: terminate the app first so every trial is a true cold start.
-  openDeeplink(url, { terminateFirst: true });
+  // Terminate the app first so every trial is a true cold start.
+  await openDeeplink(url, { terminateFirst: true });
   if (trialIndex < count) {
     console.log(`  waiting ${delayMs}ms for resume/handshake to settle…`);
     await sleep(delayMs);

--- a/playground/mwp-connect-bench/run-trial.mjs
+++ b/playground/mwp-connect-bench/run-trial.mjs
@@ -9,17 +9,23 @@
  * `yarn watch | tee <arm>.log` so analyze.mjs can consume it).
  *
  * Usage:
- *   node run-trial.mjs             # one trial
- *   node run-trial.mjs 5           # five trials, 20s apart
- *   node run-trial.mjs 5 30000     # five trials, 30s apart
+ *   node run-trial.mjs                  # one trial
+ *   node run-trial.mjs 5                # five trials, 20s apart
+ *   node run-trial.mjs 5 30000          # five trials, 30s apart
+ *   node run-trial.mjs 5 30000 --with-request
+ *     # embeds an inline wallet_createSession (direct-deeplink flow): the
+ *     # wallet shows a connection APPROVAL each trial (reject it manually)
+ *     # and logs create_session_received — required to measure the approval
+ *     # path (e.g. metamask-mobile#32470 eager approval).
  */
 import { buildConnectUrl, openDeeplink, sleep } from './lib.mjs';
 
 const count = Number(process.argv[2] ?? 1);
 const delayMs = Number(process.argv[3] ?? 20000);
+const withRequest = process.argv.includes('--with-request');
 
 for (let n = 1; n <= count; n++) {
-  const { id, url } = buildConnectUrl(`Trial ${Date.now()}`);
+  const { id, url } = buildConnectUrl(`Trial ${Date.now()}`, { withRequest });
   console.log(`[trial ${n}/${count}] session id=${id}`);
   // -t: terminate the app first so every trial is a true cold start.
   openDeeplink(url, { terminateFirst: true });

--- a/playground/mwp-connect-bench/run-trial.mjs
+++ b/playground/mwp-connect-bench/run-trial.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Runs one cold-start connect trial: force-terminates the simulator MetaMask,
  * then fires a fresh synthetic connect deeplink so the app cold-launches
@@ -18,18 +17,19 @@
  *     # and logs create_session_received — required to measure the approval
  *     # path (e.g. metamask-mobile#32470 eager approval).
  */
+// eslint-disable-next-line import-x/extensions -- plain Node ESM script; the runtime import requires the file extension
 import { buildConnectUrl, openDeeplink, sleep } from './lib.mjs';
 
 const count = Number(process.argv[2] ?? 1);
 const delayMs = Number(process.argv[3] ?? 20000);
 const withRequest = process.argv.includes('--with-request');
 
-for (let n = 1; n <= count; n++) {
+for (let trialIndex = 1; trialIndex <= count; trialIndex++) {
   const { id, url } = buildConnectUrl(`Trial ${Date.now()}`, { withRequest });
-  console.log(`[trial ${n}/${count}] session id=${id}`);
+  console.log(`[trial ${trialIndex}/${count}] session id=${id}`);
   // -t: terminate the app first so every trial is a true cold start.
   openDeeplink(url, { terminateFirst: true });
-  if (n < count) {
+  if (trialIndex < count) {
     console.log(`  waiting ${delayMs}ms for resume/handshake to settle…`);
     await sleep(delayMs);
   }

--- a/playground/mwp-connect-bench/seed-sessions.mjs
+++ b/playground/mwp-connect-bench/seed-sessions.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Seeds persisted MetaMask Connect (SDKConnectV2 / MWP) sessions in the iOS
  * simulator by firing synthetic trusted-mode connect deeplinks via `mmdl`.
@@ -11,6 +10,7 @@
  *   node seed-sessions.mjs 10 6000         # 6s between connects
  *   node seed-sessions.mjs 3 0 --dry-run   # print URLs, don't open
  */
+// eslint-disable-next-line import-x/extensions -- plain Node ESM script; the runtime import requires the file extension
 import { buildConnectUrl, openDeeplink, sleep } from './lib.mjs';
 
 const count = Number(process.argv[2] ?? 18);
@@ -21,17 +21,19 @@ console.log(
   `Seeding ${count} MWP session(s), ${delayMs}ms apart${dryRun ? ' [dry-run]' : ''}`,
 );
 
-for (let n = 1; n <= count; n++) {
-  const label = `Seed Dapp ${String(n).padStart(2, '0')}`;
+for (let seedIndex = 1; seedIndex <= count; seedIndex++) {
+  const label = `Seed Dapp ${String(seedIndex).padStart(2, '0')}`;
   const { id, url } = buildConnectUrl(label);
   if (dryRun) {
-    console.log(`[${n}/${count}] id=${id} ${url.slice(0, 100)}…`);
+    console.log(`[${seedIndex}/${count}] id=${id} ${url.slice(0, 100)}…`);
     continue;
   }
-  console.log(`[${n}/${count}] ${label} (id=${id})`);
+  console.log(`[${seedIndex}/${count}] ${label} (id=${id})`);
   // Open in-place (no terminate) so earlier handshakes finish undisturbed.
   openDeeplink(url);
-  if (n < count) await sleep(delayMs);
+  if (seedIndex < count) {
+    await sleep(delayMs);
+  }
 }
 
 console.log(

--- a/playground/mwp-connect-bench/seed-sessions.mjs
+++ b/playground/mwp-connect-bench/seed-sessions.mjs
@@ -1,6 +1,7 @@
 /**
  * Seeds persisted MetaMask Connect (SDKConnectV2 / MWP) sessions in the iOS
- * simulator by firing synthetic trusted-mode connect deeplinks via `mmdl`.
+ * simulator by firing synthetic trusted-mode connect deeplinks via
+ * `xcrun simctl`.
  * Each seed performs a real relay handshake and persists a session that the
  * app resumes on every cold start — the background load PR #32475 defers.
  *
@@ -30,7 +31,7 @@ for (let seedIndex = 1; seedIndex <= count; seedIndex++) {
   }
   console.log(`[${seedIndex}/${count}] ${label} (id=${id})`);
   // Open in-place (no terminate) so earlier handshakes finish undisturbed.
-  openDeeplink(url);
+  await openDeeplink(url);
   if (seedIndex < count) {
     await sleep(delayMs);
   }

--- a/playground/mwp-connect-bench/seed-sessions.mjs
+++ b/playground/mwp-connect-bench/seed-sessions.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Seeds persisted MetaMask Connect (SDKConnectV2 / MWP) sessions in the iOS
+ * simulator by firing synthetic trusted-mode connect deeplinks via `mmdl`.
+ * Each seed performs a real relay handshake and persists a session that the
+ * app resumes on every cold start — the background load PR #32475 defers.
+ *
+ * Usage:
+ *   node seed-sessions.mjs                 # 18 sessions, 4s apart
+ *   node seed-sessions.mjs 10              # 10 sessions
+ *   node seed-sessions.mjs 10 6000         # 6s between connects
+ *   node seed-sessions.mjs 3 0 --dry-run   # print URLs, don't open
+ */
+import { buildConnectUrl, openDeeplink, sleep } from './lib.mjs';
+
+const count = Number(process.argv[2] ?? 18);
+const delayMs = Number(process.argv[3] ?? 4000);
+const dryRun = process.argv.includes('--dry-run');
+
+console.log(
+  `Seeding ${count} MWP session(s), ${delayMs}ms apart${dryRun ? ' [dry-run]' : ''}`,
+);
+
+for (let n = 1; n <= count; n++) {
+  const label = `Seed Dapp ${String(n).padStart(2, '0')}`;
+  const { id, url } = buildConnectUrl(label);
+  if (dryRun) {
+    console.log(`[${n}/${count}] id=${id} ${url.slice(0, 100)}…`);
+    continue;
+  }
+  console.log(`[${n}/${count}] ${label} (id=${id})`);
+  // Open in-place (no terminate) so earlier handshakes finish undisturbed.
+  openDeeplink(url);
+  if (n < count) await sleep(delayMs);
+}
+
+console.log(
+  'Done. Verify the session count in the wallet UI, or count "connect_end" ' +
+    'lines in the [MWPPerf] output.',
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,6 +4428,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/mwp-connect-bench@workspace:playground/mwp-connect-bench":
+  version: 0.0.0-use.local
+  resolution: "@metamask/mwp-connect-bench@workspace:playground/mwp-connect-bench"
+  dependencies:
+    eciesjs: "npm:0.4.17"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/network-controller@npm:^25.0.0":
   version: 25.0.0
   resolution: "@metamask/network-controller@npm:25.0.0"


### PR DESCRIPTION
## Explanation

Adds `playground/mwp-connect-bench` — a **private, unpublished** package for measuring MetaMask Connect (MWP) deeplink connection latency against a MetaMask Mobile dev build in the iOS simulator, and for verifying connection-flow changes don't regress session resume.

**Why:** we needed a repeatable rig to A/B [MetaMask/metamask-mobile#32475](https://github.com/MetaMask/metamask-mobile/pull/32475) (defer session resume/reconnect while a new connect is in flight, WAPI-1566), and the pieces are reusable for any MWP connect-latency experiment (WAPI-1564 investigation).

**What's inside:**
- `patches/mwp-perf-instrumentation.patch` — NOT-for-merge patch adding `[MWPPerf]` timing logs to metamask-mobile's `Connection` service (create / connect-handshake / resume spans). Applied locally to the build under test.
- `seed-sessions.mjs` — persists N synthetic MWP sessions to create cold-start resume load. Works because trusted-mode handshakes require no dapp acknowledgement: a valid connect deeplink without `initialMessage` (QR-style) does a real relay handshake and persists a session with no approval UI. Payloads pass the wallet's `isConnectionRequest()` validation, including real compressed-secp256k1 peer keys (via this package's own `eciesjs` dep, pinned to the version already in the repo).
- `run-trial.mjs` — one cold-start measurement trial (force-kill app → fresh connect deeplink via the `mmdl` simulator CLI).
- `analyze.mjs` — parses tee'd Metro logs; reports median/p75 handshake durations, resume failures (regression check), and resume-during-connect counts (contention indicator).

The README documents the full A/B protocol (single native build, JS-only arm swap, ABBA trial blocks, network throttling, median-based comparison) and trial hygiene (session cap, simulator persistence, cleanup).

Constraints/CI: playground packages are excluded from the publish/constraints checks (`yarn.config.cjs`), and `yarn constraints` passes. Lockfile updated for the new workspace.

## References

- Benchmarks [MetaMask/metamask-mobile#32475](https://github.com/MetaMask/metamask-mobile/pull/32475)
- Related: WAPI-1566, WAPI-1564

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate (N/A — measurement harness, no runtime code shipped)
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed (private package CHANGELOG added)
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (N/A — no consumers)