### PR TITLE
fix(connect-multichain): wipe MWP pairing on full disconnect (MCWP-822)

### DIFF
--- a/packages/connect-multichain/CHANGELOG.md
+++ b/packages/connect-multichain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Full disconnect (`disconnect()` with no remaining scopes) on the MWP (mobile deeplink) transport now always wipes the persisted MWP pairing (relay channel + ECIES keys) from `SessionStore`, independent of `dappClient`'s in-memory session state. Previously, `dappClient.disconnect()` was a no-op when its in-memory session was already `null` (e.g. after a prior failed `resume()`), leaving the pairing in storage. The next `connect()` would then try to resume that already-revoked pairing via `getActiveSession()`, time out, and leave the dapp stuck — surviving even a page refresh until storage was wiped manually. Full disconnect also now clears the stored `pending_session_request` so a later `connect()` can't pick up a dead handshake URI. As defense in depth, a failed session resume now deletes that specific pairing from `SessionStore` before rethrowing (MCWP-822).
+
 ## [1.2.0]
 
 ### Added

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable id-length -- vitest alias */
 /* eslint-disable no-empty-function -- Empty mock functions */
+import {
+  SessionStore,
+  type Session,
+} from '@metamask/mobile-wallet-protocol-core';
 import * as t from 'vitest';
 import { vi } from 'vitest';
 
@@ -7,6 +11,21 @@ import { MWPTransport } from '.';
 import type { StoreAdapter } from '../../../domain';
 import { getPlatformType, PlatformType } from '../../../domain/platform';
 import { MULTICHAIN_PROVIDER_STREAM_NAME } from '../constants';
