### PR TITLE
fix: unwrap the CommonJS default export when loading eciesjs

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `PrivateKey is not a constructor` when connecting over the MWP transport from a bundled browser app. `eciesjs` publishes CommonJS only — no `module` field, and no `import` condition in its `exports` map — so bundlers shape `await import('eciesjs')` as `{ default: <module.exports> }` rather than a namespace carrying the named exports, leaving `decrypt`, `encrypt`, `PrivateKey` and `PublicKey` `undefined`. `createKeyManager` now unwraps `default` when it is present. Node and dev servers that synthesize the named exports were unaffected. ([#343](https://github.com/MetaMask/connect-monorepo/pull/343))
+
 ## [1.2.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable id-length -- vitest alias */
+import type { IKeyManager } from '@metamask/mobile-wallet-protocol-core';
+import * as t from 'vitest';
+import { vi } from 'vitest';
+
+import { createKeyManager } from './KeyManager';
+
+const PLAINTEXT = 'hello from the dapp';
+
+/**
+ * Exercises every method of the key manager against real `eciesjs`.
+ *
+ * @param keymanager - The key manager under test.
+ * @returns The decrypted plaintext, which should match what was encrypted.
+ */
+async function roundTrip(keymanager: IKeyManager): Promise<string> {
+  const { privateKey, publicKey } = keymanager.generateKeyPair();
+  keymanager.validatePeerKey(publicKey);
+  const ciphertext = await keymanager.encrypt(PLAINTEXT, publicKey);
+  return keymanager.decrypt(ciphertext, privateKey);
+}
+
+t.describe('createKeyManager', () => {
+  t.it('round-trips with the namespace shape Node resolves', async () => {
+    const keymanager = await createKeyManager();
+
+    t.expect(await roundTrip(keymanager)).toBe(PLAINTEXT);
+  });
+
+  t.it('round-trips when the import resolves to `{ default }`', async () => {
+    // The shape bundlers produce for `eciesjs`, which publishes CommonJS only.
+    // Destructuring it directly yields `undefined` for every named export.
+    const actual = await vi.importActual('eciesjs');
+    vi.resetModules();
+    vi.doMock('eciesjs', () => ({ default: actual }));
+
+    try {
+      const { createKeyManager: create } = await import('./KeyManager');
+      const keymanager = await create();
+
+      t.expect(await roundTrip(keymanager)).toBe(PLAINTEXT);
+    } finally {
+      vi.doUnmock('eciesjs');
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/KeyManager.ts
@@ -16,7 +16,10 @@ import type {
  * @returns A ready-to-use key manager instance.
  */
 export async function createKeyManager(): Promise<IKeyManager> {
-  const { decrypt, encrypt, PrivateKey, PublicKey } = await import('eciesjs');
+  // `eciesjs` is CommonJS-only, so bundlers shape this import as
+  // `{ default: <module.exports> }` rather than a namespace of named exports.
+  const ecies = await import('eciesjs');
+  const { decrypt, encrypt, PrivateKey, PublicKey } = ecies.default ?? ecies;
 
   return {
     generateKeyPair(): KeyPair {


### PR DESCRIPTION
## Explanation

`createKeyManager()` destructures a dynamic import of `eciesjs`:

```ts
const { decrypt, encrypt, PrivateKey, PublicKey } = await import('eciesjs');
```

`eciesjs@0.4.17` publishes CommonJS only — no `module` field, and no `import` condition in its `exports` map. Bundlers therefore shape that import as `{ default: <module.exports> }` instead of a namespace carrying the named exports, so all four bindings come back `undefined` and connecting over MWP throws `PrivateKey is not a constructor`. Node and dev servers synthesize the named exports, which is why this survives CI and Vite dev but breaks a production browser build (hit on Angular 22 / esbuild).

This unwraps `default` when it is present, leaving the lazy `import()` from #244 intact.

The new `KeyManager.test.ts` round-trips generate → validate → encrypt → decrypt against real `eciesjs` in both module shapes; the `{ default }` case fails on `main` and passes here.

I audited the other dynamic imports in `connect-multichain`: the only remaining third-party CommonJS one is `@metamask/mobile-wallet-protocol-core` in `#createDappClient()`, which fails the same way (`undefined is not an object (evaluating 'mwpCore.SessionStore.create')`). That one is a packaging bug at the source — the package ships an ESM build but declares no `module`/`exports` — so I've fixed it there rather than working around it here: MetaMask/mobile-wallet-protocol#85. `ws` is only imported on the non-browser branch, where Node's named-export detection applies.

## References

- Fixes #342
- Upstream half of the same bug: MetaMask/mobile-wallet-protocol#85

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes — n/a, no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)