### PR TITLE
fix: reopen StoreAdapterWeb IndexedDB after force-close

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reopen IndexedDB when the browser or WKWebView force-closes the connection. `StoreAdapterWeb` now invalidates the cached `IDBDatabase` on `close` / `versionchange` and retries `get` / `set` / `delete` once after `InvalidStateError` or `UnknownError`, so storage keeps working without a page reload.
+
 ## [1.2.0]
 
 ### Added

--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reopen IndexedDB when the browser or WKWebView force-closes the connection. `StoreAdapterWeb` now invalidates the cached `IDBDatabase` on `close` / `versionchange` and retries `get` / `set` / `delete` once after `InvalidStateError` or `UnknownError`, so storage keeps working without a page reload.
+- Reopen IndexedDB when the browser or WKWebView force-closes the connection. `StoreAdapterWeb` now invalidates the cached `IDBDatabase` on `close` / `versionchange` and retries `get` / `set` / `delete` once after `InvalidStateError` or `UnknownError`, so storage keeps working without a page reload ([#346](https://github.com/MetaMask/connect-monorepo/pull/346))
 
 ## [1.2.0]
 

--- a/packages/connect-multichain/package.json
+++ b/packages/connect-multichain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/connect-multichain",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MetaMask Connect multichain client — CAIP multichain API, session management, and transport negotiation",
   "keywords": [
     "MetaMask",

--- a/packages/connect-multichain/src/store/adapters/web.ts
+++ b/packages/connect-multichain/src/store/adapters/web.ts
@@ -8,6 +8,31 @@ import { StoreAdapter } from '../../domain';
 
 type KvStores = 'sdk-kv-store' | 'key-value-pairs';
 
+/**
+ * True when IndexedDB rejected because the connection was force-closed
+ * (Safari / WKWebView) rather than a durable store error.
+ *
+ * @param error - Thrown value from `transaction` or a request `onerror`.
+ * @returns Whether the adapter should drop the cached handle and retry once.
+ */
+function isRecoverableIdbError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const name = 'name' in error ? String(error.name) : '';
+  const message = 'message' in error ? String(error.message).toLowerCase() : '';
+
+  if (name === 'InvalidStateError' || name === 'UnknownError') {
+    return true;
+  }
+
+  return (
+    message.includes('connection is closing') ||
+    message.includes('indexed database server lost')
+  );
+}
+
 export class StoreAdapterWeb extends StoreAdapter {
   static readonly stores: KvStores[] = ['sdk-kv-store', 'key-value-pairs'];
 
@@ -15,7 +40,19 @@ export class StoreAdapterWeb extends StoreAdapter {
 
   readonly platform = 'web';
 
-  readonly dbPromise: Promise<IDBDatabase>;
+  private cachedDbPromise: Promise<IDBDatabase> | null = null;
+
+  private readonly dbName: string;
+
+  /**
+   * Current (or newly opened) IndexedDB connection. Public so callers and
+   * tests can await the same handle the adapter uses.
+   *
+   * @returns Promise that resolves to the live `IDBDatabase` instance.
+   */
+  get dbPromise(): Promise<IDBDatabase> {
+    return this.getDb();
+  }
 
   private get internal(): IDBFactory {
     if (typeof window === 'undefined' || !window.indexedDB) {
@@ -30,12 +67,35 @@ export class StoreAdapterWeb extends StoreAdapter {
   ) {
     super();
 
-    const dbName = `${StoreAdapterWeb.DB_NAME}${dbNameSuffix}`;
-    this.dbPromise = new Promise((resolve, reject) => {
+    this.dbName = `${StoreAdapterWeb.DB_NAME}${dbNameSuffix}`;
+    this.cachedDbPromise = this.openDb();
+  }
+
+  private invalidateDb(): void {
+    this.cachedDbPromise = null;
+  }
+
+  private async getDb(): Promise<IDBDatabase> {
+    this.cachedDbPromise ??= this.openDb();
+    return await this.cachedDbPromise;
+  }
+
+  private async openDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
       try {
-        const request = this.internal.open(dbName, 1);
+        const request = this.internal.open(this.dbName, 1);
         request.onerror = () => reject(new Error('Failed to open IndexedDB.'));
-        request.onsuccess = () => resolve(request.result);
+        request.onsuccess = () => {
+          const db = request.result;
+          db.onclose = () => {
+            this.invalidateDb();
+          };
+          db.onversionchange = () => {
+            db.close();
+            this.invalidateDb();
+          };
+          resolve(db);
+        };
         request.onupgradeneeded = () => {
           const db = request.result;
           for (const name of StoreAdapterWeb.stores) {
@@ -47,57 +107,105 @@ export class StoreAdapterWeb extends StoreAdapter {
       } catch (error) {
         reject(error);
       }
-    });
+    }).then(
+      (db) => db,
+      (error) => {
+        this.invalidateDb();
+        throw error;
+      },
+    );
+  }
+
+  private async withDb<Result>(
+    operation: (db: IDBDatabase) => Promise<Result>,
+  ): Promise<Result> {
+    try {
+      return await operation(await this.getDb());
+    } catch (error) {
+      if (!isRecoverableIdbError(error)) {
+        throw error;
+      }
+      this.invalidateDb();
+      return await operation(await this.getDb());
+    }
+  }
+
+  private rejectStoreError(
+    request: IDBRequest,
+    fallbackMessage: string,
+    reject: (reason?: unknown) => void,
+  ): void {
+    const { error } = request;
+    if (error && isRecoverableIdbError(error)) {
+      reject(error);
+      return;
+    }
+    reject(new Error(fallbackMessage));
   }
 
   async get(key: string): Promise<string | null> {
     const { storeName } = this;
-    const db = await this.dbPromise;
-    return new Promise((resolve, reject) => {
-      try {
-        const tx = db.transaction(storeName, 'readonly');
-        const store = tx.objectStore(storeName);
-        const request = store.get(key);
-        request.onerror = () =>
-          reject(new Error('Failed to get value from IndexedDB.'));
-        request.onsuccess = () => resolve((request.result as string) ?? null);
-      } catch (error) {
-        reject(error);
-      }
+    return this.withDb(async (db) => {
+      return new Promise((resolve, reject) => {
+        try {
+          const tx = db.transaction(storeName, 'readonly');
+          const store = tx.objectStore(storeName);
+          const request = store.get(key);
+          request.onerror = () =>
+            this.rejectStoreError(
+              request,
+              'Failed to get value from IndexedDB.',
+              reject,
+            );
+          request.onsuccess = () => resolve((request.result as string) ?? null);
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   }
 
   async set(key: string, value: string): Promise<void> {
     const { storeName } = this;
-    const db = await this.dbPromise;
-    return new Promise((resolve, reject) => {
-      try {
-        const tx = db.transaction(storeName, 'readwrite');
-        const store = tx.objectStore(storeName);
-        const request = store.put(value, key);
-        request.onerror = () =>
-          reject(new Error('Failed to set value in IndexedDB.'));
-        request.onsuccess = () => resolve();
-      } catch (error) {
-        reject(error);
-      }
+    return this.withDb(async (db) => {
+      return new Promise((resolve, reject) => {
+        try {
+          const tx = db.transaction(storeName, 'readwrite');
+          const store = tx.objectStore(storeName);
+          const request = store.put(value, key);
+          request.onerror = () =>
+            this.rejectStoreError(
+              request,
+              'Failed to set value in IndexedDB.',
+              reject,
+            );
+          request.onsuccess = () => resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   }
 
   async delete(key: string): Promise<void> {
     const { storeName } = this;
-    const db = await this.dbPromise;
-    return new Promise((resolve, reject) => {
-      try {
-        const tx = db.transaction(storeName, 'readwrite');
-        const store = tx.objectStore(storeName);
-        const request = store.delete(key);
-        request.onerror = () =>
-          reject(new Error('Failed to delete value from IndexedDB.'));
-        request.onsuccess = () => resolve();
-      } catch (error) {
-        reject(error);
-      }
+    return this.withDb(async (db) => {
+      return new Promise((resolve, reject) => {
+        try {
+          const tx = db.transaction(storeName, 'readwrite');
+          const store = tx.objectStore(storeName);
+          const request = store.delete(key);
+          request.onerror = () =>
+            this.rejectStoreError(
+              request,
+              'Failed to delete value from IndexedDB.',
+              reject,
+            );
+          request.onsuccess = () => resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   }
 }

--- a/packages/connect-multichain/src/store/index.test.ts
+++ b/packages/connect-multichain/src/store/index.test.ts
@@ -324,6 +324,146 @@ t.describe('StoreAdapterWeb DB naming', () => {
   });
 });
 
+t.describe('StoreAdapterWeb IndexedDB recovery', () => {
+  t.afterEach(() => {
+    t.vi.unstubAllGlobals();
+    t.vi.restoreAllMocks();
+  });
+
+  /**
+   * @returns A stubbed IDBFactory plus an open spy and a live adapter.
+   */
+  function createWebAdapter() {
+    const idbFactory = new IDBFactory();
+    const openSpy = t.vi.spyOn(idbFactory, 'open');
+    t.vi.stubGlobal('window', { indexedDB: idbFactory });
+    const adapter = new StoreAdapterWeb();
+    return { adapter, openSpy };
+  }
+
+  t.it(
+    'reopens IndexedDB after onclose and reads the persisted value',
+    async () => {
+      const { adapter, openSpy } = createWebAdapter();
+      await adapter.set('anonId', 'before-close');
+      const db = await adapter.dbPromise;
+      t.expect(openSpy).toHaveBeenCalledOnce();
+
+      db.onclose?.(new Event('close'));
+
+      const result = await adapter.get('anonId');
+
+      t.expect(result).toBe('before-close');
+      t.expect(openSpy).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  t.it('retries set once after InvalidStateError on transaction', async () => {
+    const { adapter, openSpy } = createWebAdapter();
+    const db = await adapter.dbPromise;
+    const originalTransaction = db.transaction.bind(db);
+    let remainingFailures = 1;
+    db.transaction = ((storeNames, mode) => {
+      if (remainingFailures > 0) {
+        remainingFailures -= 1;
+        throw new DOMException(
+          "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing",
+          'InvalidStateError',
+        );
+      }
+      return originalTransaction(storeNames, mode);
+    }) as typeof db.transaction;
+
+    await adapter.set('anonId', 'retried');
+
+    t.expect(await adapter.get('anonId')).toBe('retried');
+    t.expect(openSpy).toHaveBeenCalledTimes(2);
+  });
+
+  t.it('retries get once after UnknownError on transaction', async () => {
+    const { adapter, openSpy } = createWebAdapter();
+    await adapter.set('anonId', 'persisted');
+    const db = await adapter.dbPromise;
+    const originalTransaction = db.transaction.bind(db);
+    let remainingFailures = 1;
+    db.transaction = ((storeNames, mode) => {
+      if (remainingFailures > 0) {
+        remainingFailures -= 1;
+        throw new DOMException(
+          'Connection to Indexed Database server lost',
+          'UnknownError',
+        );
+      }
+      return originalTransaction(storeNames, mode);
+    }) as typeof db.transaction;
+
+    const result = await adapter.get('anonId');
+
+    t.expect(result).toBe('persisted');
+    t.expect(openSpy).toHaveBeenCalledTimes(2);
+  });
+
+  t.it(
+    'retries delete once after InvalidStateError on transaction',
+    async () => {
+      const { adapter, openSpy } = createWebAdapter();
+      await adapter.set('anonId', 'to-delete');
+      const db = await adapter.dbPromise;
+      const originalTransaction = db.transaction.bind(db);
+      let remainingFailures = 1;
+      db.transaction = ((storeNames, mode) => {
+        if (remainingFailures > 0) {
+          remainingFailures -= 1;
+          throw new DOMException(
+            'The database connection is closing',
+            'InvalidStateError',
+          );
+        }
+        return originalTransaction(storeNames, mode);
+      }) as typeof db.transaction;
+
+      await adapter.delete('anonId');
+
+      t.expect(await adapter.get('anonId')).toBeNull();
+      t.expect(openSpy).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  t.it('does not reopen IndexedDB after ConstraintError', async () => {
+    const { adapter, openSpy } = createWebAdapter();
+    const db = await adapter.dbPromise;
+    db.transaction = (() => {
+      throw new DOMException(
+        'Key already exists in the object store',
+        'ConstraintError',
+      );
+    }) as typeof db.transaction;
+
+    await t
+      .expect(adapter.set('anonId', 'blocked'))
+      .rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof DOMException && error.name === 'ConstraintError',
+      );
+
+    t.expect(openSpy).toHaveBeenCalledOnce();
+  });
+
+  t.it('does not reopen IndexedDB after a generic Error', async () => {
+    const { adapter, openSpy } = createWebAdapter();
+    const db = await adapter.dbPromise;
+    db.transaction = (() => {
+      throw new Error('unexpected adapter failure');
+    }) as typeof db.transaction;
+
+    await t
+      .expect(adapter.get('anonId'))
+      .rejects.toThrow('unexpected adapter failure');
+
+    t.expect(openSpy).toHaveBeenCalledOnce();
+  });
+});
+
 t.describe(`Store with RNAdapter`, () => {
   // Test RN storage with mocked AsyncStorage
   createStoreTests(


### PR DESCRIPTION
## Summary
- Recovers `@metamask/connect-multichain` `StoreAdapterWeb` after Safari/WKWebView force-closes IndexedDB by invalidating the cached handle on `close` / `versionchange` and retrying `get` / `set` / `delete` once on `InvalidStateError` or `UnknownError`.
- Leaves `StoreAdapterRN` (AsyncStorage) unchanged. Custom `storage` overrides are unaffected.
- Addresses [MCWP-821](https://consensyssoftware.atlassian.net/browse/MCWP-821). Patch bump to `1.2.1`.

## Test plan
- [x] `yarn workspace @metamask/connect-multichain test src/store/index.test.ts` (76 tests)
- [ ] Confirm a WebView/browser dapp using the default adapter can resume after backgrounding without a page reload
- [ ] After merge, run the connect-monorepo release workflow to publish `1.2.1` to npm


Made with [Cursor](https://cursor.com)