+
+/**
+ * Builds a minimal mock `Session` (as persisted by `SessionStore`) for tests
+ * that don't care about the actual key material.
+ *
+ * @param id - The session id.
+ * @returns A mock `Session`.
+ */
+const buildMockSession = (id: string): Session => ({
+  id,
+  channel: `channel-${id}`,
+  keyPair: { publicKey: new Uint8Array(), privateKey: new Uint8Array() },
+  theirPublicKey: new Uint8Array(),
+  expiresAt: Date.now() + 60_000,
+});
 
 vi.mock('../../../domain/platform', async () => {
   const actual = await vi.importActual('../../../domain/platform');
@@ -25,12 +44,15 @@ t.describe('MWPTransport', () => {
     mockDappClient = {
       on: t.vi.fn(),
       off: t.vi.fn(),
+      once: t.vi.fn(),
       reconnect: t.vi.fn(),
       send: t.vi.fn(),
       sendRequest: t.vi.fn().mockResolvedValue(undefined),
       connect: t.vi.fn().mockResolvedValue(undefined),
       disconnect: t.vi.fn().mockResolvedValue(undefined),
+      resume: t.vi.fn().mockResolvedValue(undefined),
       isConnected: t.vi.fn().mockReturnValue(false),
+      state: 'DISCONNECTED',
     };
 
     mockKvstore = {
@@ -777,6 +799,130 @@ t.describe('MWPTransport', () => {
             });
           },
         );
+      },
+    );
+  });
+
+  t.describe('disconnect() — MCWP-822 MWP pairing cleanup', () => {
+    // In-memory stand-in for the SessionStore-backed pairing storage.
+    // `list` reflects whatever hasn't been `delete`d, so these tests exercise
+    // the real invariant: after a full disconnect, getActiveSession() must
+    // resolve `undefined`.
+    let storedSessions: Session[];
+    let listSpy: ReturnType<typeof t.vi.spyOn>;
+    let deleteSpy: ReturnType<typeof t.vi.spyOn>;
+
+    t.beforeEach(() => {
+      storedSessions = [buildMockSession('pairing-1')];
+      listSpy = t.vi
+        .spyOn(SessionStore.prototype, 'list')
+        .mockImplementation(async () => storedSessions);
+      deleteSpy = t.vi
+        .spyOn(SessionStore.prototype, 'delete')
+        .mockImplementation(async (id: string) => {
+          storedSessions = storedSessions.filter(
+            (session) => session.id !== id,
+          );
+        });
+    });
+
+    t.afterEach(() => {
+      listSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+
+    t.it(
+      'wipes the persisted MWP pairing and pending session request on a full disconnect, independent of dappClient.session',
+      async () => {
+        // dappClient.disconnect() being a no-op (as it is when the in-memory
+        // `session` is already null, e.g. after a failed resume) must not
+        // prevent the pairing from being wiped from SessionStore.
+        (
+          mockDappClient.disconnect as ReturnType<typeof t.vi.fn>
+        ).mockResolvedValue(undefined);
+
+        await transport.disconnect();
+
+        t.expect(deleteSpy).toHaveBeenCalledWith('pairing-1');
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        t.expect(mockKvstore.delete).toHaveBeenCalledWith(
+          'cache_wallet_getSession',
+        );
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        t.expect(mockKvstore.delete).toHaveBeenCalledWith(
+          'pending_session_request',
+        );
+        t.expect(mockDappClient.disconnect).toHaveBeenCalledTimes(1);
+
+        // The real invariant: the next connect() must not find a stale pairing.
+        await t.expect(transport.getActiveSession()).resolves.toBeUndefined();
+      },
+    );
+
+    t.it(
+      'does not touch the SessionStore pairing on a partial disconnect (scopes remain)',
+      async () => {
+        (mockKvstore.get as ReturnType<typeof t.vi.fn>).mockResolvedValue(
+          JSON.stringify({
+            result: {
+              sessionScopes: {
+                'eip155:1': { accounts: [], methods: [], notifications: [] },
+                'eip155:137': { accounts: [], methods: [], notifications: [] },
+              },
+            },
+          }),
+        );
+
+        await transport.disconnect(['eip155:1']);
+
+        t.expect(deleteSpy).not.toHaveBeenCalled();
+        t.expect(mockDappClient.disconnect).not.toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        t.expect(mockKvstore.delete).not.toHaveBeenCalledWith(
+          'cache_wallet_getSession',
+        );
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        t.expect(mockKvstore.delete).not.toHaveBeenCalledWith(
+          'pending_session_request',
+        );
+      },
+    );
+
+    t.it(
+      'connect() takes #startSession (not resume) after a full disconnect cleared the pairing',
+      async () => {
+        const mockGetPlatformType = t.vi.mocked(getPlatformType);
+        mockGetPlatformType.mockReturnValue(PlatformType.DesktopWeb);
+        t.vi
+          .spyOn(transport, 'getStoredPendingSessionRequest')
+          .mockResolvedValue(null);
+
+        await transport.disconnect();
+        t.expect(storedSessions).toHaveLength(0);
+
+        const connectPromise = transport
+          .connect({ scopes: [], caipAccountIds: [] })
+          .catch(() => undefined);
+
+        await t.vi.waitFor(() => {
+          t.expect(mockDappClient.connect).toHaveBeenCalledTimes(1);
+        });
+
+        t.expect(mockDappClient.resume).not.toHaveBeenCalled();
+
+        // Cleanup: drive connect() to rejection so the timeout/handler unwind.
+        const messageHandlers = mockDappClient.on.mock.calls
+          .filter((call: unknown[]) => call[0] === 'message')
+          .map((call: unknown[]) => call[1]);
+        const initialHandler = messageHandlers[messageHandlers.length - 1];
+        const sendRequestArgs = mockDappClient.sendRequest.mock.calls[0]?.[0];
+        await initialHandler?.({
+          data: {
+            id: sendRequestArgs?.data.id,
+            error: { code: 4001, message: 'User rejected' },
+          },
+        });
+        await connectPromise;
       },
     );
   });

--- a/packages/connect-multichain/src/multichain/transports/mwp/index.ts
+++ b/packages/connect-multichain/src/multichain/transports/mwp/index.ts
@@ -457,13 +457,22 @@ export class MWPTransport implements ExtendedTransport {
 
     const cleanup = () => this.dappClient.off('connected', runOnResumeHandler);
 
-    return Promise.race([
-      resumeDeferred.promise,
-      timeoutDeferred.promise,
-    ]).finally(() => {
-      clearTimeout(timeout);
-      cleanup();
-    });
+    return Promise.race([resumeDeferred.promise, timeoutDeferred.promise])
+      .catch(async (error) => {
+        // Defense in depth (complements the SessionStore wipe in
+        // `disconnect()`): the wallet may have already revoked this pairing
+        // out-of-band, so resuming it fails/times out here instead. Delete
+        // it from SessionStore so a subsequent connect() doesn't keep
+        // retrying the same dead pairing.
+        if (session.id) {
+          await this.#deleteMwpSession(session.id);
+        }
+        throw error;
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        cleanup();
+      });
   }
 
   /**
@@ -748,7 +757,18 @@ export class MWPTransport implements ExtendedTransport {
         this.windowFocusHandler = undefined;
       }
 
-      await this.dappClient.disconnect();
+      // Ensure a later connect() can't pick up a dead handshake URI from a
+      // pending connection attempt that never completed.
+      await this.removeStoredPendingSessionRequest();
+
+      // Wipe the MWP pairing (relay channel + ECIES keys) from SessionStore
+      // regardless of in-memory `dappClient.session` state. `dappClient.disconnect()`
+      // alone is a no-op when the in-memory session is already null (e.g. after a
+      // failed resume), which leaves the SessionStore entry behind. The next
+      // connect() reads that leftover entry via getActiveSession() and tries to
+      // resume a pairing the wallet has already revoked, which times out.
+      // See: https://consensyssoftware.atlassian.net/browse/MCWP-822
+      await this.#clearMwpPairing();
     }
 
     this.notifyCallbacks({
@@ -757,6 +777,65 @@ export class MWPTransport implements ExtendedTransport {
         sessionScopes: newSessionScopes,
       },
     });
+  }
+
+  /**
+   * Wipes any persisted MWP pairing(s) (relay channel + ECIES keys) from the
+   * `SessionStore`, independent of `dappClient`'s in-memory session state.
+   *
+   * `dappClient.disconnect()` only deletes the SessionStore entry when its
+   * in-memory `session` is set — if it's already `null` (e.g. a prior
+   * `resume()` failure nulled it out without clearing storage), that call is
+   * a no-op and the pairing survives. This guarantees `getActiveSession()`
+   * returns `undefined` afterwards so the next `connect()` takes
+   * `#startSession` instead of resuming a pairing the wallet already revoked.
+   *
+   * The SessionStore wipe happens first and unconditionally so the invariant
+   * holds even if the subsequent `dappClient.disconnect()` call fails.
+   * `dappClient.disconnect()` is still called (so transport/channel cleanup
+   * runs when a session is set) and its rejection is intentionally
+   * propagated, preserving the existing contract that a failed disconnect
+   * surfaces to callers of `MWPTransport.disconnect()`.
+   *
+   * @returns Nothing
+   */
+  async #clearMwpPairing(): Promise<void> {
+    const { SessionStore } = await import(
+      '@metamask/mobile-wallet-protocol-core'
+    );
+    const sessionStore = await SessionStore.create(this.kvstore);
+
+    try {
+      const sessions = await sessionStore.list();
+      await Promise.all(
+        sessions.map(async (session) => sessionStore.delete(session.id)),
+      );
+    } catch (error) {
+      logger('error clearing MWP pairing from SessionStore', error);
+    }
+
+    await this.dappClient.disconnect();
+  }
+
+  /**
+   * Deletes a single pairing entry from `SessionStore` by id. Used as
+   * defense-in-depth when resuming a specific session fails, so a
+   * subsequent `connect()` doesn't try to resume the same dead pairing
+   * again (see `#clearMwpPairing` for the full wipe done on disconnect).
+   *
+   * @param sessionId - The id of the `SessionStore` entry to delete.
+   * @returns Nothing
+   */
+  async #deleteMwpSession(sessionId: string): Promise<void> {
+    try {
+      const { SessionStore } = await import(
+        '@metamask/mobile-wallet-protocol-core'
+      );
+      const sessionStore = await SessionStore.create(this.kvstore);
+      await sessionStore.delete(sessionId);
+    } catch (error) {
+      logger('error deleting MWP session from SessionStore', error);
+    }
   }
 
   /**


### PR DESCRIPTION
## Explanation

`MWPTransport.disconnect()`'s full-disconnect branch only called `dappClient.disconnect()`, relying on the wallet-protocol client's in-memory `session` to be non-null. `dappClient.disconnect()` is a no-op when that in-memory session is already `null` — e.g. after a prior failed `resume()`, which nulls the session without clearing `SessionStore`. In that case the pairing (relay channel + ECIES keys) survived in `SessionStore`.

The next `connect()` reads that leftover pairing via `getActiveSession()` (`SessionStore.list()[0]`), takes the resume path, and tries to resume a pairing the wallet has already revoked. That resume attempt times out, and the dapp is stuck — surviving even a page refresh, since the CAIP-25 session cache and the MWP pairing are two independent persisted stores. Only wiping storage manually recovered.

This reproduced for Fireblocks (`@metamask/connect-multichain@1.2.0`) on a successful connect → sign → `disconnect()` → `connect()`.

### Fix

- Added `MWPTransport.#clearMwpPairing()`: on a full disconnect (no remaining scopes), list and delete every `SessionStore` entry directly, independent of `dappClient`'s in-memory session state. `dappClient.disconnect()` is still called afterward for transport/channel cleanup, and its rejection is intentionally left to propagate — this preserves the existing behavior where a failed disconnect surfaces to callers (see `MWPTransport.disconnect()`'s existing `should handle disconnect errors` test).
- Full disconnect now also clears the persisted `pending_session_request`, matching what `connect()` already does in its `finally`, so a later `connect()` can't pick up a dead handshake URI.
- Defense in depth: if `#resumeSession` fails (e.g. the wallet already revoked the pairing out-of-band), that specific pairing is now deleted from `SessionStore` before rethrowing. This complements #180's existing reject-path cleanup on `#startSession`.
- Added unit test coverage for `disconnect()` in `mwp/index.test.ts` (previously untested): full disconnect wipes the pairing and `getActiveSession()` resolves `undefined` afterward, partial disconnect leaves the pairing untouched, and a subsequent `connect()` takes `#startSession` rather than resume.

Scope is intentionally limited to `@metamask/connect-multichain` in this repo — the leftover pairing lives in the dapp-side adapter (localStorage / IndexedDB / AsyncStorage), not in any Mobile wallet-side store, so `app/core/SDKConnectV2` in `metamask-mobile` is unaffected and out of scope here.


<img width="816" height="793" alt="image" src="https://github.com/user-attachments/assets/d8c55706-6077-41be-b8ca-8b131459a3f5" />


## References

* Fixes [MCWP-822](https://consensyssoftware.atlassian.net/browse/MCWP-822)
* Related to [MCWP-823](https://consensyssoftware.atlassian.net/browse/MCWP-823) (status=`connected` with `#transport` undefined) and [MCWP-821](https://consensyssoftware.atlassian.net/browse/MCWP-821) (stale IndexedDB handle) — same underlying report, not fixed by this change
* Complements [#180](https://github.com/MetaMask/connect-monorepo/pull/180) (cleans `SessionStore` on connect rejection); this PR closes the same gap on the disconnect path
* Epic: [MCWP-769](https://consensyssoftware.atlassian.net/browse/MCWP-769)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed, highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
