### PR TITLE
fix: revoke the entire session on connect-evm disconnect

### DIFF
--- a/packages/connect-evm/CHANGELOG.md
+++ b/packages/connect-evm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `disconnect()` now revokes the entire session instead of only its `eip155:*` scopes ([#344](https://github.com/MetaMask/connect-monorepo/pull/344)). The wallet may grant scopes beyond those requested (e.g. networks pre-selected on the connect prompt), and revoking only the `eip155:*` scopes stranded those extras in a session the wallet still reported as connected. This matches the legacy EIP-1193 behavior where `wallet_revokePermissions` revokes the origin's entire permission.
+
 ## [2.1.1]
 
 ### Added

--- a/packages/connect-evm/src/connect.test.ts
+++ b/packages/connect-evm/src/connect.test.ts
@@ -1262,7 +1262,7 @@ describe('MetamaskConnectEVM', () => {
   });
 
   describe('disconnect', () => {
-    it('calls core.disconnect with all eip155 scopes from the current session', async () => {
+    it('calls core.disconnect with no scopes to revoke the entire session', async () => {
       const mockCore = createMockCore();
       mockCore.storage.adapter.get.mockResolvedValue(JSON.stringify('0x1'));
       const client = await MetamaskConnectEVM.create({ core: mockCore });
@@ -1279,6 +1279,11 @@ describe('MetamaskConnectEVM', () => {
             notifications: [],
             accounts: ['eip155:137:0x1234567890123456789012345678901234567890'],
           },
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+            methods: [],
+            notifications: [],
+            accounts: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:1234567890'],
+          },
         },
       };
       mockCore.emit('wallet_sessionChanged', session);
@@ -1288,12 +1293,11 @@ describe('MetamaskConnectEVM', () => {
 
       await client.disconnect();
 
+      // Called with no scopes so the wallet revokes the whole session,
+      // including scopes granted beyond the eip155 scopes this client
+      // requested (e.g. networks pre-selected by the wallet).
       expect(mockCore.disconnect).toHaveBeenCalledTimes(1);
-      const [scopes] = mockCore.disconnect.mock.calls[0];
-      expect(scopes).toEqual(
-        expect.arrayContaining(['eip155:1', 'eip155:137']),
-      );
-      expect(scopes).toHaveLength(2);
+      expect(mockCore.disconnect).toHaveBeenCalledWith();
     });
   });
 

--- a/packages/connect-evm/src/connect.ts
+++ b/packages/connect-evm/src/connect.ts
@@ -30,11 +30,7 @@ import type {
   ProviderRequest,
   ProviderRequestInterceptor,
 } from './types';
-import {
-  getEthAccounts,
-  getPermittedEthChainIds,
-  parseScopeString,
-} from './utils/caip';
+import { getEthAccounts, getPermittedEthChainIds } from './utils/caip';
 import {
   isAccountsRequest,
   isAddChainRequest,
@@ -601,18 +597,21 @@ export class MetamaskConnectEVM {
   /**
    * Disconnects from the wallet by revoking the session and cleaning up event listeners.
    *
+   * The entire session is revoked rather than just its `eip155:*` scopes. The
+   * wallet may grant additional scopes beyond those requested (e.g. it
+   * pre-selects all of the user's enabled networks for EIP-1193 compatible
+   * connections), and no other client on the page is responsible for cleaning
+   * those up. Revoking only the `eip155:*` scopes would strand the extra
+   * scopes in a session that the wallet still reports as connected. This also
+   * matches the legacy EIP-1193 behavior, where `wallet_revokePermissions`
+   * revokes the origin's entire CAIP-25 permission.
+   *
    * @returns A promise that resolves when disconnection is complete
    */
   async disconnect(): Promise<void> {
     logger('request: disconnect');
 
-    const sessionScopes = this.#sessionScopes;
-    const eip155Scopes = Object.keys(sessionScopes).filter((scope) => {
-      const { namespace } = parseScopeString(scope as Scope);
-      return namespace === 'eip155';
-    });
-
-    await this.#core.disconnect(eip155Scopes as Scope[]);
+    await this.#core.disconnect();
     this.#onDisconnect();
     this.#clearConnectionState();
 


### PR DESCRIPTION
## Summary

Make `connect-evm`'s `disconnect()` revoke the entire session instead of only its `eip155:*` scopes, so scopes granted beyond the client's request don't get stranded in a session the wallet still reports as connected.

## Problem

`disconnect()` filters the session scopes to `eip155:*` and passes only those to `wallet_revokeSession`. The wallet's revoke handler does a partial revocation when scopes are specified and keeps the permission alive while any accounts remain on other scopes.

The wallet can grant more than the client requested: for EIP-1193 compatible connections it pre-selects all of the user's enabled networks on the connect prompt (see [fix: pre-select all networks for eip1193-compatible requests](https://github.com/MetaMask/metamask-extension/pull/45261)), so a single approval can include Solana, Bitcoin, and Tron scopes alongside the requested EVM chains. No client on the page is responsible for revoking those extras:

- `connect-evm` revokes only `eip155:*`
- the Solana Wallet Standard wallet revokes only `solana:*`
- nothing revokes `bip122:*` / `tron:*`

Net effect (reproduced while testing the extension PR above on app.uniswap.org): after the dapp's disconnect flow runs, the wallet still shows the site as connected, with Bitcoin and Tron listed as connected networks, and the user can only fully disconnect from inside the wallet UI.

## Solution

Call `core.disconnect()` with no scope filter. The transport sends `wallet_revokeSession` with empty scopes, which the wallet treats as "revoke the whole session".

This matches the legacy EIP-1193 behavior this client emulates: wagmi's injected disconnect calls `wallet_revokePermissions`, which revokes the origin's entire CAIP-25 permission, over-granted scopes included. That symmetry (broad grant, broad revoke) is why stranded scopes were never an issue before the migration to scoped revocation.

## Risk

A dapp that manages its EVM and Solana connections independently and expects `connect-evm.disconnect()` to leave a concurrent Solana connection intact will now see the full session revoked (the Solana client is notified via `wallet_sessionChanged`, so its state stays consistent). This is the pre-migration behavior of the injected flow, and we're not aware of a dapp relying on the scoped behavior; flagging it in case reviewers know of one.
