### PR TITLE
chore: add mobile platform code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-* @MetaMask/wallet-integrations
+* @MetaMask/wallet-integrations @MetaMask/mobile-platform


### PR DESCRIPTION
## Explanation

Add `@MetaMask/mobile-platform` as a repository-wide code owner so the team can review dapp connection UI-related changes. Preserve `@MetaMask/wallet-integrations` ownership during the transition.

## References

Requested during review coordination for the dapp connection UI improvements.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/connect-monorepo/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes